### PR TITLE
add consumer/producer listeners that publish metrics

### DIFF
--- a/kafka-instrumentation/src/main/java/dev/responsive/kafka/clients/EndOffsetsPoller.java
+++ b/kafka-instrumentation/src/main/java/dev/responsive/kafka/clients/EndOffsetsPoller.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.kafka.clients;
+
+import java.time.Duration;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo;
+import org.apache.kafka.clients.admin.OffsetSpec;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.metrics.Gauge;
+import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.serialization.BytesDeserializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class polls the current end offset of the topic partitions assigned locally and
+ * publishes the values as a metric. It gets the set of assigned partitions by listening
+ * on ResponsiveConsumer. This class should not be assumed to be thread-safe by callers.
+ * Internally, it runs asynchronous poller tasks and synchronizes access to its own shared
+ * state.
+ */
+public class EndOffsetsPoller {
+  private static final Logger LOGGER = LoggerFactory.getLogger(EndOffsetsPoller.class);
+
+  private final Map<String, Listener> threadIdToMetrics = new HashMap<>();
+  private final Metrics metrics;
+  private final Map<String, Object> configs;
+  private final Factories factories;
+  private final ScheduledExecutorService executor;
+  private Poller poller = null;
+
+  public EndOffsetsPoller(
+      final Map<String, ?> configs,
+      final Metrics metrics
+  ) {
+    this(
+        configs,
+        metrics,
+        Executors.newSingleThreadScheduledExecutor(r -> {
+          final var t = new Thread(r);
+          t.setDaemon(true);
+          t.setName("responsive-end-offsets-poller");
+          return t;
+        }),
+        new Factories() {}
+    );
+  }
+
+  EndOffsetsPoller(
+      final Map<String, ?> configs,
+      final Metrics metrics,
+      final ScheduledExecutorService executor,
+      final Factories factories
+  ) {
+    // TODO: does admin client get only committed offsets?
+    this.configs = Map.copyOf(Objects.requireNonNull(configs));
+    this.metrics = Objects.requireNonNull(metrics);
+    this.executor = Objects.requireNonNull(executor);
+    this.factories = Objects.requireNonNull(factories);
+  }
+
+  public synchronized Listener addForThread(final String threadId) {
+    LOGGER.info("add end offset metrics for thread {}", threadId);
+    final var tm = new Listener(threadId, metrics, this::removeForThread);
+    if (threadIdToMetrics.containsKey(threadId)) {
+      final var msg = String.format("end offset poller already has metrics for %s", threadId);
+      final var err = new RuntimeException(msg);
+      LOGGER.error(msg, err);
+      throw err;
+    }
+    if (threadIdToMetrics.isEmpty()) {
+      initPoller();
+    }
+    threadIdToMetrics.put(threadId, tm);
+    return tm;
+  }
+
+  private synchronized void removeForThread(final String threadId) {
+    final Listener tm = threadIdToMetrics.remove(threadId);
+    if (tm != null) {
+      if (threadIdToMetrics.isEmpty()) {
+        stopPoller();
+      }
+    } else {
+      LOGGER.warn("no metrics found for thread {}", threadId);
+    }
+  }
+
+  private synchronized Collection<Listener> getThreadMetrics() {
+    return List.copyOf(threadIdToMetrics.values());
+  }
+
+  private void initPoller() {
+    LOGGER.info("init end offsets poller");
+    assert poller == null;
+    poller = new Poller(factories.createAdminClient(configs), executor, this::getThreadMetrics);
+  }
+
+  private void stopPoller() {
+    LOGGER.info("stopping end offsets poller");
+    poller.stop();
+    poller = null;
+  }
+
+  private static class Poller {
+    private final Admin adminClient;
+    private final ScheduledFuture<?> future;
+    private final ScheduledExecutorService executor;
+    private final Supplier<Collection<Listener>> threadMetricsSupplier;
+
+    private Poller(
+        final Admin adminClient,
+        final ScheduledExecutorService executor,
+        final Supplier<Collection<Listener>> threadMetricsSupplier
+    ) {
+      this.adminClient = adminClient;
+      this.executor = executor;
+      this.threadMetricsSupplier = threadMetricsSupplier;
+      this.future = executor.scheduleAtFixedRate(this::pollEndOffsets, 0, 30, TimeUnit.SECONDS);
+    }
+
+    private void stop() {
+      future.cancel(true);
+      executor.schedule(() -> adminClient.close(Duration.ofNanos(0)), 0, TimeUnit.SECONDS);
+    }
+
+    private void pollEndOffsets() {
+      final var partitions = new HashMap<TopicPartition, OffsetSpec>();
+      final Collection<Listener> threadMetrics = threadMetricsSupplier.get();
+      for (final var tm : threadMetrics) {
+        for (final var tp : tm.endOffsets.keySet()) {
+          partitions.put(tp, OffsetSpec.latest());
+        }
+      }
+      final var result = adminClient.listOffsets(partitions);
+      final Map<TopicPartition, ListOffsetsResultInfo> endOffsets;
+      try {
+        endOffsets = result.all().get();
+      } catch (final InterruptedException | ExecutionException e) {
+        throw new RuntimeException(e);
+      }
+      threadMetrics.forEach(tm -> tm.update(endOffsets));
+    }
+  }
+
+  static class Listener implements ResponsiveConsumer.Listener {
+    private final String threadId;
+    private final Map<TopicPartition, Long> endOffsets = new ConcurrentHashMap<>();
+    private final Logger logger;
+    private final Metrics metrics;
+    private final Consumer<String> onClose;
+
+
+    private Listener(final String threadId, final Metrics metrics, final Consumer<String> onClose) {
+      this.threadId = threadId;
+      this.metrics = metrics;
+      this.onClose = onClose;
+      logger = LoggerFactory.getLogger(EndOffsetsPoller.class.getName() + "." + threadId);
+    }
+
+    @Override
+    public void onPartitionsLost(final Collection<TopicPartition> lost) {
+      onPartitionsRevoked(lost);
+    }
+
+    @Override
+    public void onPartitionsRevoked(final Collection<TopicPartition> revoked) {
+      for (final var p : revoked) {
+        metrics.removeMetric(metricName(p));
+        endOffsets.remove(p);
+      }
+    }
+
+    @Override
+    public void onPartitionsAssigned(final Collection<TopicPartition> assigned) {
+      for (final var p : assigned) {
+        endOffsets.put(p, -1L);
+        metrics.addMetric(
+            metricName(p),
+            (Gauge<Long>) (config, now) -> endOffsets.getOrDefault(p, -1L)
+        );
+      }
+    }
+
+    private void update(final Map<TopicPartition, ListOffsetsResultInfo> endOffsets) {
+      for (final var tp : endOffsets.keySet()) {
+        this.endOffsets.computeIfPresent(tp, (k, v) -> {
+          logger.info("update end offset metric of {}/{} to {}",
+              tp.topic(),
+              tp.partition(),
+              endOffsets.get(tp)
+          );
+          return endOffsets.get(tp).offset();
+        });
+      }
+    }
+
+    public void close() {
+      logger.info("cleanup offset metrics for thread {}", threadId);
+      for (final TopicPartition p : endOffsets.keySet()) {
+        metrics.removeMetric(metricName(p));
+      }
+      onClose.accept(threadId);
+    }
+
+    private MetricName metricName(final TopicPartition topicPartition) {
+      final var tags = new HashMap<String, String>();
+      tags.put("thread", threadId);
+      tags.put("topic", topicPartition.topic());
+      tags.put("partition", Integer.toString(topicPartition.partition()));
+      return new MetricName("end-offset", "responsive.streams", "", tags);
+    }
+  }
+
+  interface Factories {
+    default Admin createAdminClient(final Map<String, Object> configs) {
+      return Admin.create(configs);
+    }
+  }
+}

