### PR TITLE
better handling of get target state errors

### DIFF
--- a/operator/src/main/java/dev/responsive/k8s/operator/reconciler/ResponsivePolicyReconciler.java
+++ b/operator/src/main/java/dev/responsive/k8s/operator/reconciler/ResponsivePolicyReconciler.java
@@ -73,15 +73,13 @@ public class ResponsivePolicyReconciler implements
                 // TODO(rohan): this is a hack to force an event at each poll interval.
                 // we should either: 1. make the controller robust to not rely on polling
                 //                   2. poll in some less hacky way (while still using events)
-                // TODO(rohan): there is a bug here where this repeatedly throws and we never
-                //              call the plugin:
-                //    1. controller restarts and forgets about policy
-                //    2. this call always throws, so we never upsert the policy again
                 responsiveCtx.getControllerClient()
                     .getTargetState(ControllerProtoFactories.emptyRequest(policy))));
           } catch (final Throwable t) {
             LOGGER.error("Error fetching target state", t);
-            return Collections.emptySet();
+            // We return an empty target state to force reconciliation to run, since right now the
+            // controller is stateless and relies on periodic updates after it restarts
+            return ImmutableSet.of(new TargetStateWithTimestamp());
           }
         },
         ctx.getPrimaryCache(),

--- a/operator/src/main/java/dev/responsive/k8s/operator/reconciler/TargetStateWithTimestamp.java
+++ b/operator/src/main/java/dev/responsive/k8s/operator/reconciler/TargetStateWithTimestamp.java
@@ -18,18 +18,23 @@ package dev.responsive.k8s.operator.reconciler;
 
 import java.time.Instant;
 import java.util.Objects;
+import java.util.Optional;
 import responsive.controller.v1.controller.proto.ControllerOuterClass;
 
 class TargetStateWithTimestamp {
   private final Instant timestamp;
-  private final ControllerOuterClass.ApplicationState targetState;
+  private final Optional<ControllerOuterClass.ApplicationState> targetState;
 
   TargetStateWithTimestamp(final ControllerOuterClass.ApplicationState targetState) {
-    this(Instant.now(), targetState);
+    this(Instant.now(), Optional.of(targetState));
+  }
+
+  TargetStateWithTimestamp() {
+    this(Instant.now(), Optional.empty());
   }
 
   TargetStateWithTimestamp(final Instant timestamp,
-                           final ControllerOuterClass.ApplicationState targetState) {
+                           final Optional<ControllerOuterClass.ApplicationState> targetState) {
     this.timestamp = Objects.requireNonNull(timestamp);
     this.targetState = Objects.requireNonNull(targetState);
   }
@@ -38,7 +43,7 @@ class TargetStateWithTimestamp {
     return timestamp;
   }
 
-  public ControllerOuterClass.ApplicationState getTargetState() {
+  public Optional<ControllerOuterClass.ApplicationState> getTargetState() {
     return targetState;
   }
 

--- a/operator/src/test/java/dev/responsive/k8s/operator/reconciler/DemoPolicyPluginTest.java
+++ b/operator/src/test/java/dev/responsive/k8s/operator/reconciler/DemoPolicyPluginTest.java
@@ -257,6 +257,19 @@ class DemoPolicyPluginTest {
     verifyNoInteractions(rsDeployment);
   }
 
+  @Test
+  public void shouldNotPatchDeploymentIfNoTargetStateSpecified() {
+    // given:
+    when(ctx.getSecondaryResource(TargetStateWithTimestamp.class))
+        .thenReturn(Optional.of(new TargetStateWithTimestamp()));
+
+    // when:
+    plugin.reconcile(policy, ctx, responsiveCtx);
+
+    // then:
+    verifyNoInteractions(rsDeployment);
+  }
+
   @SuppressWarnings("unchecked")
   private <R extends HasMetadata> Optional<InformerEventSource<R, ResponsivePolicy>> maybePullSrc(
       final Map<String, EventSource> sources,


### PR DESCRIPTION
This patch improves handling of get target state errors. When we get an error, we still want to run the main reconciler, because the controller relies on periodic updates from operator. So, instead of returning empty from the poller, we return an updated status with an empty target state - which forces the framework to re-run reconciliation.