### PR TITLE
use TLS for GRPC channel

### DIFF
--- a/operator/src/main/java/dev/responsive/controller/client/grpc/ControllerGrpcClient.java
+++ b/operator/src/main/java/dev/responsive/controller/client/grpc/ControllerGrpcClient.java
@@ -21,9 +21,9 @@ import dev.responsive.controller.client.ControllerClient;
 import io.grpc.ChannelCredentials;
 import io.grpc.ClientInterceptor;
 import io.grpc.Grpc;
-import io.grpc.InsecureChannelCredentials;
 import io.grpc.ManagedChannel;
 import io.grpc.Metadata;
+import io.grpc.TlsChannelCredentials;
 import io.grpc.stub.MetadataUtils;
 import java.util.concurrent.TimeUnit;
 import responsive.controller.v1.controller.proto.ControllerGrpc;
@@ -48,7 +48,7 @@ public class ControllerGrpcClient implements ControllerClient {
     metadata.put(Metadata.Key.of(
         ApiKeyHeaders.SECRET_METADATA_KEY, Metadata.ASCII_STRING_MARSHALLER), secret);
 
-    channel = grpcFactories.createChannel(target, InsecureChannelCredentials.create(),
+    channel = grpcFactories.createChannel(target, TlsChannelCredentials.create(),
             MetadataUtils.newAttachHeadersInterceptor(metadata));
     stub = grpcFactories.createBlockingStub(channel);
   }

--- a/operator/src/test/java/dev/responsive/controller/client/grpc/ControllerGrpcClientTest.java
+++ b/operator/src/test/java/dev/responsive/controller/client/grpc/ControllerGrpcClientTest.java
@@ -32,7 +32,6 @@ import static org.mockito.Mockito.when;
 
 import io.grpc.ClientInterceptor;
 import io.grpc.ClientInterceptors;
-import io.grpc.InsecureChannelCredentials;
 import io.grpc.ManagedChannel;
 import io.grpc.Metadata;
 import io.grpc.ServerCall;
@@ -40,6 +39,7 @@ import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.grpc.ServerInterceptors;
 import io.grpc.StatusRuntimeException;
+import io.grpc.TlsChannelCredentials;
 import io.grpc.examples.helloworld.GreeterGrpc;
 import io.grpc.examples.helloworld.HelloReply;
 import io.grpc.examples.helloworld.HelloRequest;
@@ -104,7 +104,7 @@ class ControllerGrpcClientTest {
 
   @Test
   public void shouldConnectCorrectly() {
-    verify(grpcFactories).createChannel(eq(TARGET), any(InsecureChannelCredentials.class),
+    verify(grpcFactories).createChannel(eq(TARGET), any(TlsChannelCredentials.class),
         any(ClientInterceptor.class));
     verify(grpcFactories).createBlockingStub(channel);
   }


### PR DESCRIPTION
our controller endpoints are now secured we need this in order to establish the connection. will make it configurable so we can run test deployments later