### PR TITLE
add getX prefix to Jackson getters

### DIFF
--- a/operator/src/main/java/dev/responsive/k8s/controller/ControllerProtoFactories.java
+++ b/operator/src/main/java/dev/responsive/k8s/controller/ControllerProtoFactories.java
@@ -50,19 +50,19 @@ public final class ControllerProtoFactories {
 
   private static ApplicationPolicy policyFromK8sResource(final ResponsivePolicySpec policySpec) {
     final var builder = ApplicationPolicy.newBuilder();
-    switch (policySpec.policyType()) {
+    switch (policySpec.getPolicyType()) {
       case DEMO:
-        assert policySpec.demoPolicy().isPresent();
-        final var demoPolicy = policySpec.demoPolicy().get();
+        assert policySpec.getDemoPolicy().isPresent();
+        final var demoPolicy = policySpec.getDemoPolicy().get();
         builder.setDemoPolicy(ControllerOuterClass.DemoPolicy.newBuilder()
-            .setMaxReplicas(demoPolicy.maxReplicas())
+            .setMaxReplicas(demoPolicy.getMaxReplicas())
             .build()
         );
         break;
       default:
-        throw new IllegalStateException("Unexpected type: " + policySpec.policyType());
+        throw new IllegalStateException("Unexpected type: " + policySpec.getPolicyType());
     }
-    builder.setStatus(policySpec.status());
+    builder.setStatus(policySpec.getStatus());
     return builder.build();
   }
 

--- a/operator/src/main/java/dev/responsive/k8s/crd/ResponsivePolicySpec.java
+++ b/operator/src/main/java/dev/responsive/k8s/crd/ResponsivePolicySpec.java
@@ -48,23 +48,23 @@ public class ResponsivePolicySpec {
     this.demoPolicy = Objects.requireNonNull(demoPolicy);
   }
 
-  public String applicationNamespace() {
+  public String getApplicationNamespace() {
     return applicationNamespace;
   }
 
-  public String applicationName() {
+  public String getApplicationName() {
     return applicationName;
   }
 
-  public PolicyStatus status() {
+  public PolicyStatus getStatus() {
     return status;
   }
 
-  public PolicyType policyType() {
+  public PolicyType getPolicyType() {
     return policyType;
   }
 
-  public Optional<DemoPolicy> demoPolicy() {
+  public Optional<DemoPolicy> getDemoPolicy() {
     return demoPolicy;
   }
 
@@ -79,7 +79,7 @@ public class ResponsivePolicySpec {
       this.maxReplicas = maxReplicas;
     }
 
-    public int maxReplicas() {
+    public int getMaxReplicas() {
       return maxReplicas;
     }
   }

--- a/operator/src/main/java/dev/responsive/k8s/operator/reconciler/DemoPolicyPlugin.java
+++ b/operator/src/main/java/dev/responsive/k8s/operator/reconciler/DemoPolicyPlugin.java
@@ -63,8 +63,8 @@ public class DemoPolicyPlugin implements PolicyPlugin {
       final Context<ResponsivePolicy> ctx,
       final ResponsiveContext responsiveCtx
   ) {
-    final var appNamespace = policy.getSpec().applicationNamespace();
-    final var appName = policy.getSpec().applicationName();
+    final var appNamespace = policy.getSpec().getApplicationNamespace();
+    final var appName = policy.getSpec().getApplicationName();
     final var deployment = getAndMaybeLabelCurrentDeployment(policy, ctx);
 
     LOGGER.info("Found deployment {} for app {}/{}", deployment, appNamespace, appName);
@@ -114,8 +114,8 @@ public class DemoPolicyPlugin implements PolicyPlugin {
       // with the required label. Label the deployment here.
       // TODO(rohan): double-check this understanding
       final Deployment deployment;
-      final String appNs = policy.getSpec().applicationNamespace();
-      final String app = policy.getSpec().applicationName();
+      final String appNs = policy.getSpec().getApplicationNamespace();
+      final String app = policy.getSpec().getApplicationName();
       final var appClient = ctx.getClient().apps();
       deployment = appClient.deployments()
           .inNamespace(appNs)
@@ -190,7 +190,7 @@ public class DemoPolicyPlugin implements PolicyPlugin {
 
   private static Set<ResourceID> toDeploymentMapper(final ResponsivePolicy policy) {
     return ImmutableSet.of(
-        new ResourceID(policy.getSpec().applicationName(), policy.getSpec().applicationNamespace())
+        new ResourceID(policy.getSpec().getApplicationName(), policy.getSpec().getApplicationNamespace())
     );
   }
 }

--- a/operator/src/main/java/dev/responsive/k8s/operator/reconciler/DemoPolicyPlugin.java
+++ b/operator/src/main/java/dev/responsive/k8s/operator/reconciler/DemoPolicyPlugin.java
@@ -190,7 +190,9 @@ public class DemoPolicyPlugin implements PolicyPlugin {
 
   private static Set<ResourceID> toDeploymentMapper(final ResponsivePolicy policy) {
     return ImmutableSet.of(
-        new ResourceID(policy.getSpec().getApplicationName(), policy.getSpec().getApplicationNamespace())
+        new ResourceID(
+            policy.getSpec().getApplicationName(),
+            policy.getSpec().getApplicationNamespace())
     );
   }
 }

--- a/operator/src/main/java/dev/responsive/k8s/operator/reconciler/ResponsivePolicyReconciler.java
+++ b/operator/src/main/java/dev/responsive/k8s/operator/reconciler/ResponsivePolicyReconciler.java
@@ -108,7 +108,7 @@ public class ResponsivePolicyReconciler implements
     LOGGER.info("Received event for {}", resource.getFullResourceName());
     responsiveCtx.getControllerClient()
         .upsertPolicy(ControllerProtoFactories.upsertPolicyRequest(resource));
-    plugins.get(resource.getSpec().policyType()).reconcile(resource, ctx, responsiveCtx);
+    plugins.get(resource.getSpec().getPolicyType()).reconcile(resource, ctx, responsiveCtx);
     return UpdateControl.patchStatus(resource);
   }
 }


### PR DESCRIPTION
when migrating from JDK17->11 I used record style getters (no `getX` prefix) but this causes Jackson to fail as it expects getters with a specific naming convention. Instead of changing convention, I renamed the getters.