### PR TITLE
Misc cleanups to the auth code

### DIFF
--- a/operator/build.gradle.kts
+++ b/operator/build.gradle.kts
@@ -31,9 +31,7 @@ dependencies {
     implementation(libs.jackson)
     implementation(libs.javaoperatorsdk)
 
-    implementation("commons-cli:commons-cli:1.5.0")
-    implementation("org.apache.commons:commons-configuration2:2.8.0")
-    implementation("commons-beanutils:commons-beanutils:1.9.4")
+    implementation(libs.bundles.commons)
 
     annotationProcessor(libs.javaoperatorsdk)
     annotationProcessor(libs.crd.generator.atp)

--- a/operator/docker/scripts/run-operator
+++ b/operator/docker/scripts/run-operator
@@ -1,1 +1,1 @@
-java -Dorg.apache.logging.log4j.level=INFO -cp "/usr/share/java/responsive-operator/*" dev.responsive.k8s.operator.OperatorMain ${CONTROLLER_EP}
+java -Dorg.apache.logging.log4j.level=INFO -cp "/usr/share/java/responsive-operator/*" dev.responsive.k8s.operator.OperatorMain --controller-url ${CONTROLLER_EP} --config-file "/dummy"

--- a/operator/src/main/java/dev/responsive/k8s/operator/OperatorMain.java
+++ b/operator/src/main/java/dev/responsive/k8s/operator/OperatorMain.java
@@ -68,8 +68,8 @@ public class OperatorMain {
       System.exit(1);
     }
 
-    final String apiKey = config.getString(API_KEY_CONFIG);
-    final String secret = config.getString(SECRET_CONFIG);
+    final String apiKey = config.getString(API_KEY_CONFIG, "");
+    final String secret = config.getString(SECRET_CONFIG, "");
 
     final Operator operator = new Operator();
     Serialization.jsonMapper().registerModule(new Jdk8Module());
@@ -90,7 +90,7 @@ public class OperatorMain {
 
   private static Options getOptions() {
     Options options = new Options();
-    Option serverOption = Option.builder("server-url")
+    Option serverOption = Option.builder("controller-url")
             .hasArg(true)
             .required(true)
             .desc("The URL for the controller server")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -56,6 +56,11 @@ dependencyResolutionManagement {
 
             library("protobuf-java-util", "com.google.protobuf", "protobuf-java-util").versionRef("protobuf-java")
             library("crd-generator-atp", "io.fabric8", "crd-generator-apt").version("6.5.1")
+
+            library("commons-cli", "commons-cli:commons-cli:1.5.0")
+            library("commons-configuration2", "org.apache.commons:commons-configuration2:2.8.0")
+            library("commons-beanutils", "commons-beanutils:commons-beanutils:1.9.4")
+            bundle("commons", listOf("commons-cli", "commons-configuration2", "commons-beanutils"))
         }
 
         create("testlibs") {


### PR DESCRIPTION
* Fix the imports to match the conventions with kotlin
* update the docker run script to include command line args
* set default values of the api key and secret configs to empty string. With this, and the server side code to make auth [optional](https://github.com/responsivedev/responsive-platform/pull/21), things should just work ™ in test environments.