### PR TITLE
add plugin for logging tests

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -24,4 +24,5 @@ repositories {
 
 dependencies {
     implementation("pl.allegro.tech.build:axion-release-plugin:1.15.2")
+    implementation("com.adarshr:gradle-test-logger-plugin:3.2.0")
 }

--- a/buildSrc/src/main/kotlin/responsive.java-common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/responsive.java-common-conventions.gradle.kts
@@ -1,3 +1,5 @@
+import com.adarshr.gradle.testlogger.theme.ThemeType
+
 /*
  * Copyright 2023 Responsive Computing, Inc.
  *
@@ -21,6 +23,8 @@ plugins {
     `signing`
 
     id("pl.allegro.tech.build.axion-release")
+    id("com.adarshr.test-logger")
+
 }
 
 dependencies {
@@ -45,6 +49,10 @@ repositories {
 tasks.test {
     // Use the built-in JUnit support of Gradle.
     useJUnitPlatform()
+}
+
+testlogger {
+    theme = ThemeType.MOCHA
 }
 
 allprojects {


### PR DESCRIPTION
Sample output:
```

> Task :kafka-client:test

  dev.responsive.db.CassandraClientIntegrationTest

    ✔ shouldReturnAllKeysInLexicalOrder() (1.8s)
    ✔ shouldReturnRangeKeysInLexicalOrder() (1.2s)

  dev.responsive.kafka.store.CommitBufferTest

    ✔ shouldIgnoreFlushFailuresOnRestore() (5.6s)
    ✔ shouldRestoreRecordsGreaterThanCassandraOffset() (4.6s)
    ✔ shouldThrowErrorOnFlushWhenSmallerOffset() (4.5s)
    ✔ shouldFlushAndUpdateOffsetWhenLargerOffset() (4.5s)
    ✔ shouldThrowErrorOnFlushWhenDifferentTxnIdIsSet() (4.5s)
    ✔ shouldDeleteRowInCassandraWithTombstone() (4.4s)
    ✔ shouldThrowErrorOnFlushWhenEqualOffset() (4.4s)

  dev.responsive.kafka.store.LocalRemoteKvIteratorTest

    ✔ shouldIgnoreTombstoneWithNoRemoteMatch()
    ✔ shouldIgnoreRemoteValueWithLocalTombstone()
    ✔ shouldIterateLocalOnlyWithTombstones()
    ✔ shouldReturnUniqueKeysLexicographicallyFromTwoSources()
    ✔ shouldReturnLocalOnConflictingKeys()
    ✔ shouldIterateRemoteOnly()

  dev.responsive.kafka.store.ResponsiveStoreEosIntegrationTest

    ✔ shouldMaintainStateOnEosFailOverAndFenceOldClient() (35.3s)

  dev.responsive.kafka.store.ResponsiveWindowIntegrationTest

    ✔ shouldComputeWindowedJoinUsingRanges() (11.9s)
    ✔ shouldComputeWindowedAggregateWithRetention() (9.8s)

  18 passing (2m 21s)
```