### PR TITLE
add consumer/producer listeners that publish metrics

### DIFF
--- a/kafka-instrumentation/src/main/java/dev/responsive/kafka/clients/EndOffsetsPoller.java
+++ b/kafka-instrumentation/src/main/java/dev/responsive/kafka/clients/EndOffsetsPoller.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.kafka.clients;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.metrics.Gauge;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.serialization.BytesDeserializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class polls the current end offset of the topic partitions assigned locally and
+ * publishes the values as a metric. It gets the set of assigned partitions by listening
+ * on ResponsiveConsumer.
+ *
+ */
+public class EndOffsetsPoller {
+  private static final Logger LOGGER = LoggerFactory.getLogger(EndOffsetsPoller.class);
+
+  private final Map<String, ThreadMetrics> threadIdToMetrics = new HashMap<>();
+  private final Metrics metrics;
+  private final Map<String, Object> configs;
+  private final Factories factories;
+  private ScheduledExecutorService executor;
+  private ScheduledFuture<?> pollFuture;
+  private Consumer<?, ?> consumer;
+
+  public EndOffsetsPoller(
+      final Map<String, ?> configs,
+      final Metrics metrics
+  ) {
+    this(configs, metrics, new Factories() {});
+  }
+
+  EndOffsetsPoller(
+      final Map<String, ?> configs,
+      final Metrics metrics,
+      final Factories factories
+  ) {
+    // TODO: make sure to use a read-committed consumer
+    this.configs = consumerConfigs(Objects.requireNonNull(configs));
+    this.metrics = Objects.requireNonNull(metrics);
+    this.factories = Objects.requireNonNull(factories);
+  }
+
+  private Map<String, Object> consumerConfigs(final Map<String, ?> providedConfigs) {
+    final HashMap<String, Object> configs = new HashMap<>(providedConfigs);
+    configs.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, BytesDeserializer.class);
+    configs.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, BytesDeserializer.class);
+    return Map.copyOf(configs);
+  }
+
+  public ResponsiveConsumer.Listener addForThread(final String threadId) {
+    LOGGER.info("add end offset metrics for thread {}", threadId);
+    final var tm = new ThreadMetrics(threadId);
+    synchronized (this) {
+      assert !threadIdToMetrics.containsKey(threadId);
+      if (threadIdToMetrics.isEmpty()) {
+        initPoller();
+        threadIdToMetrics.put(threadId, tm);
+      }
+    }
+    return tm;
+  }
+
+  public void removeForThread(final String threadId) {
+    final ThreadMetrics tm;
+    synchronized (this) {
+      tm = threadIdToMetrics.remove(threadId);
+      if (tm != null) {
+        tm.cleanup();
+        if (threadIdToMetrics.isEmpty()) {
+          stopPoller();
+        }
+      }
+    }
+  }
+
+  private void pollEndOffsets() {
+    final Set<TopicPartition> partitions = new HashSet<>();
+    final Collection<ThreadMetrics> threadMetrics;
+    synchronized (this) {
+      threadMetrics = List.copyOf(this.threadIdToMetrics.values());
+    }
+    for (final var tm : threadMetrics) {
+      partitions.addAll(tm.endOffsets.keySet());
+    }
+    final var endOffsets = consumer.endOffsets(partitions);
+    threadMetrics.forEach(tm -> tm.update(endOffsets));
+  }
+
+  private void initPoller() {
+    LOGGER.info("init end offsets poller");
+    assert consumer == null;
+    assert executor == null;
+    consumer = factories.createConsumer(configs);
+    executor = factories.createExecutor();
+    pollFuture = executor.scheduleAtFixedRate(this::pollEndOffsets, 0, 30, TimeUnit.SECONDS);
+  }
+
+  private void stopPoller() {
+    LOGGER.info("stopping end offsets poller");
+    try {
+      consumer.close(Duration.ofNanos(0));
+    } catch (final Exception e) {
+      LOGGER.warn("error closing consumer", e);
+    }
+    consumer = null;
+    pollFuture.cancel(true);
+    executor.shutdown();
+    executor = null;
+  }
+
+  private class ThreadMetrics implements ResponsiveConsumer.Listener {
+    private final String threadId;
+    private final Map<TopicPartition, Long> endOffsets = new ConcurrentHashMap<>();
+
+    private ThreadMetrics(final String threadId) {
+      this.threadId = Objects.requireNonNull(threadId);
+    }
+
+    @Override
+    public void onPartitionsLost(final Collection<TopicPartition> lost) {
+      onPartitionsRevoked(lost);
+    }
+
+    @Override
+    public void onPartitionsRevoked(final Collection<TopicPartition> revoked) {
+      for (final var p : revoked) {
+        metrics.removeMetric(metricName(p));
+        endOffsets.remove(p);
+      }
+    }
+
+    @Override
+    public void onPartitionsAssigned(final Collection<TopicPartition> assigned) {
+      for (final var p : assigned) {
+        endOffsets.put(p, -1L);
+        metrics.addMetric(
+            metricName(p),
+            (Gauge<Long>) (config, now) -> endOffsets.getOrDefault(p, -1L)
+        );
+      }
+    }
+
+    private void update(final Map<TopicPartition, Long> endOffsets) {
+      for (final var tp : endOffsets.keySet()) {
+        this.endOffsets.computeIfPresent(tp, (k, v) -> {
+          LOGGER.info("update end offset of {}/{} to {}",
+              tp.topic(),
+              tp.partition(),
+              endOffsets.get(tp)
+          );
+          return endOffsets.get(tp);
+        });
+      }
+    }
+
+    private void cleanup() {
+      LOGGER.info("cleanup offsets for thread {}", threadId);
+      for (final TopicPartition p : endOffsets.keySet()) {
+        metrics.removeMetric(metricName(p));
+      }
+    }
+
+    private MetricName metricName(final TopicPartition topicPartition) {
+      final var tags = new HashMap<String, String>();
+      tags.put("thread", threadId);
+      tags.put("topic", topicPartition.topic());
+      tags.put("partition", Integer.toString(topicPartition.partition()));
+      return new MetricName("end-offset", "responsive.streams", "", tags);
+    }
+  }
+
+  interface Factories {
+    default KafkaConsumer<byte[], byte[]> createConsumer(final Map<String, Object> configs) {
+      return new KafkaConsumer<>(configs);
+    }
+
+    default ScheduledExecutorService createExecutor() {
+      return Executors.newSingleThreadScheduledExecutor(r -> {
+        final var t = new Thread(r);
+        t.setDaemon(true);
+        return t;
+      });
+    }
+  }
+}

