### PR TITLE
Add responsive client supplier

### DIFF
--- a/kafka-instrumentation/src/main/java/dev/responsive/kafka/clients/EndOffsetsPoller.java
+++ b/kafka-instrumentation/src/main/java/dev/responsive/kafka/clients/EndOffsetsPoller.java
@@ -1,0 +1,255 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.kafka.clients;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo;
+import org.apache.kafka.clients.admin.OffsetSpec;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.metrics.Gauge;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.serialization.BytesDeserializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class polls the current end offset of the topic partitions assigned locally and
+ * publishes the values as a metric. It gets the set of assigned partitions by listening
+ * on ResponsiveConsumer. This class should not be assumed to be thread-safe by callers.
+ * Internally, it runs asynchronous poller tasks and synchronizes access to its own shared
+ * state.
+ */
+public class EndOffsetsPoller {
+  private static final Logger LOGGER = LoggerFactory.getLogger(EndOffsetsPoller.class);
+
+  private final Map<String, Listener> threadIdToMetrics = new HashMap<>();
+  private final Metrics metrics;
+  private final Map<String, Object> configs;
+  private final Factories factories;
+  private final ScheduledExecutorService executor;
+  private Poller poller = null;
+
+  public EndOffsetsPoller(
+      final Map<String, ?> configs,
+      final Metrics metrics
+  ) {
+    this(
+        configs,
+        metrics,
+        Executors.newSingleThreadScheduledExecutor(r -> {
+          final var t = new Thread(r);
+          t.setDaemon(true);
+          return t;
+        }),
+        new Factories() {}
+    );
+  }
+
+  EndOffsetsPoller(
+      final Map<String, ?> configs,
+      final Metrics metrics,
+      final ScheduledExecutorService executor,
+      final Factories factories
+  ) {
+    // TODO: make sure to use a read-committed consumer
+    this.configs = consumerConfigs(Objects.requireNonNull(configs));
+    this.metrics = Objects.requireNonNull(metrics);
+    this.executor = Objects.requireNonNull(executor);
+    this.factories = Objects.requireNonNull(factories);
+  }
+
+  private Map<String, Object> consumerConfigs(final Map<String, ?> providedConfigs) {
+    final HashMap<String, Object> configs = new HashMap<>(providedConfigs);
+    configs.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, BytesDeserializer.class);
+    configs.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, BytesDeserializer.class);
+    return Map.copyOf(configs);
+  }
+
+  public synchronized Listener addForThread(final String threadId) {
+    LOGGER.info("add end offset metrics for thread {}", threadId);
+    final var tm = new Listener(threadId, metrics, this::removeForThread);
+    if (threadIdToMetrics.containsKey(threadId)) {
+      final var err = String.format("end offset poller already has metrics for %s", threadId);
+      LOGGER.error(err);
+      throw new RuntimeException(err);
+    }
+    if (threadIdToMetrics.isEmpty()) {
+      initPoller();
+    }
+    threadIdToMetrics.put(threadId, tm);
+    return tm;
+  }
+
+  private synchronized void removeForThread(final String threadId) {
+    final Listener tm = threadIdToMetrics.remove(threadId);
+    if (tm != null) {
+      if (threadIdToMetrics.isEmpty()) {
+        stopPoller();
+      }
+    } else {
+      LOGGER.warn("no metrics found for thread {}", threadId);
+    }
+  }
+
+  private synchronized Collection<Listener> getThreadMetrics() {
+    return List.copyOf(threadIdToMetrics.values());
+  }
+
+  private void initPoller() {
+    LOGGER.info("init end offsets poller");
+    assert poller == null;
+    poller = new Poller(factories.createAdminClient(configs), executor, this::getThreadMetrics);
+  }
+
+  private void stopPoller() {
+    LOGGER.info("stopping end offsets poller");
+    poller.stop();
+    poller = null;
+  }
+
+  private static class Poller {
+    private final Admin adminClient;
+    private final ScheduledFuture<?> future;
+    private final ScheduledExecutorService executor;
+    private final Supplier<Collection<Listener>> threadMetricsSupplier;
+
+    private Poller(
+        final Admin adminClient,
+        final ScheduledExecutorService executor,
+        final Supplier<Collection<Listener>> threadMetricsSupplier
+    ) {
+      this.adminClient = adminClient;
+      this.executor = executor;
+      this.threadMetricsSupplier = threadMetricsSupplier;
+      this.future = executor.scheduleAtFixedRate(this::pollEndOffsets, 0, 30, TimeUnit.SECONDS);
+    }
+
+    private void stop() {
+      future.cancel(true);
+      executor.schedule(() -> adminClient.close(Duration.ofNanos(0)), 0, TimeUnit.SECONDS);
+    }
+
+    private void pollEndOffsets() {
+      final var partitions = new HashMap<TopicPartition, OffsetSpec>();
+      final Collection<Listener> threadMetrics = threadMetricsSupplier.get();
+      for (final var tm : threadMetrics) {
+        for (final var tp : tm.endOffsets.keySet()) {
+          partitions.put(tp, OffsetSpec.latest());
+        }
+      }
+      final var result = adminClient.listOffsets(partitions);
+      final Map<TopicPartition, ListOffsetsResultInfo> endOffsets;
+      try {
+        endOffsets = result.all().get();
+      } catch (final InterruptedException | ExecutionException e) {
+        throw new RuntimeException(e);
+      }
+      threadMetrics.forEach(tm -> tm.update(endOffsets));
+    }
+  }
+
+  static class Listener implements ResponsiveConsumer.Listener {
+    private final String threadId;
+    private final Map<TopicPartition, Long> endOffsets = new ConcurrentHashMap<>();
+    private final Logger logger;
+    private final Metrics metrics;
+    private final Consumer<String> onClose;
+
+
+    private Listener(final String threadId, final Metrics metrics, final Consumer<String> onClose) {
+      this.threadId = threadId;
+      this.metrics = metrics;
+      this.onClose = onClose;
+      logger = LoggerFactory.getLogger(EndOffsetsPoller.class.getName() + "." + threadId);
+    }
+
+    @Override
+    public void onPartitionsLost(final Collection<TopicPartition> lost) {
+      onPartitionsRevoked(lost);
+    }
+
+    @Override
+    public void onPartitionsRevoked(final Collection<TopicPartition> revoked) {
+      for (final var p : revoked) {
+        metrics.removeMetric(metricName(p));
+        endOffsets.remove(p);
+      }
+    }
+
+    @Override
+    public void onPartitionsAssigned(final Collection<TopicPartition> assigned) {
+      for (final var p : assigned) {
+        endOffsets.put(p, -1L);
+        metrics.addMetric(
+            metricName(p),
+            (Gauge<Long>) (config, now) -> endOffsets.getOrDefault(p, -1L)
+        );
+      }
+    }
+
+    private void update(final Map<TopicPartition, ListOffsetsResultInfo> endOffsets) {
+      for (final var tp : endOffsets.keySet()) {
+        this.endOffsets.computeIfPresent(tp, (k, v) -> {
+          logger.info("update end offset of {}/{} to {}",
+              tp.topic(),
+              tp.partition(),
+              endOffsets.get(tp)
+          );
+          return endOffsets.get(tp).offset();
+        });
+      }
+    }
+
+    public void close() {
+      logger.info("cleanup offsets for thread {}", threadId);
+      for (final TopicPartition p : endOffsets.keySet()) {
+        metrics.removeMetric(metricName(p));
+      }
+      onClose.accept(threadId);
+    }
+
+    private MetricName metricName(final TopicPartition topicPartition) {
+      final var tags = new HashMap<String, String>();
+      tags.put("thread", threadId);
+      tags.put("topic", topicPartition.topic());
+      tags.put("partition", Integer.toString(topicPartition.partition()));
+      return new MetricName("end-offset", "responsive.streams", "", tags);
+    }
+  }
+
+  interface Factories {
+    default Admin createAdminClient(final Map<String, Object> configs) {
+      return Admin.create(configs);
+    }
+  }
+}