--- a/kafka-instrumentation/src/main/java/dev/responsive/kafka/clients/MetricPublishingCommitListener.java
+++ b/kafka-instrumentation/src/main/java/dev/responsive/kafka/clients/MetricPublishingCommitListener.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.kafka.clients;
+
+import dev.responsive.kafka.clients.ResponsiveProducer.RecordingKey;
+import java.io.Closeable;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.metrics.Gauge;
+import org.apache.kafka.common.metrics.Metrics;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This class publishes a metric that provides the current committed offset for a given
+ * topic-partition. It implements ResponsiveProducer.Listener and ResponsiveConsumer.Listener
+ * to listen on commit events and partition assignment changes, respectively. On a partition
+ * assignment change, it adds or removes metric instances. Each metric instance returns the
+ * current committed offset provided by the producer callback.
+ *
+ * Synchronization: All shared access goes through the "offsets" map.
+ */
+public class MetricPublishingCommitListener
+    implements ResponsiveProducer.Listener, ResponsiveConsumer.Listener, Closeable {
+  private static final Logger LOGGER
+      = LoggerFactory.getLogger(MetricPublishingCommitListener.class);
+  private final Metrics metrics;
+  private final String threadId;
+  private final Map<TopicPartition, Optional<CommittedOffset>> offsets = new ConcurrentHashMap<>();
+
+  private static class CommittedOffset {
+    private final long offset;
+    private final String consumerGroup;
+
+    private CommittedOffset(final long offset, final String consumerGroup) {
+      this.offset = offset;
+      this.consumerGroup = consumerGroup;
+    }
+
+    public long getOffset() {
+      return offset;
+    }
+
+    public String getConsumerGroup() {
+      return consumerGroup;
+    }
+  }
+
+  public MetricPublishingCommitListener(final Metrics metrics, final String threadId) {
+    this.metrics = Objects.requireNonNull(metrics);
+    this.threadId = Objects.requireNonNull(threadId);
+  }
+
+  private MetricName metricName(final RecordingKey k) {
+    return metricName(k.getPartition(), k.getConsumerGroup());
+  }
+
+  private MetricName metricName(final TopicPartition partition, final String consumerGroup) {
+    final Map<String, String> tags = new HashMap<>();
+    tags.put("consumerGroup", consumerGroup);
+    tags.put("thread", threadId);
+    tags.put("topic", partition.topic());
+    tags.put("partition", Integer.toString(partition.partition()));
+    return new MetricName("committed-offset", "responsive.streams", "", tags);
+  }
+
+  @Override
+  public void onCommit(final Map<RecordingKey, Long> committedOffsets) {
+    for (final var e : committedOffsets.entrySet()) {
+      offsets.computeIfPresent(
+          e.getKey().getPartition(),
+          (k, v) -> {
+            if (v.isEmpty()) {
+              LOGGER.info("add committed offset metric for {} {}", threadId, k);
+              metrics.addMetric(
+                  metricName(e.getKey()),
+                  (Gauge<Long>) (config, now) ->
+                      offsets.getOrDefault(k, Optional.empty())
+                          .map(CommittedOffset::getOffset).orElse(-1L)
+              );
+            }
+            LOGGER.info("record committed offset {} {}: {}", threadId, k, e.getValue());
+            return Optional.of(new CommittedOffset(e.getValue(), e.getKey().getConsumerGroup()));
+          }
+      );
+    }
+  }
+
+  @Override
+  public void onClose() {
+  }
+
+  @Override
+  public void onPartitionsRevoked(final Collection<TopicPartition> partitions) {
+    LOGGER.info("Remove committed offset metrics entry for {}",
+        partitions.stream()
+            .filter(offsets::containsKey)
+            .map(TopicPartition::toString)
+            .collect(Collectors.joining(","))
+    );
+    for (final var p : partitions) {
+      offsets.computeIfPresent(p, (k, v) -> {
+        v.ifPresent(offset -> metrics.removeMetric(metricName(k, offset.getConsumerGroup())));
+        return null;
+      });
+    }
+  }
+
+  @Override
+  public void onPartitionsAssigned(final Collection<TopicPartition> partitions) {
+    LOGGER.info("Add committed offsets metrics entry for {}",
+        partitions.stream().map(TopicPartition::toString).collect(Collectors.joining(","))
+    );
+    for (final var p : partitions) {
+      offsets.putIfAbsent(p, Optional.empty());
+    }
+  }
+
+  @Override
+  public void onPartitionsLost(final Collection<TopicPartition> partitions) {
+    onPartitionsRevoked(partitions);
+  }
+
+  @Override
+  public void close() {
+    // at this point we assume no threads will call the other callbacks
+    for (final TopicPartition p : offsets.keySet()) {
+      if (offsets.get(p).isPresent()) {
+        LOGGER.info("Clean up committed offset metric {} {}", threadId, p);
+        metrics.removeMetric(metricName(p, offsets.get(p).get().getConsumerGroup()));
+      }
+    }
+    offsets.clear();
+  }
+}

