### PR TITLE
use b64 encoded secrets file

### DIFF
--- a/operator/docker/scripts/run-operator
+++ b/operator/docker/scripts/run-operator
@@ -1,8 +1,1 @@
-if test -f /etc/secrets/ctl-api-key; then
-  echo "responsive.platform.api.key: $(cat /etc/secrets/ctl-api-key)" >> /etc/responsive-operator/app.properties
-fi
-if test -f /etc/secrets/ctl-api-secret; then
-  echo "responsive.platform.api.secret: $(cat /etc/secrets/ctl-api-secret)" >> /etc/responsive-operator/app.properties
-fi
-
-java -Dorg.apache.logging.log4j.level=INFO -cp "/usr/share/java/responsive-operator/*" dev.responsive.k8s.operator.OperatorMain -controllerUrl ${CONTROLLER_EP} -configFile "/etc/responsive-operator/app.properties"
+java -Dorg.apache.logging.log4j.level=INFO -cp "/usr/share/java/responsive-operator/*" dev.responsive.k8s.operator.OperatorMain -controllerUrl ${CONTROLLER_EP} -secretsFile "/etc/responsive-operator/secrets.properties.b64"

--- a/operator/src/main/helm/templates/deployment.yaml
+++ b/operator/src/main/helm/templates/deployment.yaml
@@ -36,11 +36,11 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
-            - name: secrets
-              mountPath: /etc/secrets
+            - name: cfg
+              mountPath: /etc/responsive-operator/
               readOnly: true
       volumes:
-        - name: secrets
+        - name: cfg
           secret:
             secretName: {{ .Values.controllerSecret }}
             optional: true

--- a/operator/src/main/java/dev/responsive/k8s/operator/OperatorOptions.java
+++ b/operator/src/main/java/dev/responsive/k8s/operator/OperatorOptions.java
@@ -30,15 +30,15 @@ public final class OperatorOptions {
       .numberOfArgs(1)
       .build();
 
-  public static final Option CONFIG_FILE = Option.builder("configFile")
+  public static final Option SECRETS_FILE = Option.builder("secretsFile")
       .hasArg(true)
       .required(true)
-      .desc("The path to the config file")
+      .desc("The path to the secrets file")
       .numberOfArgs(1)
       .build();
 
   public static final Options OPTIONS = new Options()
       .addOption(CONTROLLER_URL)
-      .addOption(CONFIG_FILE);
+      .addOption(SECRETS_FILE);
 
 }

--- a/operator/src/main/java/dev/responsive/k8s/operator/PropertiesLoader.java
+++ b/operator/src/main/java/dev/responsive/k8s/operator/PropertiesLoader.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.k8s.operator;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.Reader;
+import java.io.StringReader;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Base64;
+import java.util.Properties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Loads {@link java.util.Properties} depending on the encoding
+ * of the file type.
+ */
+public final class PropertiesLoader {
+
+  private static final Logger LOG = LoggerFactory.getLogger(PropertiesLoader.class);
+
+  private PropertiesLoader() {}
+
+  public static Properties load(final String fileName) {
+    final Properties properties = new Properties();
+    try {
+      final Reader reader;
+      if (fileName.endsWith("b64")) {
+        final byte[] encodedBytes = Files.readAllBytes(Paths.get(fileName));
+        byte[] decodedBytes = Base64.getDecoder().decode(encodedBytes);
+        reader = new StringReader(new String(decodedBytes));
+      } else {
+        final File configFile = new File(fileName);
+        reader = new FileReader(configFile);
+      }
+      properties.load(reader);
+    } catch (Exception e) {
+      LOG.error("Error loading configuration properties: {}", e.getMessage());
+    }
+    return properties;
+  }
+
+}

--- a/operator/src/test/java/dev/responsive/k8s/operator/PropertiesLoaderTest.java
+++ b/operator/src/test/java/dev/responsive/k8s/operator/PropertiesLoaderTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.k8s.operator;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.Properties;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+public class PropertiesLoaderTest {
+
+  @Test
+  public void shouldDecodeB64Properties() {
+    // Given:
+    final String path = PropertiesLoaderTest.class.getResource("/sample.properties.b64").getPath();
+
+    // When:
+    final Properties properties = PropertiesLoader.load(path);
+
+    // Then:
+    assertThat(properties.getProperty("foo.bar"), Matchers.is("baz"));
+  }
+
+  @Test
+  public void shouldLoadNonB64Properties() {
+    // Given:
+    final String path = PropertiesLoaderTest.class.getResource("/sample.properties").getPath();
+
+    // When:
+    final Properties properties = PropertiesLoader.load(path);
+
+    // Then:
+    assertThat(properties.getProperty("foo.bar"), Matchers.is("baz"));
+  }
+
+}

--- a/operator/src/test/resources/sample.properties
+++ b/operator/src/test/resources/sample.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2023 Responsive Computing, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+foo.bar=baz

--- a/operator/src/test/resources/sample.properties.b64
+++ b/operator/src/test/resources/sample.properties.b64
@@ -1,0 +1,1 @@
+Zm9vLmJhcj1iYXoK

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -58,9 +58,8 @@ dependencyResolutionManagement {
             library("crd-generator-atp", "io.fabric8", "crd-generator-apt").version("6.5.1")
 
             library("commons-cli", "commons-cli:commons-cli:1.5.0")
-            library("commons-configuration2", "org.apache.commons:commons-configuration2:2.8.0")
             library("commons-beanutils", "commons-beanutils:commons-beanutils:1.9.4")
-            bundle("commons", listOf("commons-cli", "commons-configuration2", "commons-beanutils"))
+            bundle("commons", listOf("commons-cli", "commons-beanutils"))
 
             // do not include these in jars that are distributed - these
             // should only be used when the distributed artifact is deployable (e.g.


### PR DESCRIPTION
Use `java.util.Properties` because it accepts a reader which can either read directly from a non-b64 encoded file or just load a `Reader` with the decoded contents.