--- a/kafka-instrumentation/src/main/java/dev/responsive/kafka/clients/MetricPublishingCommitListener.java
+++ b/kafka-instrumentation/src/main/java/dev/responsive/kafka/clients/MetricPublishingCommitListener.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.kafka.clients;
+
+import dev.responsive.kafka.clients.ResponsiveProducer.RecordingKey;
+import java.io.Closeable;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.metrics.Gauge;
+import org.apache.kafka.common.metrics.Metrics;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class publishes a metric that provides the current committed offset for a given
+ * topic-partition. It implements ResponsiveProducer.Listener and ResponsiveConsumer.Listener
+ * to listen on commit events and partition assignment changes, respectively. On a partition
+ * assignment change, it adds or removes metric instances. Each metric instance returns the
+ * current committed offset provided by the producer callback.
+ *
+ * Synchronization: All shared access goes through the "offsets" map.
+ */
+public class MetricPublishingCommitListener
+    implements ResponsiveProducer.Listener, ResponsiveConsumer.Listener, Closeable {
+  private static final Logger LOGGER
+      = LoggerFactory.getLogger(MetricPublishingCommitListener.class);
+  private final Metrics metrics;
+  private final String threadId;
+  private final Map<TopicPartition, Optional<CommittedOffset>> offsets = new ConcurrentHashMap<>();
+
+  private static class CommittedOffset {
+    private final long offset;
+    private final String consumerGroup;
+
+    private CommittedOffset(final long offset, final String consumerGroup) {
+      this.offset = offset;
+      this.consumerGroup = consumerGroup;
+    }
+
+    public long getOffset() {
+      return offset;
+    }
+
+    public String getConsumerGroup() {
+      return consumerGroup;
+    }
+  }
+
+  public MetricPublishingCommitListener(final Metrics metrics, final String threadId) {
+    this.metrics = Objects.requireNonNull(metrics);
+    this.threadId = Objects.requireNonNull(threadId);
+  }
+
+  private MetricName metricName(final RecordingKey k) {
+    return metricName(k.getPartition(), k.getConsumerGroup());
+  }
+
+  private MetricName metricName(final TopicPartition partition, final String consumerGroup) {
+    final Map<String, String> tags = new HashMap<>();
+    tags.put("consumerGroup", consumerGroup);
+    tags.put("thread", threadId);
+    tags.put("topic", partition.topic());
+    tags.put("partition", Integer.toString(partition.partition()));
+    return new MetricName("committed-offset", "responsive.streams", "", tags);
+  }
+
+  @Override
+  public void onCommit(final Map<RecordingKey, Long> committedOffsets) {
+    for (final var e : committedOffsets.entrySet()) {
+      offsets.computeIfPresent(
+          e.getKey().getPartition(),
+          (k, v) -> {
+            if (v.isEmpty()) {
+              LOGGER.info("add committed offset metric for {} {}", threadId, k);
+              metrics.addMetric(
+                  metricName(e.getKey()),
+                  (Gauge<Long>) (config, now) ->
+                      offsets.getOrDefault(k, Optional.empty())
+                          .map(CommittedOffset::getOffset).orElse(-1L)
+              );
+            }
+            LOGGER.info("record committed offset {} {}: {}", threadId, k, e.getValue());
+            return Optional.of(new CommittedOffset(e.getValue(), e.getKey().getConsumerGroup()));
+          }
+      );
+    }
+  }
+
+  @Override
+  public void onClose() {
+  }
+
+  @Override
+  public void onPartitionsRevoked(final Collection<TopicPartition> partitions) {
+    for (final var p : partitions) {
+      LOGGER.info("Remove committed offset metric for {} {}", threadId, p);
+      offsets.computeIfPresent(p, (k, v) -> {
+        v.ifPresent(offset -> metrics.removeMetric(metricName(k, offset.getConsumerGroup())));
+        return null;
+      });
+    }
+  }
+
+  @Override
+  public void onPartitionsAssigned(final Collection<TopicPartition> partitions) {
+    for (final var p : partitions) {
+      LOGGER.info("Add committed offset entry for {} {}", threadId, p);
+      offsets.putIfAbsent(p, Optional.empty());
+    }
+  }
+
+  @Override
+  public void onPartitionsLost(final Collection<TopicPartition> partitions) {
+    onPartitionsRevoked(partitions);
+  }
+
+  @Override
+  public void close() {
+    // at this point we assume no threads will call the other callbacks
+    for (final TopicPartition p : offsets.keySet()) {
+      if (offsets.get(p).isPresent()) {
+        LOGGER.info("Clean up committed offset metric {} {}", threadId, p);
+        metrics.removeMetric(metricName(p, offsets.get(p).get().getConsumerGroup()));
+      }
+    }
+    offsets.clear();
+  }
+}

