### PR TITLE
add responsive-test-utils module and refactor Driver

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveDriver.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveDriver.java
@@ -51,7 +51,7 @@ import org.apache.kafka.streams.state.WindowStore;
  * The driver can be reused to create new state stores, even across
  * different Kafka Streams applications.
  */
-public class ResponsiveDriver implements Closeable {
+public class ResponsiveDriver implements StreamsStoreDriver, Closeable {
 
   private static final Map<String, String> CHANGELOG_CONFIG = Map.of(
       TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_DELETE);
@@ -106,22 +106,17 @@ public class ResponsiveDriver implements Closeable {
   }
 
   /**
-   * @param name the state store name
-   * @return a key value store supplier with the given name that uses Responsive's
-   *         storage for its backend
+   * {@inheritDoc}
    */
+  @Override
   public KeyValueBytesStoreSupplier kv(final String name) {
     return new ResponsiveKeyValueBytesStoreSupplier(client, name, executor, admin);
   }
 
   /**
-   * @param name the state store name
-   * @param retentionMs the retention for each entry
-   * @param windowSize the window size
-   * @param retainDuplicates whether to retain duplicates
-   * @return a windowed key value store supplier with the given name that
-   *         uses Responsive's storage for its backend
+   * {@inheritDoc}
    */
+  @Override
   public WindowBytesStoreSupplier windowed(
       final String name,
       final long retentionMs,
@@ -140,8 +135,9 @@ public class ResponsiveDriver implements Closeable {
   }
 
   /**
-   * @see #kv(String)
+   * {@inheritDoc}
    */
+  @Override
   public <K, V> Materialized<K, V, KeyValueStore<Bytes, byte[]>> materialized(
       final String name
   ) {
@@ -150,8 +146,9 @@ public class ResponsiveDriver implements Closeable {
   }
 
   /**
-   * @see #windowed(String, long, long, boolean)
+   * {@inheritDoc}
    */
+  @Override
   public <K, V> Materialized<K, V, WindowStore<Bytes, byte[]>> materialized(
       final String name,
       final long retentionMs,

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/StreamsStoreDriver.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/StreamsStoreDriver.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.kafka.api;
+
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.WindowBytesStoreSupplier;
+import org.apache.kafka.streams.state.WindowStore;
+
+/**
+ * An interface that allows for easily wrapping different Kafka Streams
+ * state store implementations and swapping them at ease.
+ */
+public interface StreamsStoreDriver {
+
+  /**
+   * @param name the state store name
+   * @return a key value store supplier with the given name that uses Responsive's
+   *         storage for its backend
+   */
+  KeyValueBytesStoreSupplier kv(final String name);
+
+  /**
+   * @param name the state store name
+   * @param retentionMs the retention for each entry
+   * @param windowSize the window size
+   * @param retainDuplicates whether to retain duplicates
+   * @return a windowed key value store supplier with the given name that
+   *         uses Responsive's storage for its backend
+   */
+  WindowBytesStoreSupplier windowed(
+      final String name,
+      final long retentionMs,
+      final long windowSize,
+      final boolean retainDuplicates
+  );
+
+  /**
+   * @see #kv(String)
+   */
+  <K, V> Materialized<K, V, KeyValueStore<Bytes, byte[]>> materialized(
+      final String name
+  );
+
+  /**
+   * @see #windowed(String, long, long, boolean)
+   */
+  <K, V> Materialized<K, V, WindowStore<Bytes, byte[]>> materialized(
+      final String name,
+      final long retentionMs,
+      final long windowSize,
+      final boolean retainDuplicates
+  );
+
+}

--- a/responsive-test-utils/build.gradle.kts
+++ b/responsive-test-utils/build.gradle.kts
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id("responsive.java-library-conventions")
+}
+
+dependencies {
+    implementation(project(":kafka-client"))
+
+    testImplementation(testlibs.bundles.base)
+    testImplementation(libs.bundles.logging)
+    testImplementation(testlibs.kafka.streams.test.utils)
+}

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/api/TestStoreDriver.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/api/TestStoreDriver.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.kafka.api;
+
+import java.time.Duration;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.streams.state.WindowBytesStoreSupplier;
+import org.apache.kafka.streams.state.WindowStore;
+
+/**
+ * For use in testing, this {@link StreamsStoreDriver} will simply create
+ * in memory stores for all state stores.
+ */
+public class TestStoreDriver implements StreamsStoreDriver {
+
+  @Override
+  public KeyValueBytesStoreSupplier kv(final String name) {
+    return Stores.inMemoryKeyValueStore(name);
+  }
+
+  @Override
+  public WindowBytesStoreSupplier windowed(final String name, final long retentionMs,
+      final long windowSize, final boolean retainDuplicates) {
+    return Stores.inMemoryWindowStore(
+        name,
+        Duration.ofMillis(retentionMs),
+        Duration.ofMillis(windowSize),
+        retainDuplicates
+    );
+  }
+
+  @Override
+  public <K, V> Materialized<K, V, KeyValueStore<Bytes, byte[]>> materialized(final String name) {
+    return Materialized.as(kv(name));
+  }
+
+  @Override
+  public <K, V> Materialized<K, V, WindowStore<Bytes, byte[]>> materialized(final String name,
+      final long retentionMs, final long windowSize, final boolean retainDuplicates) {
+    return Materialized.as(windowed(name, retentionMs, windowSize, retainDuplicates));
+  }
+}

--- a/responsive-test-utils/src/test/java/dev/responsive/kafka/api/TopologyTestDriverExampleTest.java
+++ b/responsive-test-utils/src/test/java/dev/responsive/kafka/api/TopologyTestDriverExampleTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.kafka.api;
+
+import java.util.List;
+import java.util.Properties;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.TestInputTopic;
+import org.apache.kafka.streams.TestOutputTopic;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.TopologyTestDriver;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KTable;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+public class TopologyTestDriverExampleTest {
+
+  // this test is a demonstration of using the TestStoreDriver
+  // with the TopologyTestDriver so that using StreamsStoreDriver
+  // is possible
+  @Test
+  public void shouldRunWithoutResponsiveConnection() {
+    // Given:
+    final Properties props = new Properties();
+    props.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.StringSerde.class);
+    props.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.StringSerde.class);
+
+    final Topology topo = topology(new TestStoreDriver());
+    final TopologyTestDriver driver = new TopologyTestDriver(topo, props);
+
+    final TestInputTopic<String, String> bids = driver.createInputTopic(
+        "bids", new StringSerializer(), new StringSerializer());
+    final TestInputTopic<String, String> people = driver.createInputTopic(
+        "people", new StringSerializer(), new StringSerializer());
+    final TestOutputTopic<String, String> output = driver.createOutputTopic(
+        "output", new StringDeserializer(), new StringDeserializer());
+
+    // When:
+    people.pipeInput("1", "1,alice,CA");
+    people.pipeInput("2", "2,bob,OR");
+    people.pipeInput("3", "3,carol,CA");
+
+    bids.pipeInput("a", "a,100,1");
+    bids.pipeInput("b", "b,101,2");
+    bids.pipeInput("c", "c,102,1");
+    bids.pipeInput("d", "d,103,3");
+
+    // Then:
+    final List<String> outputs = output.readValuesToList();
+    MatcherAssert.assertThat(outputs, Matchers.contains(
+        "a,100,1,1,alice,CA",
+        "c,102,1,1,alice,CA",
+        "d,103,3,3,carol,CA"
+    ));
+    driver.close();
+  }
+
+  Topology topology(final StreamsStoreDriver driver) {
+    final StreamsBuilder builder = new StreamsBuilder();
+
+    // schema for bids is key: <bid_id> value: <bid_id, amount, person_id>
+    final KStream<String, String> bids = builder.stream("bids");
+    // schema for people is key: <person_id> value: <person_id, name, state>
+    final KTable<String, String> people = builder.table("people", driver.materialized("people"));
+
+    bids
+        // person_id is 3rd column
+        .selectKey((k, v) -> v.split(",")[2])
+        // schema is now <bid_id, amount, person_id, name, state>
+        .join(people, (bid, person) -> bid + "," + person)
+        // state is the 6th column
+        .filter((k, v) -> v.split(",")[5].equals("CA"))
+        .to("output");
+
+    return builder.build();
+  }
+
+}

--- a/responsive-test-utils/src/test/resources/log4j.properties
+++ b/responsive-test-utils/src/test/resources/log4j.properties
@@ -1,0 +1,21 @@
+#
+# Copyright 2023 Responsive Computing, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+log4j.rootLogger=INFO, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=[%d] %p %m (%c:%L)%n

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -24,6 +24,8 @@ include("kafka-client")
 include("controller-api")
 include("operator")
 
+include("responsive-test-utils")
+
 dependencyResolutionManagement {
 
     versionCatalogs {


### PR DESCRIPTION
This makes it possible to use `TestStoreDriver` with `TopologyTestDriver` and abstracts away an interface for the `ResponsiveDriver`.