### PR TITLE
clean up some of the GHA scripts

### DIFF
--- a/.github/workflows/github-main.yaml
+++ b/.github/workflows/github-main.yaml
@@ -1,4 +1,4 @@
-name: Build & Test
+name: CI/CD Main
 on:
   push:
     branches: main
@@ -34,6 +34,10 @@ jobs:
 
       - name: Release
         uses: gradle/gradle-build-action@v2
-        if: github.ref == 'refs/heads/main'
         with:
           arguments: release
+
+      - name: Publish
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: publishMavenJavaPublicationToS3Repository # publish only to S3

--- a/.github/workflows/github-pr.yaml
+++ b/.github/workflows/github-pr.yaml
@@ -1,4 +1,4 @@
-name: Build & Test
+name: PR Build
 on:
   pull_request:
     branches: ["main"]
@@ -27,13 +27,12 @@ jobs:
           role-session-name: github-pr-builder
           aws-region: us-west-2
 
-      - name: Setup Gradle
+      - name: Build & Test
         uses: gradle/gradle-build-action@v2
         with:
           arguments: build
 
       - name: Dryrun Release
         uses: gradle/gradle-build-action@v2
-        if: github.ref == 'refs/heads/main'
         with:
           arguments: release -Prelease.dryRun

--- a/.github/workflows/github-pr.yaml
+++ b/.github/workflows/github-pr.yaml
@@ -31,8 +31,3 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           arguments: build
-
-      - name: Dryrun Release
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: release -Prelease.dryRun

--- a/.github/workflows/github-publish.yaml
+++ b/.github/workflows/github-publish.yaml
@@ -3,9 +3,9 @@ on:
   workflow_dispatch:
     inputs:
       name:
-        versionIncrement:
-          default: incrementMinor
-          description: which version to increment on release (e.g. incrementMajor)
+        module:
+          required: true
+          description: which module to publish (e.g. operator)
 jobs:
   build:
     permissions:
@@ -39,7 +39,7 @@ jobs:
       - name: Release
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: release -Prelease.incrementer=${{ inputs.versionIncrement }}
+          arguments: :${{ inputs.module }}:release -Prelease.versionIncrementer=incrementMinor
 
       - name: Publish
         uses: gradle/gradle-build-action@v2

--- a/.github/workflows/github-publish.yaml
+++ b/.github/workflows/github-publish.yaml
@@ -1,5 +1,11 @@
 name: Publish Artifacts
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      name:
+        versionIncrement:
+          default: incrementMinor
+          description: which version to increment on release (e.g. incrementMajor)
 jobs:
   build:
     permissions:
@@ -25,10 +31,20 @@ jobs:
           role-session-name: github-publish-artifacts
           aws-region: us-west-2
 
-      - name: Build & Publish
+      - name: Build & Test
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: build publish
+          arguments: build
+
+      - name: Release
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: release -Prelease.incrementer=${{ inputs.versionIncrement }}
+
+      - name: Publish
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: publish # publish to both S3 and Sonatype OSSRH
         env:
           OSSRH_USER: ${{ secrets.OSSRH_USER }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}

--- a/buildSrc/src/main/kotlin/responsive.java-common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/responsive.java-common-conventions.gradle.kts
@@ -112,6 +112,7 @@ allprojects {
 
         repositories {
             maven {
+                name = "s3"
                 val releasesUrl = "s3://maven-repo.responsive.dev/releases"
                 val snapshotsUrl = "s3://maven-repo.responsive.dev/snapshots"
                 url = uri(if (version.toString().endsWith("SNAPSHOT")) snapshotsUrl else releasesUrl)


### PR DESCRIPTION
Makes the following changes:
- renames the actions to be more descriptive
- publishes artifacts to S3 every main build
- runs the dry run release on the PR builder
- adds `versionIncrementer` configuration for the publish artifacts job and defaults to `incrementMinor`