--- a/kafka-instrumentation/src/main/java/dev/responsive/kafka/clients/ResponsiveKafkaClientSupplier.java
+++ b/kafka-instrumentation/src/main/java/dev/responsive/kafka/clients/ResponsiveKafkaClientSupplier.java
@@ -1,0 +1,328 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.kafka.clients;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.common.Configurable;
+import org.apache.kafka.common.metrics.JmxReporter;
+import org.apache.kafka.common.metrics.KafkaMetricsContext;
+import org.apache.kafka.common.metrics.MetricConfig;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.metrics.MetricsContext;
+import org.apache.kafka.common.metrics.MetricsReporter;
+import org.apache.kafka.common.utils.Time;
+import org.apache.kafka.streams.KafkaClientSupplier;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An implementation of KafkaClientSupplier for Responsive applications. The supplier returns
+ * wrapped kafka producers/consumers that are instrumented to work with the responsive platform
+ * by, for example, emitting metrics useful for debug and scaling.
+ *
+ * Synchronization: This class is read/written during client initialization and close (via the
+ * close callbacks on the returned clients). As these calls are not on the performance path we
+ * rely on coarse-grained locks around sections reading/writing shared state.
+ */
+public final class ResponsiveKafkaClientSupplier implements KafkaClientSupplier, Configurable {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ResponsiveKafkaClientSupplier.class);
+  private final SharedListeners sharedListeners = new SharedListeners();
+  private final KafkaClientSupplier wrapped;
+  private final Factories factories;
+  private boolean eosV2 = false;
+  private boolean configured = false;
+  private Metrics metrics;
+  private EndOffsetsPoller endOffsetsPoller;
+
+  public ResponsiveKafkaClientSupplier() {
+    this(new Factories() {}, new DefaultKafkaClientSupplier());
+  }
+
+  ResponsiveKafkaClientSupplier(final Factories factories, final KafkaClientSupplier wrapped) {
+    this.factories = factories;
+    this.wrapped = wrapped;
+  }
+
+  @Override
+  public void configure(final Map<String, ?> configs) {
+    LOGGER.trace(
+        "Configuring the client supplier. Got configs: {}",
+        configs.entrySet().stream()
+            .map(e -> e.getKey() + ":" + e.getValue())
+            .collect(Collectors.joining("\n"))
+    );
+    eosV2 = (configs.get(StreamsConfig.PROCESSING_GUARANTEE_CONFIG))
+        .equals(StreamsConfig.EXACTLY_ONCE_V2);
+    final JmxReporter jmxReporter = new JmxReporter();
+    jmxReporter.configure(configs);
+    final MetricsContext metricsContext
+        = new KafkaMetricsContext("dev.responsive", new HashMap<>());
+    metrics = factories.createMetrics(
+        new MetricConfig(),
+        Collections.singletonList(jmxReporter),
+        Time.SYSTEM,
+        metricsContext
+    );
+    endOffsetsPoller = factories.createEndOffsetPoller(configs, metrics);
+    configured = true;
+  }
+
+  @Override
+  public Admin getAdmin(final Map<String, Object> config) {
+    return wrapped.getAdmin(config);
+  }
+
+  @Override
+  public Producer<byte[], byte[]> getProducer(final Map<String, Object> config) {
+    if (!configured) {
+      throw new IllegalStateException("must be configured before supplying clients");
+    }
+    if (!eosV2) {
+      return wrapped.getProducer(config);
+    }
+    LOGGER.info("Creating responsive producer");
+    final String tid = threadIdFromProducerConfig(config);
+    final ListenersForThread tc = sharedListeners.getAndMaybeInitListenersForThread(
+        tid,
+        metrics,
+        endOffsetsPoller,
+        factories
+    );
+    return factories.createResponsiveProducer(
+        (String) config.get(CommonClientConfigs.CLIENT_ID_CONFIG),
+        wrapped.getProducer(config),
+        Collections.unmodifiableList(
+            Arrays.asList(
+                tc.commitListener,
+                new CloseListener(tid)
+            )
+        )
+    );
+  }
+
+  @Override
+  public Consumer<byte[], byte[]> getConsumer(final Map<String, Object> config) {
+    if (!configured) {
+      throw new IllegalStateException("must be configured before supplying clients");
+    }
+    if (!eosV2) {
+      return wrapped.getConsumer(config);
+    }
+    LOGGER.info("Creating responsive consumer");
+    final String tid = threadIdFromConsumerConfig(config);
+    final ListenersForThread tc = sharedListeners.getAndMaybeInitListenersForThread(
+        tid,
+        metrics,
+        endOffsetsPoller,
+        factories
+    );
+    // TODO: the end offsets poller call is kind of heavy for a synchronized block
+    return factories.createResponsiveConsumer(
+        (String) config.get(CommonClientConfigs.CLIENT_ID_CONFIG),
+        wrapped.getConsumer(config),
+        List.of(
+            tc.commitListener,
+            tc.endOffsetsPollerListener,
+            new CloseListener(tid)
+        )
+    );
+  }
+
+  @Override
+  public Consumer<byte[], byte[]> getRestoreConsumer(final Map<String, Object> config) {
+    return wrapped.getRestoreConsumer(config);
+  }
+
+  @Override
+  public Consumer<byte[], byte[]> getGlobalConsumer(final Map<String, Object> config) {
+    return wrapped.getGlobalConsumer(config);
+  }
+
+  private String threadIdFromProducerConfig(final Map<String, Object> config) {
+    final String clientId = (String) config.get(CommonClientConfigs.CLIENT_ID_CONFIG);
+    LOGGER.info("Found producer client ID {}", clientId);
+    final var regex = Pattern.compile(".*-(StreamThread-\\d+)-producer");
+    final var match = regex.matcher(clientId);
+    if (!match.find()) {
+      throw new RuntimeException("unexpected client id " + clientId);
+    }
+    return match.group(1);
+  }
+
+  private String threadIdFromConsumerConfig(final Map<String, Object> config) {
+    final String clientId = (String) config.get(CommonClientConfigs.CLIENT_ID_CONFIG);
+    LOGGER.info("Found consumer client ID {}", clientId);
+    final var regex = Pattern.compile(".*-(StreamThread-\\d+)-consumer$");
+    final var match = regex.matcher(clientId);
+    if (!match.find()) {
+      throw new RuntimeException("unexpected client id " + clientId);
+    }
+    return match.group(1);
+  }
+
+  class CloseListener implements ResponsiveConsumer.Listener, ResponsiveProducer.Listener {
+    private final String threadId;
+
+    private CloseListener(final String threadId) {
+      this.threadId = threadId;
+    }
+
+    @Override
+    public void onClose() {
+      sharedListeners.derefListenersForThread(threadId);
+    }
+  }
+
+  private static class SharedListeners {
+    private final Map<String, ReferenceCounted<ListenersForThread>> threadListeners
+        = new HashMap<>();
+
+    private synchronized ListenersForThread getAndMaybeInitListenersForThread(
+        final String threadId,
+        final Metrics metrics,
+        final EndOffsetsPoller endOffsetsPoller,
+        final Factories factories
+    ) {
+      if (threadListeners.containsKey(threadId)) {
+        final var tl = threadListeners.get(threadId);
+        tl.ref();
+        return tl.getVal();
+      }
+      final var tl = new ReferenceCounted<>(new ListenersForThread(
+          threadId,
+          factories.createMetricsPublishingCommitListener(metrics, threadId),
+          endOffsetsPoller.addForThread(threadId)
+      ));
+      threadListeners.put(threadId, tl);
+      return tl.getVal();
+    }
+
+    private synchronized void derefListenersForThread(final String threadId) {
+      if (threadListeners.get(threadId).deref()) {
+        threadListeners.remove(threadId);
+      }
+    }
+  }
+
+  private static class ListenersForThread implements Closeable {
+    final String threadId;
+    final MetricPublishingCommitListener commitListener;
+    final EndOffsetsPoller.Listener endOffsetsPollerListener;
+
+    public ListenersForThread(
+        final String threadId,
+        final MetricPublishingCommitListener commitListener,
+        final EndOffsetsPoller.Listener endOffsetsPollerListener) {
+      this.threadId = threadId;
+      this.commitListener = commitListener;
+      this.endOffsetsPollerListener = endOffsetsPollerListener;
+    }
+
+    public void close() {
+      commitListener.close();
+      endOffsetsPollerListener.close();
+    }
+  }
+
+  private static class ReferenceCounted<T extends Closeable> {
+    final T val;
+    int count;
+
+    private ReferenceCounted(final T val) {
+      this.val = val;
+      this.count = 1;
+    }
+
+    private void ref() {
+      LOGGER.info("bumping ref count to {}", count + 1);
+      count += 1;
+    }
+
+    private boolean deref() {
+      LOGGER.info("reducing ref count to {}", count - 1);
+      count -= 1;
+      if (count == 0) {
+        LOGGER.info("closing referred value");
+        try {
+          val.close();
+        } catch (final IOException e) {
+          throw new RuntimeException(e);
+        }
+        return true;
+      }
+      return false;
+    }
+
+    private T getVal() {
+      return val;
+    }
+  }
+
+  interface Factories {
+    default EndOffsetsPoller createEndOffsetPoller(
+        final Map<String, ?> config,
+        final Metrics metrics
+    ) {
+      return new EndOffsetsPoller(config, metrics);
+    }
+
+    default Metrics createMetrics(
+        final MetricConfig config,
+        final List<MetricsReporter> reporters,
+        final Time time,
+        final MetricsContext ctx
+    ) {
+      return new Metrics(config, reporters, time, ctx);
+    }
+
+    default <K, V> ResponsiveProducer<K, V> createResponsiveProducer(
+        final String clientId,
+        final Producer<K, V> wrapped,
+        final List<ResponsiveProducer.Listener> listeners
+    ) {
+      return new ResponsiveProducer<>(clientId, wrapped, listeners);
+    }
+
+    default <K, V> ResponsiveConsumer<K, V> createResponsiveConsumer(
+        final String clientId,
+        final Consumer<K, V> wrapped,
+        final List<ResponsiveConsumer.Listener> listeners) {
+      return new ResponsiveConsumer<>(clientId, wrapped, listeners);
+    }
+
+    default <K, V> MetricPublishingCommitListener createMetricsPublishingCommitListener(
+        final Metrics metrics,
+        final String threadId
+    ) {
+      return new MetricPublishingCommitListener(metrics, threadId);
+    }
+  }
+}