--- a/kafka-instrumentation/src/test/java/dev/responsive/kafka/clients/EndOffsetsPollerTest.java
+++ b/kafka-instrumentation/src/test/java/dev/responsive/kafka/clients/EndOffsetsPollerTest.java
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.kafka.clients;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import dev.responsive.kafka.clients.EndOffsetsPoller.Factories;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Optional;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.stream.Collectors;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.ListOffsetsResult;
+import org.apache.kafka.clients.admin.ListOffsetsResult.ListOffsetsResultInfo;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.internals.KafkaFutureImpl;
+import org.apache.kafka.common.metrics.Gauge;
+import org.apache.kafka.common.metrics.MetricValueProvider;
+import org.apache.kafka.common.metrics.Metrics;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class EndOffsetsPollerTest {
+  private static final Map<String, Object> CONFIGS = Map.of();
+  private static final String THREAD_ID = "StreamThread-0";
+  private static final TopicPartition PARTITION1 = new TopicPartition("alice", 1);
+  private static final TopicPartition PARTITION2 = new TopicPartition("bob", 2);
+
+  @Mock
+  private AdminClient adminClient;
+  @Mock
+  private Factories factories;
+  @Mock
+  private Metrics metrics;
+  @Mock
+  private ScheduledExecutorService executor;
+  @Mock
+  private ScheduledFuture<Object> pollFuture;
+  @Captor
+  private ArgumentCaptor<MetricName> metricNameCaptor;
+  @Captor
+  private ArgumentCaptor<MetricValueProvider<Long>> valueProviderCaptor;
+  @Captor
+  private ArgumentCaptor<Runnable> taskCaptor;
+  private EndOffsetsPoller endOffsetsPoller;
+
+  @BeforeEach
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  public void setup() {
+    lenient().when(factories.createAdminClient(anyMap())).thenReturn(adminClient);
+    lenient().when(executor.scheduleAtFixedRate(any(), anyLong(), anyLong(), any()))
+        .thenReturn((ScheduledFuture) pollFuture);
+    endOffsetsPoller = new EndOffsetsPoller(CONFIGS, metrics, executor, factories);
+  }
+
+  @Test
+  public void shouldAddEndOffsetMetricForThreadWhenPartitionsAssigned() {
+    // when:
+    final var callback = endOffsetsPoller.addForThread(THREAD_ID);
+    callback.onPartitionsAssigned(List.of(PARTITION1, PARTITION2));
+
+    // then:
+    verify(metrics, times(2))
+        .addMetric(metricNameCaptor.capture(), any(MetricValueProvider.class));
+    assertThat(metricNameCaptor.getAllValues(), contains(
+        metricName(THREAD_ID, PARTITION1),
+        metricName(THREAD_ID, PARTITION2))
+    );
+  }
+
+  @Test
+  public void shouldRemoveEndOffsetMetricWhenPartitionsRevoked() {
+    // given:
+    final var callback = endOffsetsPoller.addForThread(THREAD_ID);
+    callback.onPartitionsAssigned(List.of(PARTITION1, PARTITION2));
+
+    // when:
+    callback.onPartitionsRevoked(List.of(PARTITION1));
+
+    // then:
+    verify(metrics).removeMetric(metricName(THREAD_ID, PARTITION1));
+  }
+
+  @Test
+  public void shouldRemoveEndOffsetMetricForThread() {
+    // given:
+    final var callback = endOffsetsPoller.addForThread(THREAD_ID);
+    callback.onPartitionsAssigned(List.of(PARTITION1));
+
+    // when:
+    callback.close();
+
+    // then:
+    verify(metrics).removeMetric(metricName(THREAD_ID, PARTITION1));
+  }
+
+  @Test
+  public void shouldPollAllEndOffsetsForThread() {
+    // given:
+    final var result = completedOffsetListing(Map.of(
+        PARTITION1, new ListOffsetsResultInfo(123L, 100L, Optional.empty()),
+        PARTITION2, new ListOffsetsResultInfo(456L, 200L, Optional.empty())
+    ));
+    when(adminClient.listOffsets(anyMap())).thenReturn(result);
+    final var callback = endOffsetsPoller.addForThread(THREAD_ID);
+    callback.onPartitionsAssigned(List.of(PARTITION1, PARTITION2));
+    verify(metrics, times(2)).addMetric(any(), valueProviderCaptor.capture());
+    verify(executor).scheduleAtFixedRate(taskCaptor.capture(), eq(0L), anyLong(), any());
+    final var task = taskCaptor.getValue();
+
+    // when:
+    task.run();
+
+    // then:
+    final List<MetricValueProvider<Long>> providers = valueProviderCaptor.getAllValues();
+    assertThat(providers.get(0), instanceOf(Gauge.class));
+    assertThat(((Gauge<Long>) providers.get(0)).value(null, 0L), equalTo(123L));
+    assertThat(providers.get(1), instanceOf(Gauge.class));
+    assertThat(((Gauge<Long>) providers.get(1)).value(null, 0L), equalTo(456L));
+  }
+
+  @Test
+  public void shouldPollEndOffsetsForMultipleThreads() {
+    // given:
+    final var result = completedOffsetListing(Map.of(
+        PARTITION1, new ListOffsetsResultInfo(123L, 100L, Optional.empty()),
+        PARTITION2, new ListOffsetsResultInfo(456L, 200L, Optional.empty())
+    ));
+    when(adminClient.listOffsets(anyMap())).thenReturn(result);
+    final var callback = endOffsetsPoller.addForThread(THREAD_ID);
+    callback.onPartitionsAssigned(List.of(PARTITION1));
+    final var callback2 = endOffsetsPoller.addForThread("StreamThread-1");
+    callback2.onPartitionsAssigned(List.of(PARTITION2));
+    verify(metrics, times(2)).addMetric(any(), valueProviderCaptor.capture());
+    verify(executor).scheduleAtFixedRate(taskCaptor.capture(), eq(0L), anyLong(), any());
+    final var task = taskCaptor.getValue();
+
+    // when:
+    task.run();
+
+    // then:
+    final List<MetricValueProvider<Long>> providers = valueProviderCaptor.getAllValues();
+    assertThat(providers.get(0), instanceOf(Gauge.class));
+    assertThat(((Gauge<Long>) providers.get(0)).value(null, 0L), equalTo(123L));
+    assertThat(providers.get(1), instanceOf(Gauge.class));
+    assertThat(((Gauge<Long>) providers.get(1)).value(null, 0L), equalTo(456L));
+  }
+
+  private MetricName metricName(final String thread, final TopicPartition tp) {
+    return new MetricName("end-offset", "responsive.streams", "",
+        Map.of(
+            "thread", thread,
+            "topic", tp.topic(),
+            "partition", Integer.toString(tp.partition())
+        )
+    );
+  }
+
+  private ListOffsetsResult completedOffsetListing(
+      final Map<TopicPartition, ListOffsetsResultInfo> result
+  ) {
+    final Map<TopicPartition, KafkaFuture<ListOffsetsResultInfo>> futures = result.entrySet()
+        .stream()
+        .collect(Collectors.toMap(
+            Entry::getKey,
+            e -> {
+              final KafkaFutureImpl<ListOffsetsResultInfo> future = new KafkaFutureImpl<>();
+              future.complete(e.getValue());
+              return future;
+            }
+        ));
+    return new ListOffsetsResult(futures);
+  }
+}