--- a/kafka-instrumentation/src/main/java/dev/responsive/kafka/clients/MetricPublishingCommitListener.java
+++ b/kafka-instrumentation/src/main/java/dev/responsive/kafka/clients/MetricPublishingCommitListener.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.kafka.clients;
+
+import dev.responsive.kafka.clients.ResponsiveProducer.RecordingKey;
+import java.io.Closeable;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.metrics.Gauge;
+import org.apache.kafka.common.metrics.Metrics;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class publishes a metric that provides the current committed offset for a given
+ * topic-partition. It implements ResponsiveProducer.Listener and ResponsiveConsumer.Listener
+ * to listen on commit events and partition assignment changes, respectively. On a partition
+ * assignment change, it adds or removes metric instances. Each metric instance returns the
+ * current committed offset provided by the producer callback.
+ *
+ * Synchronization: All shared access goes through the "offsets" map.
+ */
+public class MetricPublishingCommitListener
+    implements ResponsiveProducer.Listener, ResponsiveConsumer.Listener, Closeable {
+  private static final Logger LOGGER
+      = LoggerFactory.getLogger(MetricPublishingCommitListener.class);
+  private final Metrics metrics;
+  private final String threadId;
+  private final Map<TopicPartition, Optional<CommittedOffset>> offsets = new ConcurrentHashMap<>();
+
+  private static class CommittedOffset {
+    private final long offset;
+    private final String consumerGroup;
+
+    private CommittedOffset(final long offset, final String consumerGroup) {
+      this.offset = offset;
+      this.consumerGroup = consumerGroup;
+    }
+
+    public long getOffset() {
+      return offset;
+    }
+
+    public String getConsumerGroup() {
+      return consumerGroup;
+    }
+  }
+
+  public MetricPublishingCommitListener(final Metrics metrics, final String threadId) {
+    this.metrics = Objects.requireNonNull(metrics);
+    this.threadId = Objects.requireNonNull(threadId);
+  }
+
+  private MetricName metricName(final RecordingKey k) {
+    return metricName(k.getPartition(), k.getConsumerGroup());
+  }
+
+  private MetricName metricName(final TopicPartition partition, final String consumerGroup) {
+    final Map<String, String> tags = new HashMap<>();
+    tags.put("consumerGroup", consumerGroup);
+    tags.put("thread", threadId);
+    tags.put("topic", partition.topic());
+    tags.put("partition", Integer.toString(partition.partition()));
+    return new MetricName("committed-offset", "responsive.streams", "", tags);
+  }
+
+  @Override
+  public void onCommit(final Map<RecordingKey, Long> committedOffsets) {
+    for (final var e : committedOffsets.entrySet()) {
+      offsets.computeIfPresent(
+          e.getKey().getPartition(),
+          (k, v) -> {
+            if (v.isEmpty()) {
+              LOGGER.info("add committed offset metric for {} {}", threadId, k);
+              metrics.addMetric(
+                  metricName(e.getKey()),
+                  (Gauge<Long>) (config, now) ->
+                      offsets.getOrDefault(k, Optional.empty())
+                          .map(CommittedOffset::getOffset).orElse(-1L)
+              );
+            }
+            LOGGER.info("record committed offset {} {}: {}", threadId, k, e.getValue());
+            return Optional.of(new CommittedOffset(e.getValue(), e.getKey().getConsumerGroup()));
+          }
+      );
+    }
+  }
+
+  @Override
+  public void onClose() {
+  }
+
+  @Override
+  public void onPartitionsRevoked(final Collection<TopicPartition> partitions) {
+    for (final var p : partitions) {
+      LOGGER.info("Remove committed offset metric for {} {}", threadId, p);
+      offsets.computeIfPresent(p, (k, v) -> {
+        v.ifPresent(offset -> metrics.removeMetric(metricName(k, offset.getConsumerGroup())));
+        return null;
+      });
+    }
+  }
+
+  @Override
+  public void onPartitionsAssigned(final Collection<TopicPartition> partitions) {
+    for (final var p : partitions) {
+      LOGGER.info("Add committed offset entry for {} {}", threadId, p);
+      offsets.putIfAbsent(p, Optional.empty());
+    }
+  }
+
+  @Override
+  public void onPartitionsLost(final Collection<TopicPartition> partitions) {
+    onPartitionsRevoked(partitions);
+  }
+
+  @Override
+  public void close() {
+    // at this point we assume no threads will call the other callbacks
+    for (final TopicPartition p : offsets.keySet()) {
+      if (offsets.get(p).isPresent()) {
+        LOGGER.info("Clean up committed offset metric {} {}", threadId, p);
+        metrics.removeMetric(metricName(p, offsets.get(p).get().getConsumerGroup()));
+      }
+    }
+    offsets.clear();
+  }
+}