--- a/kafka-instrumentation/src/test/java/dev/responsive/kafka/clients/EndOffsetsPollerTest.java
+++ b/kafka-instrumentation/src/test/java/dev/responsive/kafka/clients/EndOffsetsPollerTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.kafka.clients;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import dev.responsive.kafka.clients.EndOffsetsPoller.Factories;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.stream.Collectors;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.ListOffsetsResult;
+import org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.internals.KafkaFutureImpl;
+import org.apache.kafka.common.metrics.Gauge;
+import org.apache.kafka.common.metrics.MetricValueProvider;
+import org.apache.kafka.common.metrics.Metrics;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class EndOffsetsPollerTest {
+  private static final Map<String, Object> CONFIGS = Map.of();
+  private static final String THREAD_ID = "StreamThread-0";
+  private static final TopicPartition PARTITION1 = new TopicPartition("alice", 1);
+  private static final TopicPartition PARTITION2 = new TopicPartition("bob", 2);
+
+  @Mock
+  private AdminClient adminClient;
+  @Mock
+  private Factories factories;
+  @Mock
+  private Metrics metrics;
+  @Mock
+  private ScheduledExecutorService executor;
+  @Mock
+  private ScheduledFuture<Object> pollFuture;
+  @Captor
+  private ArgumentCaptor<MetricName> metricNameCaptor;
+  @Captor
+  private ArgumentCaptor<MetricValueProvider<Long>> valueProviderCaptor;
+  @Captor
+  private ArgumentCaptor<Runnable> taskCaptor;
+  private EndOffsetsPoller endOffsetsPoller;
+
+  @BeforeEach
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  public void setup() {
+    lenient().when(factories.createAdminClient(anyMap())).thenReturn(adminClient);
+    lenient().when(executor.scheduleAtFixedRate(any(), anyLong(), anyLong(), any()))
+        .thenReturn((ScheduledFuture) pollFuture);
+    endOffsetsPoller = new EndOffsetsPoller(CONFIGS, metrics, executor, factories);
+  }
+
+  @Test
+  public void shouldAddEndOffsetMetricForThreadWhenPartitionsAssigned() {
+    // when:
+    final var callback = endOffsetsPoller.addForThread(THREAD_ID);
+    callback.onPartitionsAssigned(List.of(PARTITION1, PARTITION2));
+
+    // then:
+    verify(metrics, times(2))
+        .addMetric(metricNameCaptor.capture(), any(MetricValueProvider.class));
+    assertThat(metricNameCaptor.getAllValues(), contains(
+        metricName(THREAD_ID, PARTITION1),
+        metricName(THREAD_ID, PARTITION2))
+    );
+  }
+
+  @Test
+  public void shouldRemoveEndOffsetMetricWhenPartitionsRevoked() {
+    // given:
+    final var callback = endOffsetsPoller.addForThread(THREAD_ID);
+    callback.onPartitionsAssigned(List.of(PARTITION1, PARTITION2));
+
+    // when:
+    callback.onPartitionsRevoked(List.of(PARTITION1));
+
+    // then:
+    verify(metrics).removeMetric(metricName(THREAD_ID, PARTITION1));
+  }
+
+  @Test
+  public void shouldRemoveEndOffsetMetricForThread() {
+    // given:
+    final var callback = endOffsetsPoller.addForThread(THREAD_ID);
+    callback.onPartitionsAssigned(List.of(PARTITION1));
+
+    // when:
+    callback.close();
+
+    // then:
+    verify(metrics).removeMetric(metricName(THREAD_ID, PARTITION1));
+  }
+
+  @Test
+  public void shouldPollAllEndOffsetsForThread() {
+    // given:
+    final var result = completedOffsetListing(Map.of(
+        PARTITION1, new ListOffsetsResultInfo(123L, 100L, Optional.empty()),
+        PARTITION2, new ListOffsetsResultInfo(456L, 200L, Optional.empty())
+    ));
+    when(adminClient.listOffsets(anyMap())).thenReturn(result);
+    final var callback = endOffsetsPoller.addForThread(THREAD_ID);
+    callback.onPartitionsAssigned(List.of(PARTITION1, PARTITION2));
+    verify(metrics, times(2)).addMetric(any(), valueProviderCaptor.capture());
+    verify(executor).scheduleAtFixedRate(taskCaptor.capture(), eq(0L), anyLong(), any());
+    final var task = taskCaptor.getValue();
+
+    // when:
+    task.run();
+
+    // then:
+    final List<MetricValueProvider<Long>> providers = valueProviderCaptor.getAllValues();
+    assertThat(providers.get(0), instanceOf(Gauge.class));
+    assertThat(((Gauge<Long>) providers.get(0)).value(null, 0L), equalTo(123L));
+    assertThat(providers.get(1), instanceOf(Gauge.class));
+    assertThat(((Gauge<Long>) providers.get(1)).value(null, 0L), equalTo(456L));
+  }
+
+  @Test
+  public void shouldPollEndOffsetsForMultipleThreads() {
+    // given:
+    final var result = completedOffsetListing(Map.of(
+        PARTITION1, new ListOffsetsResultInfo(123L, 100L, Optional.empty()),
+        PARTITION2, new ListOffsetsResultInfo(456L, 200L, Optional.empty())
+    ));
+    when(adminClient.listOffsets(anyMap())).thenReturn(result);
+    final var callback = endOffsetsPoller.addForThread(THREAD_ID);
+    callback.onPartitionsAssigned(List.of(PARTITION1));
+    final var callback2 = endOffsetsPoller.addForThread("StreamThread-1");
+    callback2.onPartitionsAssigned(List.of(PARTITION2));
+    verify(metrics, times(2)).addMetric(any(), valueProviderCaptor.capture());
+    verify(executor).scheduleAtFixedRate(taskCaptor.capture(), eq(0L), anyLong(), any());
+    final var task = taskCaptor.getValue();
+
+    // when:
+    task.run();
+
+    // then:
+    final List<MetricValueProvider<Long>> providers = valueProviderCaptor.getAllValues();
+    assertThat(providers.get(0), instanceOf(Gauge.class));
+    assertThat(((Gauge<Long>) providers.get(0)).value(null, 0L), equalTo(123L));
+    assertThat(providers.get(1), instanceOf(Gauge.class));
+    assertThat(((Gauge<Long>) providers.get(1)).value(null, 0L), equalTo(456L));
+  }
+
+  private MetricName metricName(final String thread, final TopicPartition tp) {
+    return new MetricName("end-offset", "responsive.streams", "",
+        Map.of(
+            "thread", thread,
+            "topic", tp.topic(),
+            "partition", Integer.toString(tp.partition())
+        )
+    );
+  }
+
+  private ListOffsetsResult completedOffsetListing(
+      final Map<TopicPartition, ListOffsetsResultInfo> result
+  ) {
+    final Map<TopicPartition, KafkaFuture<ListOffsetsResultInfo>> futures = result.entrySet()
+        .stream()
+        .collect(Collectors.toMap(
+            Entry::getKey,
+            e -> {
+              final KafkaFutureImpl<ListOffsetsResultInfo> future = new KafkaFutureImpl<>();
+              future.complete(e.getValue());
+              return future;
+            }
+        ));
+    return new ListOffsetsResult(futures);
+  }
+}

