### PR TITLE
fix naming in policy spec

### DIFF
--- a/operator/src/main/java/dev/responsive/k8s/controller/ControllerProtoFactories.java
+++ b/operator/src/main/java/dev/responsive/k8s/controller/ControllerProtoFactories.java
@@ -28,7 +28,7 @@ public final class ControllerProtoFactories {
     return ControllerOuterClass.UpsertPolicyRequest.newBuilder()
         .setPolicy(ControllerProtoFactories.policyFromK8sResource(policy.getSpec()))
         // TODO(rohan): dont just use a namespaced (w/ /) name
-        .setApplicationId(getNamespacedName(policy))
+        .setApplicationId(getFullApplicationName(policy))
         .build();
   }
 
@@ -37,14 +37,14 @@ public final class ControllerProtoFactories {
       final ApplicationState state
   ) {
     return ControllerOuterClass.CurrentStateRequest.newBuilder()
-        .setApplicationId(getNamespacedName(policy))
+        .setApplicationId(getFullApplicationName(policy))
         .setState(state)
         .build();
   }
 
   public static ControllerOuterClass.EmptyRequest emptyRequest(final ResponsivePolicy policy) {
     return ControllerOuterClass.EmptyRequest.newBuilder()
-        .setApplicationId(getNamespacedName(policy))
+        .setApplicationId(getFullApplicationName(policy))
         .build();
   }
 
@@ -66,7 +66,7 @@ public final class ControllerProtoFactories {
     return builder.build();
   }
 
-  private static String getNamespacedName(final ResponsivePolicy policy) {
-    return policy.getMetadata().getNamespace() + "/" + policy.getMetadata().getName();
+  private static String getFullApplicationName(final ResponsivePolicy policy) {
+    return policy.getSpec().getApplicationNamespace() + "/" + policy.getSpec().getApplicationName();
   }
 }

--- a/operator/src/test/java/dev/responsive/k8s/controller/ControllerProtoFactoriesTest.java
+++ b/operator/src/test/java/dev/responsive/k8s/controller/ControllerProtoFactoriesTest.java
@@ -60,7 +60,7 @@ class ControllerProtoFactoriesTest {
     final var request = ControllerProtoFactories.upsertPolicyRequest(demoPolicy);
 
     // then:
-    assertThat(request.getApplicationId(), is("orange/banana"));
+    assertThat(request.getApplicationId(), is("gouda/cheddar"));
     assertThat(request.getPolicy().hasDemoPolicy(), is(true));
     assertThat(request.getPolicy().getStatus(), is(PolicyStatus.POLICY_STATUS_MANAGED));
     final DemoPolicy demoPolicy = request.getPolicy().getDemoPolicy();
@@ -74,7 +74,7 @@ class ControllerProtoFactoriesTest {
         = ControllerProtoFactories.currentStateRequest(demoPolicy, demoApplicationState);
 
     // Then:
-    assertThat(request.getApplicationId(), is("orange/banana"));
+    assertThat(request.getApplicationId(), is("gouda/cheddar"));
     assertThat(request.getState().hasDemoState(), is(true));
     assertThat(request.getState().getDemoState().getReplicas(), is(3));
   }
@@ -83,6 +83,6 @@ class ControllerProtoFactoriesTest {
   public void shouldCreateEmptyRequest() {
     final var request = ControllerProtoFactories.emptyRequest(demoPolicy);
 
-    assertThat(request.getApplicationId(), is("orange/banana"));
+    assertThat(request.getApplicationId(), is("gouda/cheddar"));
   }
 }

--- a/operator/src/test/java/dev/responsive/k8s/operator/reconciler/ResponsivePolicyReconcilerTest.java
+++ b/operator/src/test/java/dev/responsive/k8s/operator/reconciler/ResponsivePolicyReconcilerTest.java
@@ -126,6 +126,13 @@ class ResponsivePolicyReconcilerTest {
     final var source = (PerResourcePollingEventSource) maybeSource.get();
     final var resource = mock(ResponsivePolicy.class);
     when(resource.getMetadata()).thenReturn(new ObjectMeta());
+    when(resource.getSpec()).thenReturn(new ResponsivePolicySpec(
+        "ping",
+        "pong",
+        PolicyStatus.POLICY_STATUS_MANAGED,
+        ResponsivePolicySpec.PolicyType.DEMO,
+        Optional.of(new ResponsivePolicySpec.DemoPolicy(123))
+    ));
     when(controllerClient.getTargetState(any())).thenThrow(new RuntimeException("oops"));
 
     // when:


### PR DESCRIPTION
A policy that looks like:
```
apiVersion: "application.responsive.dev/v1"
kind: "ResponsivePolicy"
metadata:
  name: example-policy
  namespace: policies
spec:
  applicationNamespace: responsive
  applicationName: example
  status: POLICY_STATUS_MANAGED
  policyType: DEMO
  demoPolicy:
    maxReplicas: 2
```
should manage `responsive/example` not `policies/example-policy`