--- a/kafka-instrumentation/src/test/java/dev/responsive/kafka/clients/EndOffsetsPollerTest.java
+++ b/kafka-instrumentation/src/test/java/dev/responsive/kafka/clients/EndOffsetsPollerTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.kafka.clients;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import dev.responsive.kafka.clients.EndOffsetsPoller.Factories;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.metrics.Gauge;
+import org.apache.kafka.common.metrics.Measurable;
+import org.apache.kafka.common.metrics.MetricValueProvider;
+import org.apache.kafka.common.metrics.Metrics;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class EndOffsetsPollerTest {
+  private static final Map<String, Object> CONFIGS = Map.of();
+  private static final String THREAD_ID = "StreamThread-0";
+  private static final TopicPartition PARTITION1 = new TopicPartition("alice", 1);
+  private static final TopicPartition PARTITION2 = new TopicPartition("bob", 2);
+
+  @Mock
+  private KafkaConsumer<byte[], byte[]> consumer;
+  @Mock
+  private Factories factories;
+  @Mock
+  private Metrics metrics;
+  @Mock
+  private ScheduledExecutorService executor;
+  @Captor
+  private ArgumentCaptor<MetricName> metricNameCaptor;
+  @Captor
+  private ArgumentCaptor<MetricValueProvider<Long>> valueProviderCaptor;
+  @Captor
+  private ArgumentCaptor<Runnable> taskCaptor;
+  private EndOffsetsPoller endOffsetsPoller;
+
+  @BeforeEach
+  public void setup() {
+    lenient().when(factories.createConsumer(anyMap())).thenReturn(consumer);
+    lenient().when(factories.createExecutor()).thenReturn(executor);
+    endOffsetsPoller = new EndOffsetsPoller(CONFIGS, metrics, factories);
+  }
+
+  @Test
+  public void shouldAddEndOffsetMetricForThreadWhenPartitionsAssigned() {
+    // when:
+    final var callback = endOffsetsPoller.addForThread(THREAD_ID);
+    callback.onPartitionsAssigned(List.of(PARTITION1, PARTITION2));
+
+    // then:
+    verify(metrics, times(2))
+        .addMetric(metricNameCaptor.capture(), any(MetricValueProvider.class));
+    assertThat(metricNameCaptor.getAllValues(), contains(
+        new MetricName("end-offset", "responsive.streams", "",
+            Map.of(
+                "thread", "StreamThread-0",
+                "topic", "alice",
+                "partition", "1"
+            )
+        ),
+        new MetricName("end-offset", "responsive.streams", "",
+            Map.of(
+                "thread", "StreamThread-0",
+                "topic", "bob",
+                "partition", "2"
+            )
+    )));
+  }
+
+  @Test
+  public void shouldRemoveEndOffsetMetricForThread() {
+    // given:
+    final var callback = endOffsetsPoller.addForThread(THREAD_ID);
+    callback.onPartitionsAssigned(List.of(PARTITION1, PARTITION2));
+
+    // when:
+    callback.onPartitionsRevoked(List.of(PARTITION1));
+
+    // then:
+    verify(metrics).removeMetric(metricNameCaptor.capture());
+  }
+
+  @Test
+  public void shouldPollEndOffsets() {
+    // given:
+    when(consumer.endOffsets(any())).thenReturn(Map.of(
+        PARTITION1, 123L,
+        PARTITION2, 456L
+    ));
+    final var callback = endOffsetsPoller.addForThread(THREAD_ID);
+    callback.onPartitionsAssigned(List.of(PARTITION1, PARTITION2));
+    verify(metrics, times(2)).addMetric(any(), valueProviderCaptor.capture());
+    verify(executor).scheduleAtFixedRate(taskCaptor.capture(), eq(0L), anyLong(), any());
+    final var task = taskCaptor.getValue();
+
+    // when:
+    task.run();
+
+    // then:
+    final List<MetricValueProvider<Long>> providers = valueProviderCaptor.getAllValues();
+    assertThat(providers.get(0), instanceOf(Gauge.class));
+    assertThat(((Gauge<Long>) providers.get(0)).value(null, 0L), equalTo(123L));
+    assertThat(providers.get(1), instanceOf(Gauge.class));
+    assertThat(((Gauge<Long>) providers.get(1)).value(null, 0L), equalTo(456L));
+  }
+}