--- a/kafka-instrumentation/src/test/java/dev/responsive/kafka/clients/MetricPublishingCommitListenerTest.java
+++ b/kafka-instrumentation/src/test/java/dev/responsive/kafka/clients/MetricPublishingCommitListenerTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.kafka.clients;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import dev.responsive.kafka.clients.ResponsiveProducer.RecordingKey;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.metrics.Gauge;
+import org.apache.kafka.common.metrics.Metrics;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MetricPublishingCommitListenerTest {
+  private static final String THREAD_ID = "StreamThread-0";
+  private static final String GROUP = "foo";
+  private static final TopicPartition PARTITION1 = new TopicPartition("blimp", 1);
+  private static final TopicPartition PARTITION2 = new TopicPartition("airplane", 2);
+
+  @Mock
+  private Metrics metrics;
+  @Captor
+  private ArgumentCaptor<MetricName> nameCaptor;
+  @Captor
+  private ArgumentCaptor<Gauge<Long>> metricCaptor;
+
+  private MetricPublishingCommitListener listener;
+
+  @BeforeEach
+  public void setup() {
+    listener = new MetricPublishingCommitListener(metrics, THREAD_ID);
+  }
+
+  @Test
+  public void shouldReportCommittedOffsets() {
+    // given:
+    listener.onPartitionsAssigned(List.of(PARTITION1, PARTITION2));
+
+    // when:
+    listener.onCommit(Map.of(
+        new RecordingKey(PARTITION1, GROUP), 123L,
+        new RecordingKey(PARTITION2, GROUP), 345L
+    ));
+
+    // then:
+    verify(metrics, times(2)).addMetric(
+        nameCaptor.capture(), metricCaptor.capture()
+    );
+    final var values = metricCaptor.getAllValues();
+    final var names = nameCaptor.getAllValues();
+    final var nameToValue = IntStream.range(0, names.size()).boxed()
+        .collect(Collectors.toMap(names::get, values::get));
+    assertThat(nameToValue.get(getName(PARTITION1)).value(null, 0), is(123L));
+    assertThat(nameToValue.get(getName(PARTITION2)).value(null, 0), is(345L));
+  }
+
+  @Test
+  public void shouldCleanupCommittedOffsetOnRevoke() {
+    // given:
+    listener.onPartitionsAssigned(List.of(PARTITION1, PARTITION2));
+    listener.onCommit(Map.of(
+        new RecordingKey(PARTITION1, GROUP), 123L,
+        new RecordingKey(PARTITION2, GROUP), 345L
+    ));
+
+    // when:
+    listener.onPartitionsRevoked(List.of(PARTITION1));
+
+    // then:
+    verify(metrics).removeMetric(nameCaptor.capture());
+    assertThat(nameCaptor.getValue(), is(getName(PARTITION1)));
+  }
+
+  @Test
+  public void shouldAddCommittedOffsetMetricOnAssign() {
+    // given:
+    listener.onPartitionsAssigned(List.of(PARTITION1, PARTITION2));
+
+    // when:
+    listener.onCommit(Map.of(
+        new RecordingKey(PARTITION1, GROUP), 123L,
+        new RecordingKey(PARTITION2, GROUP), 345L
+    ));
+
+    // then:
+    verify(metrics, times(2))
+        .addMetric(nameCaptor.capture(), any(Gauge.class));
+    assertThat(
+        nameCaptor.getAllValues(),
+        containsInAnyOrder(getName(PARTITION1), getName(PARTITION2))
+    );
+  }
+
+  @Test
+  public void shouldCleanupMetricsOnClose() {
+    // given:
+    listener.onPartitionsAssigned(List.of(PARTITION1, PARTITION2));
+    listener.onCommit(Map.of(
+        new RecordingKey(PARTITION1, GROUP), 123L,
+        new RecordingKey(PARTITION2, GROUP), 345L
+    ));
+
+    // when:
+    listener.close();
+
+    // then:
+    verify(metrics, times(2)).removeMetric(nameCaptor.capture());
+    assertThat(
+        nameCaptor.getAllValues(),
+        containsInAnyOrder(getName(PARTITION1), getName(PARTITION2))
+    );
+  }
+
+  private MetricName getName(final TopicPartition tp) {
+    return new MetricName(
+        "committed-offset", "responsive.streams", "",
+        Map.of(
+            "thread", THREAD_ID,
+            "topic", tp.topic(),
+            "partition", Integer.toString(tp.partition()),
+            "consumerGroup", GROUP
+        )
+    );
+  }
+}

