### PR TITLE
fix helm chart role bindings

### DIFF
--- a/operator/src/main/helm/Chart.yaml
+++ b/operator/src/main/helm/Chart.yaml
@@ -12,6 +12,6 @@ version: 0.1.0
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-# It is recommended to use it with quotes.
-# TODO(rohan): for now just pick some version, todo is to have it be the built version
-appVersion: "27e9457"
+# It is recommended to use it with quotes. This value is set by the build - if applying the
+# chart locally make sure to update this to a deployed image version.
+appVersion: "SET_BY_BUILD"

--- a/operator/src/main/helm/templates/appclusterrole.yaml
+++ b/operator/src/main/helm/templates/appclusterrole.yaml
@@ -1,18 +1,16 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole 
 metadata:
-  name: {{ printf "%s-role" (include "responsive-operator.fullname" .)  }}
+  name: {{ printf "%s-app-role" (include "responsive-operator.fullname" .)  }}
   labels:
     {{- include "responsive-operator.role.labels" . | nindent 4 }}
 rules:
 - apiGroups:
   - apps
-  - application.responsive.dev
   resources:
   - deployments
   - statefulsets
   - replicasets
-  - responsivepolicies
   verbs:
   - get
   - list

--- a/operator/src/main/helm/templates/appclusterrolebinding.yaml
+++ b/operator/src/main/helm/templates/appclusterrolebinding.yaml
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ printf "%s-app-rolebinding" (include "responsive-operator.fullname" .)  }}
+  labels:
+    {{- include "responsive-operator.role.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ printf "%s-app-role" (include "responsive-operator.fullname" .)  }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "responsive-operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}

--- a/operator/src/main/helm/templates/responsiveclusterrole.yaml
+++ b/operator/src/main/helm/templates/responsiveclusterrole.yaml
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole 
+metadata:
+  name: {{ printf "%s-responsive-role" (include "responsive-operator.fullname" .)  }}
+  labels:
+    {{- include "responsive-operator.role.labels" . | nindent 4 }}
+rules:
+- apiGroups:
+  - application.responsive.dev
+  resources: ["*"]
+  verbs: ["*"]

--- a/operator/src/main/helm/templates/responsiveclusterrolebinding.yaml
+++ b/operator/src/main/helm/templates/responsiveclusterrolebinding.yaml
@@ -1,13 +1,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ printf "%s-rolebinding" (include "responsive-operator.fullname" .)  }}
+  name: {{ printf "%s-responsive-rolebinding" (include "responsive-operator.fullname" .)  }}
   labels:
     {{- include "responsive-operator.role.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ printf "%s-role" (include "responsive-operator.fullname" .)  }} 
+  name: {{ printf "%s-responsive-role" (include "responsive-operator.fullname" .)  }}
 subjects:
 - kind: ServiceAccount
   name: {{ include "responsive-operator.serviceAccountName" . }}


### PR DESCRIPTION
```bash
$ kubectl describe clusterrole -n responsive responsive-operator-app-role
Name:         responsive-operator-app-role
Labels:       app.kubernetes.io/managed-by=Helm
              app.kubernetes.io/version=27e9457
              helm.sh/chart=responsive-operator-0.1.0
Annotations:  meta.helm.sh/release-name: responsive-operator
              meta.helm.sh/release-namespace: responsive
PolicyRule:
  Resources          Non-Resource URLs  Resource Names  Verbs
  ---------          -----------------  --------------  -----
  deployments.apps   []                 []              [get list patch update watch]
  replicasets.apps   []                 []              [get list patch update watch]
  statefulsets.apps  []                 []              [get list patch update watch]

$ kubectl describe clusterrole -n responsive responsive-operator-responsive-role
Name:         responsive-operator-responsive-role
Labels:       app.kubernetes.io/managed-by=Helm
              app.kubernetes.io/version=27e9457
              helm.sh/chart=responsive-operator-0.1.0
Annotations:  meta.helm.sh/release-name: responsive-operator
              meta.helm.sh/release-namespace: responsive
PolicyRule:
  Resources                     Non-Resource URLs  Resource Names  Verbs
  ---------                     -----------------  --------------  -----
  *.application.responsive.dev  []                 []              [*]
```