--- a/kafka-instrumentation/src/test/java/dev/responsive/kafka/clients/MetricPublishingCommitListenerTest.java
+++ b/kafka-instrumentation/src/test/java/dev/responsive/kafka/clients/MetricPublishingCommitListenerTest.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.kafka.clients;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import dev.responsive.kafka.clients.ResponsiveProducer.RecordingKey;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.metrics.Gauge;
+import org.apache.kafka.common.metrics.Metrics;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MetricPublishingCommitListenerTest {
+  private static final String THREAD_ID = "StreamThread-0";
+  private static final String GROUP = "foo";
+  private static final TopicPartition PARTITION1 = new TopicPartition("blimp", 1);
+  private static final TopicPartition PARTITION2 = new TopicPartition("airplane", 2);
+
+  @Mock
+  private Metrics metrics;
+  @Captor
+  private ArgumentCaptor<MetricName> nameCaptor;
+  @Captor
+  private ArgumentCaptor<Gauge<Long>> metricCaptor;
+
+  private MetricPublishingCommitListener listener;
+
+  @BeforeEach
+  public void setup() {
+    listener = new MetricPublishingCommitListener(metrics, THREAD_ID);
+  }
+
+  @Test
+  public void shouldReportCommittedOffsets() {
+    // given:
+    listener.onPartitionsAssigned(List.of(PARTITION1, PARTITION2));
+
+    // when:
+    listener.onCommit(Map.of(
+        new RecordingKey(PARTITION1, GROUP), 123L,
+        new RecordingKey(PARTITION2, GROUP), 345L
+    ));
+
+    // then:
+    verify(metrics, times(2)).addMetric(
+        nameCaptor.capture(), metricCaptor.capture()
+    );
+    final var values = metricCaptor.getAllValues();
+    final var names = nameCaptor.getAllValues();
+    final var nameToValue = IntStream.range(0, names.size()).boxed()
+        .collect(Collectors.toMap(names::get, values::get));
+    assertThat(nameToValue.get(getName(PARTITION1)).value(null, 0), is(123L));
+    assertThat(nameToValue.get(getName(PARTITION2)).value(null, 0), is(345L));
+  }
+
+  @Test
+  public void shouldCleanupCommittedOffsetOnRevoke() {
+    // given:
+    listener.onPartitionsAssigned(List.of(PARTITION1, PARTITION2));
+    listener.onCommit(Map.of(
+        new RecordingKey(PARTITION1, GROUP), 123L,
+        new RecordingKey(PARTITION2, GROUP), 345L
+    ));
+
+    // when:
+    listener.onPartitionsRevoked(List.of(PARTITION1));
+
+    // then:
+    verify(metrics).removeMetric(nameCaptor.capture());
+    assertThat(nameCaptor.getValue(), is(getName(PARTITION1)));
+  }
+
+  @Test
+  public void shouldAddCommittedOffsetMetricOnAssign() {
+    // given:
+    listener.onPartitionsAssigned(List.of(PARTITION1, PARTITION2));
+
+    // when:
+    listener.onCommit(Map.of(
+        new RecordingKey(PARTITION1, GROUP), 123L,
+        new RecordingKey(PARTITION2, GROUP), 345L
+    ));
+
+    // then:
+    verify(metrics, times(2))
+        .addMetric(nameCaptor.capture(), any(Gauge.class));
+    assertThat(
+        nameCaptor.getAllValues(),
+        containsInAnyOrder(getName(PARTITION1), getName(PARTITION2))
+    );
+  }
+
+  @Test
+  public void shouldCleanupMetricsOnClose() {
+    // given:
+    listener.onPartitionsAssigned(List.of(PARTITION1, PARTITION2));
+    listener.onCommit(Map.of(
+        new RecordingKey(PARTITION1, GROUP), 123L,
+        new RecordingKey(PARTITION2, GROUP), 345L
+    ));
+
+    // when:
+    listener.close();
+
+    // then:
+    verify(metrics, times(2)).removeMetric(nameCaptor.capture());
+    assertThat(
+        nameCaptor.getAllValues(),
+        containsInAnyOrder(getName(PARTITION1), getName(PARTITION2))
+    );
+  }
+
+  private MetricName getName(final TopicPartition tp) {
+    return new MetricName(
+        "committed-offset", "responsive.streams", "",
+        Map.of(
+            "thread", THREAD_ID,
+            "topic", tp.topic(),
+            "partition", Integer.toString(tp.partition()),
+            "consumerGroup", GROUP
+        )
+    );
+  }
+}


### PR DESCRIPTION
EndOffsetsPoller: listens for partitions assigned/revoked, polls the end offsets
for the assigned partitions, and publishes the offset as a metric.
MetricsPublishingCommitListener: listens for partitions assigned/revoked and for
committed offsets, and publishes the current commmitted offset for all assigned
partitions.

~Just opening a mock PR to facilitate review of https://github.com/responsivedev/responsive-pub/pull/33~

~This shows [PR #33](https://github.com/responsivedev/responsive-pub/pull/33) relative to [PR #32](https://github.com/responsivedev/responsive-pub/pull/32)~