--- a/kafka-instrumentation/src/test/java/dev/responsive/kafka/clients/ResponsiveKafkaClientSupplierTest.java
+++ b/kafka-instrumentation/src/test/java/dev/responsive/kafka/clients/ResponsiveKafkaClientSupplierTest.java
@@ -1,0 +1,236 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.kafka.clients;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import dev.responsive.kafka.clients.ResponsiveKafkaClientSupplier.Factories;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.serialization.BytesDeserializer;
+import org.apache.kafka.common.serialization.BytesSerializer;
+import org.apache.kafka.streams.KafkaClientSupplier;
+import org.apache.kafka.streams.StreamsConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ResponsiveKafkaClientSupplierTest {
+  private static final Map<String, Object> CONFIGS = Map.of(
+      ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, BytesDeserializer.class,
+      ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, BytesDeserializer.class,
+      ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, BytesSerializer.class,
+      ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, BytesSerializer.class,
+      StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_V2
+  );
+  private static final Map<String, Object> PRODUCER_CONFIGS = configsWithOverrides(
+      Map.of(
+          ProducerConfig.CLIENT_ID_CONFIG, "foo-StreamThread-0-producer"
+      )
+  );
+
+  private static final Map<String, Object> CONSUMER_CONFIGS = configsWithOverrides(
+      Map.of(
+          ProducerConfig.CLIENT_ID_CONFIG, "foo-StreamThread-0-consumer"
+      )
+  );
+
+  @Mock
+  private Factories factories;
+  @Mock
+  private Metrics metrics;
+  @Mock
+  private EndOffsetsPoller.Listener consumerEndOffsetsPollListener;
+  @Mock
+  private EndOffsetsPoller endOffsetsPoller;
+  @Mock
+  private KafkaClientSupplier wrapped;
+  @Mock
+  private Producer<byte[], byte[]> wrappedProducer;
+  @Mock
+  private Consumer<byte[], byte[]> wrappedConsumer;
+  @Mock
+  private ResponsiveProducer<byte[], byte[]> responsiveProducer;
+  @Mock
+  private ResponsiveConsumer<byte[], byte[]> responsiveConsumer;
+  @Mock
+  private MetricPublishingCommitListener metricPublishingCommitListener;
+  @Captor
+  private ArgumentCaptor<List<ResponsiveProducer.Listener>> producerListenerCaptor;
+  @Captor
+  private ArgumentCaptor<List<ResponsiveConsumer.Listener>> consumerListenerCaptor;
+  private ResponsiveKafkaClientSupplier supplier;
+
+  @BeforeEach
+  @SuppressWarnings("unchecked")
+  public void setup() {
+    when(factories.createMetrics(any(), any(), any(), any())).thenReturn(metrics);
+    when(factories.createEndOffsetPoller(any(), any())).thenReturn(endOffsetsPoller);
+    lenient().when(endOffsetsPoller.addForThread(any())).thenReturn(consumerEndOffsetsPollListener);
+    lenient().when(wrapped.getConsumer(any())).thenReturn(wrappedConsumer);
+    lenient().when(wrapped.getProducer(any())).thenReturn(wrappedProducer);
+    lenient().when(
+        factories.createResponsiveProducer(any(), (ResponsiveProducer<byte[], byte[]>) any(), any())
+    ).thenReturn(responsiveProducer);
+    lenient().when(
+        factories.createResponsiveConsumer(any(), (ResponsiveConsumer<byte[], byte[]>) any(), any())
+    ).thenReturn(responsiveConsumer);
+    lenient().when(factories.createMetricsPublishingCommitListener(any(), any()))
+        .thenReturn(metricPublishingCommitListener);
+
+    supplier = new ResponsiveKafkaClientSupplier(factories, wrapped);
+    supplier.configure(CONFIGS);
+  }
+
+  @Test
+  public void shouldNotWrapProducerIfNotEosV2() {
+    // given:
+    final var supplier = new ResponsiveKafkaClientSupplier(factories, wrapped);
+    final var config = configsWithOverrides(
+        PRODUCER_CONFIGS,
+        Map.of(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.AT_LEAST_ONCE));
+    supplier.configure(config);
+
+    // when:
+    final var producer = supplier.getProducer(config);
+
+    // then:
+    assertThat(producer, is(wrappedProducer));
+  }
+
+  @Test
+  public void shouldNotWrapConsumerIfNotEosV2() {
+    // given:
+    final var supplier = new ResponsiveKafkaClientSupplier(factories, wrapped);
+    final var config = configsWithOverrides(
+        CONSUMER_CONFIGS,
+        Map.of(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.AT_LEAST_ONCE));
+    supplier.configure(config);
+
+    // when:
+    final var consumer = supplier.getConsumer(config);
+
+    // then:
+    assertThat(consumer, is(wrappedConsumer));
+  }
+
+  @Test
+  public void shoudWrapProducer() {
+    // when:
+    final var producer = supplier.getProducer(PRODUCER_CONFIGS);
+
+    // then:
+    assertThat(producer, is(responsiveProducer));
+  }
+
+  @Test
+  public void shouldAddMetricPublishingCommitListenerToProducer() {
+    // when:
+    supplier.getProducer(PRODUCER_CONFIGS);
+
+    // then:
+    verify(factories).createResponsiveProducer(any(), any(), producerListenerCaptor.capture());
+    assertThat(producerListenerCaptor.getValue(), hasItem(metricPublishingCommitListener));
+    verify(factories).createMetricsPublishingCommitListener(metrics, "StreamThread-0");
+  }
+
+  @Test
+  public void shouldAddMetricPublishingCommitListenerToConsumer() {
+    // when:
+    supplier.getConsumer(CONSUMER_CONFIGS);
+
+    // then:
+    verify(factories).createResponsiveConsumer(any(), any(), consumerListenerCaptor.capture());
+    assertThat(consumerListenerCaptor.getValue(), hasItem(metricPublishingCommitListener));
+    verify(factories).createMetricsPublishingCommitListener(metrics, "StreamThread-0");
+  }
+
+  @Test
+  public void shouldMatchMetricPublishingCommitListenerForThread() {
+    // given:
+    supplier.getProducer(PRODUCER_CONFIGS);
+
+    // when:
+    supplier.getConsumer(CONSUMER_CONFIGS);
+    supplier.getConsumer(configsWithOverrides(
+        CONSUMER_CONFIGS,
+        Map.of(ConsumerConfig.CLIENT_ID_CONFIG, "foo-StreamThread-1-consumer")
+    ));
+
+    // then:
+    verify(factories, times(1))
+        .createMetricsPublishingCommitListener(metrics, "StreamThread-0");
+    verify(factories, times(1))
+        .createMetricsPublishingCommitListener(metrics, "StreamThread-1");
+  }
+
+  @Test
+  public void shouldAddEndOffsetsPollerListeners() {
+    // when:
+    supplier.getConsumer(CONSUMER_CONFIGS);
+
+    // then:
+    verify(factories).createResponsiveConsumer(any(), any(), consumerListenerCaptor.capture());
+    assertThat(consumerListenerCaptor.getValue(), hasItem(consumerEndOffsetsPollListener));
+  }
+
+  @Test
+  public void shouldCloseMetricPublishingCommitListenerWhenNoRefs() {
+    // given:
+    supplier.getConsumer(CONSUMER_CONFIGS);
+    supplier.getProducer(PRODUCER_CONFIGS);
+
+    // then:
+    verify(factories).createResponsiveConsumer(any(), any(), consumerListenerCaptor.capture());
+    consumerListenerCaptor.getValue().forEach(ResponsiveConsumer.Listener::onClose);
+    verify(metricPublishingCommitListener, times(0)).close();
+    verify(factories).createResponsiveProducer(any(), any(), producerListenerCaptor.capture());
+    producerListenerCaptor.getValue().forEach(ResponsiveProducer.Listener::onClose);
+    verify(metricPublishingCommitListener).close();
+  }
+
+  private static Map<String, Object> configsWithOverrides(final Map<String, Object> overrides) {
+    return configsWithOverrides(CONFIGS, overrides);
+  }
+
+  private static Map<String, Object> configsWithOverrides(
+      final Map<String, Object> configs,
+      final Map<String, Object> overrides) {
+    final var intermediate = new HashMap<String, Object>();
+    intermediate.putAll(configs);
+    intermediate.putAll(overrides);
+    return Map.copyOf(intermediate);
+  }
+}


### PR DESCRIPTION
This patch adds a client supplier that supplies responsive consumer/producer to KafkaStreams,
and hooks these up to our metrics publishers.

Depends on: https://github.com/responsivedev/responsive-pub/pull/33