### PR TITLE
add tools module + analyzer tool

### DIFF
--- a/buildSrc/src/main/kotlin/responsive.java-common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/responsive.java-common-conventions.gradle.kts
@@ -16,22 +16,6 @@
 
 import com.adarshr.gradle.testlogger.theme.ThemeType
 
-/*
- * Copyright 2023 Responsive Computing, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 plugins {
     `java`
     `checkstyle`

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,6 +23,7 @@ plugins {
 include("kafka-client")
 include("controller-api")
 include("operator")
+include("tools")
 
 dependencyResolutionManagement {
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,9 +1,16 @@
 # Responsive Tools
 
 This module contains tools that can be helpful when using the Responsive
-Platform. To run a tool in this module execute:
+Platform. This module builds a Fat JAR containing all dependencies required
+to run the tools. Once you have the JAR, you can run any of its commands -
+the example below runs `StreamsBytecodeAnalyzer`:
 ```bash
-./gradlew :tools:run --args=<args>
+java -cp tools/build/libs/tools-fat-0.1.0-1-SNAPSHOT.jar dev.responsive.tools.analyzer.StreamsBytecodeAnalyzer --help
+Usage: analyze [-hV] <jarPath>
+analyzes a JAR file for Kafka Stream usage
+      <jarPath>   Path to JAR File
+  -h, --help      Show this help message and exit.
+  -V, --version   Print version information and exit.
 ```
 
 ## Streams Bytecode Analyzer
@@ -13,7 +20,6 @@ in the `org.apache.kafka.streams` package that the JAR references. An example
 output:
 
 ```
-> Task :tools:run
 org/apache/kafka/streams/StreamsConfig -> [<init>(Map)]
 org/apache/kafka/streams/kstream/KStream -> [selectKey(KeyValueMapper), to(String), join(KTable, ValueJoiner), filter(Predicate)]
 org/apache/kafka/streams/KafkaStreams -> [<init>(Topology, StreamsConfig), start(), close()]

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,21 @@
+# Responsive Tools
+
+This module contains tools that can be helpful when using the Responsive
+Platform. To run a tool in this module execute:
+```bash
+./gradlew :tools:run --args=<args>
+```
+
+## Streams Bytecode Analyzer
+
+This tool accepts a JAR file path as its input and outputs all the methods
+in the `org.apache.kafka.streams` package that the JAR references. An example
+output:
+
+```
+> Task :tools:run
+org/apache/kafka/streams/StreamsConfig -> [<init>(Map)]
+org/apache/kafka/streams/kstream/KStream -> [selectKey(KeyValueMapper), to(String), join(KTable, ValueJoiner), filter(Predicate)]
+org/apache/kafka/streams/KafkaStreams -> [<init>(Topology, StreamsConfig), start(), close()]
+org/apache/kafka/streams/StreamsBuilder -> [table(String, Materialized), <init>(), stream(String), build()]
+```

--- a/tools/build.gradle.kts
+++ b/tools/build.gradle.kts
@@ -33,10 +33,13 @@ val fatJar = task("fatJar", type = Jar::class) {
     manifest {
         attributes["Implementation-Title"] = "Responsive Analyzer Tool"
         attributes["Implementation-Version"] = "0.1.0"
-        attributes["Main-Class"] = "dev.responsive.tools.analyzer.Main"
     }
     from(configurations.runtimeClasspath.get().map { if (it.isDirectory) it else zipTree(it) })
     with(tasks.jar.get() as CopySpec)
+}
+
+tasks.withType<JavaCompile> {
+    options.compilerArgs.addAll(arrayOf("-Aproject=${project.group}/${project.name}"))
 }
 
 tasks {

--- a/tools/build.gradle.kts
+++ b/tools/build.gradle.kts
@@ -39,7 +39,10 @@ val fatJar = task("fatJar", type = Jar::class) {
 }
 
 tasks.withType<JavaCompile> {
-    options.compilerArgs.addAll(arrayOf("-Aproject=${project.group}/${project.name}"))
+    options.compilerArgs.addAll(arrayOf(
+        "-Xlint:-processing",
+        "-Aproject=${project.group}/${project.name}"
+    ))
 }
 
 tasks {

--- a/tools/build.gradle.kts
+++ b/tools/build.gradle.kts
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id("responsive.java-application-conventions")
+}
+
+dependencies {
+    // don't include these in libs since they are specific to only this
+    // tooling module and may cause issues if included in other jars
+    implementation("org.ow2.asm:asm:9.4")
+    implementation("info.picocli:picocli:4.7.4")
+
+    annotationProcessor("info.picocli:picocli-codegen:4.7.4")
+}
+
+val fatJar = task("fatJar", type = Jar::class) {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+    archiveBaseName.set("${project.name}-fat")
+    manifest {
+        attributes["Implementation-Title"] = "Responsive Analyzer Tool"
+        attributes["Implementation-Version"] = "0.1.0"
+        attributes["Main-Class"] = "dev.responsive.tools.analyzer.Main"
+    }
+    from(configurations.runtimeClasspath.get().map { if (it.isDirectory) it else zipTree(it) })
+    with(tasks.jar.get() as CopySpec)
+}
+
+tasks {
+    "build" {
+        dependsOn(fatJar)
+    }
+}

--- a/tools/src/main/java/dev/responsive/tools/StreamsBytecodeAnalyzer.java
+++ b/tools/src/main/java/dev/responsive/tools/StreamsBytecodeAnalyzer.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.tools;
+
+import dev.responsive.tools.Visitors.FilterMethodCollector;
+import java.io.BufferedInputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.util.Enumeration;
+import java.util.concurrent.Callable;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import org.objectweb.asm.ClassReader;
+import picocli.CommandLine;
+import picocli.CommandLine.Command;
+import picocli.CommandLine.Parameters;
+
+@Command(
+    name = "analyze",
+    mixinStandardHelpOptions = true,
+    description = "analyzes a JAR file for Kafka Stream usage"
+)
+public class StreamsBytecodeAnalyzer implements Callable<Integer> {
+
+  @Parameters(index = "0", description = "Path to JAR File")
+  private File jarPath;
+
+  @Override
+  public Integer call() throws Exception {
+    final FilterMethodCollector methods = new FilterMethodCollector(
+        owner -> owner.contains("org/apache/kafka/streams")
+    );
+
+    try (JarFile jar = new JarFile(jarPath)) {
+      Enumeration<JarEntry> entries = jar.entries();
+      while (entries.hasMoreElements()) {
+        JarEntry entry = entries.nextElement();
+
+        if (entry.getName().endsWith(".class")) {
+          InputStream stream = new BufferedInputStream(jar.getInputStream(entry), 1024);
+          ClassReader reader = new ClassReader(stream);
+
+          reader.accept(new Visitors.DelegatingClassVisitor(methods), 0);
+
+          stream.close();
+        }
+      }
+    }
+
+    methods.describe();
+    return 0;
+  }
+
+  public static void main(String... args) {
+    int exitCode = new CommandLine(new StreamsBytecodeAnalyzer()).execute(args);
+    System.exit(exitCode);
+  }
+}

--- a/tools/src/main/java/dev/responsive/tools/Visitors.java
+++ b/tools/src/main/java/dev/responsive/tools/Visitors.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.tools;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Predicate;
+import org.objectweb.asm.ClassVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+
+public final class Visitors {
+
+  public static class DelegatingClassVisitor extends ClassVisitor {
+
+    private final MethodVisitor delegate;
+
+    public DelegatingClassVisitor(final MethodVisitor delegate) {
+      super(Opcodes.ASM9);
+      this.delegate = delegate;
+    }
+
+    @Override
+    public MethodVisitor visitMethod(
+        final int access,
+        final String name,
+        final String desc,
+        final String signature,
+        final String[] exceptions) {
+      return delegate;
+    }
+  }
+
+  public static class FilterMethodCollector extends MethodVisitor {
+
+    private final Map<String, Set<String>> methods;
+    private final Predicate<String> ownerFilter;
+
+    public FilterMethodCollector(
+        final Predicate<String> ownerFilter
+    ) {
+      super(Opcodes.ASM9);
+      this.ownerFilter = ownerFilter;
+      this.methods = new HashMap<>();
+    }
+
+    @Override
+    public void visitMethodInsn(
+        final int opcode,
+        final String owner,
+        final String name,
+        final String descriptor,
+        final boolean isInterface
+    ) {
+      if (ownerFilter.test(owner)) {
+        methods.compute(
+            owner,
+            (k, v) -> {
+              final Set<String> result = Objects.requireNonNullElseGet(v, HashSet::new);
+              result.add(sanitize(name, descriptor));
+              return result;
+            });
+      }
+    }
+
+    public void describe() {
+      methods.forEach((k, v) -> {
+        System.out.println(k + " -> " + v);
+      });
+    }
+  }
+
+  private static String sanitize(final String name, final String desc) {
+    // the description has all the arguments in between () separated
+    // by semi-colons
+    String[] args = desc.substring(
+        desc.indexOf('(') + 1,
+        desc.lastIndexOf(')')
+    ).split(";");
+
+    // each arg contains the full package name, for simplicity we want
+    // to just return the name of the class
+    for (int i = 0; i < args.length; i++) {
+      final String arg = args[i];
+      if (arg.lastIndexOf('/') >= 0) {
+        args[i] = arg.substring(arg.lastIndexOf('/') + 1);
+      }
+    }
+
+    return name + "(" + String.join(", ", args) + ")";
+  }
+}


### PR DESCRIPTION
copy-pasting the README.md - for now there's only one tool so I didn't bother including a CLI options parser

# Responsive Tools

This module contains tools that can be helpful when using the Responsive
Platform. To run a tool in this module execute:
```bash
./gradlew :tools:run --args=<args>
```

## Streams Bytecode Analyzer

This tool accepts a JAR file path as its input and outputs all the methods
in the `org.apache.kafka.streams` package that the JAR references. An example
output:

```
> Task :tools:run
org/apache/kafka/streams/StreamsConfig -> [<init>(Map)]
org/apache/kafka/streams/kstream/KStream -> [selectKey(KeyValueMapper), to(String), join(KTable, ValueJoiner), filter(Predicate)]
org/apache/kafka/streams/KafkaStreams -> [<init>(Topology, StreamsConfig), start(), close()]
org/apache/kafka/streams/StreamsBuilder -> [table(String, Materialized), <init>(), stream(String), build()]