--- a/kafka-instrumentation/src/test/java/dev/responsive/kafka/clients/MetricPublishingCommitListenerTest.java
+++ b/kafka-instrumentation/src/test/java/dev/responsive/kafka/clients/MetricPublishingCommitListenerTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.kafka.clients;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import dev.responsive.kafka.clients.ResponsiveProducer.RecordingKey;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.metrics.Gauge;
+import org.apache.kafka.common.metrics.Metrics;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MetricPublishingCommitListenerTest {
+  private static final String THREAD_ID = "StreamThread-0";
+  private static final String GROUP = "foo";
+  private static final TopicPartition PARTITION1 = new TopicPartition("blimp", 1);
+  private static final TopicPartition PARTITION2 = new TopicPartition("airplane", 2);
+
+  @Mock
+  private Metrics metrics;
+  @Captor
+  private ArgumentCaptor<MetricName> nameCaptor;
+  @Captor
+  private ArgumentCaptor<Gauge<Long>> metricCaptor;
+
+  private MetricPublishingCommitListener listener;
+
+  @BeforeEach
+  public void setup() {
+    listener = new MetricPublishingCommitListener(metrics, THREAD_ID);
+  }
+
+  @Test
+  public void shouldReportCommittedOffsets() {
+    // given:
+    listener.onPartitionsAssigned(List.of(PARTITION1, PARTITION2));
+
+    // when:
+    listener.onCommit(Map.of(
+        new RecordingKey(PARTITION1, GROUP), 123L,
+        new RecordingKey(PARTITION2, GROUP), 345L
+    ));
+
+    // then:
+    verify(metrics, times(2)).addMetric(
+        nameCaptor.capture(), metricCaptor.capture()
+    );
+    final var values = metricCaptor.getAllValues();
+    final var names = nameCaptor.getAllValues();
+    final var nameToValue = IntStream.range(0, names.size()).boxed()
+        .collect(Collectors.toMap(names::get, values::get));
+    assertThat(nameToValue.get(getName(PARTITION1)).value(null, 0), is(123L));
+    assertThat(nameToValue.get(getName(PARTITION2)).value(null, 0), is(345L));
+  }
+
+  @Test
+  public void shouldCleanupCommittedOffsetOnRevoke() {
+    // given:
+    listener.onPartitionsAssigned(List.of(PARTITION1, PARTITION2));
+    listener.onCommit(Map.of(
+        new RecordingKey(PARTITION1, GROUP), 123L,
+        new RecordingKey(PARTITION2, GROUP), 345L
+    ));
+
+    // when:
+    listener.onPartitionsRevoked(List.of(PARTITION1));
+
+    // then:
+    verify(metrics).removeMetric(nameCaptor.capture());
+    assertThat(nameCaptor.getValue(), is(getName(PARTITION1)));
+  }
+
+  @Test
+  public void shouldAddCommittedOffsetMetricOnAssign() {
+    // given:
+    listener.onPartitionsAssigned(List.of(PARTITION1, PARTITION2));
+
+    // when:
+    listener.onCommit(Map.of(
+        new RecordingKey(PARTITION1, GROUP), 123L,
+        new RecordingKey(PARTITION2, GROUP), 345L
+    ));
+
+    // then:
+    verify(metrics, times(2))
+        .addMetric(nameCaptor.capture(), any(Gauge.class));
+    assertThat(
+        nameCaptor.getAllValues(),
+        containsInAnyOrder(getName(PARTITION1), getName(PARTITION2))
+    );
+  }
+
+  @Test
+  public void shouldCleanupMetricsOnClose() {
+    // given:
+    listener.onPartitionsAssigned(List.of(PARTITION1, PARTITION2));
+    listener.onCommit(Map.of(
+        new RecordingKey(PARTITION1, GROUP), 123L,
+        new RecordingKey(PARTITION2, GROUP), 345L
+    ));
+
+    // when:
+    listener.close();
+
+    // then:
+    verify(metrics, times(2)).removeMetric(nameCaptor.capture());
+    assertThat(
+        nameCaptor.getAllValues(),
+        containsInAnyOrder(getName(PARTITION1), getName(PARTITION2))
+    );
+  }
+
+  private MetricName getName(final TopicPartition tp) {
+    return new MetricName(
+        "committed-offset", "responsive.streams", "",
+        Map.of(
+            "thread", THREAD_ID,
+            "topic", tp.topic(),
+            "partition", Integer.toString(tp.partition()),
+            "consumerGroup", GROUP
+        )
+    );
+  }
+}


### PR DESCRIPTION
EndOffsetsPoller: listens for partitions assigned/revoked, polls the end offsets
    for the assigned partitions, and publishes the offset as a metric.
MetricsPublishingCommitListener: listens for partitions assigned/revoked and for
    committed offsets, and publishes the current commmitted offset for all assigned
    partitions.

Depends on: https://github.com/responsivedev/responsive-pub/pull/32