### PR TITLE
log operator logs to our logging pipeline

### DIFF
--- a/operator/build.gradle.kts
+++ b/operator/build.gradle.kts
@@ -34,6 +34,8 @@ dependencies {
     implementation(libs.bundles.commons)
     implementation(libs.bundles.logging)
 
+    implementation(libs.kafka.clients)
+
     annotationProcessor(libs.javaoperatorsdk)
     annotationProcessor(libs.crd.generator.atp)
 

--- a/operator/docker/Dockerfile
+++ b/operator/docker/Dockerfile
@@ -1,6 +1,7 @@
 FROM amd64/debian:11.6 
 
 RUN apt update
+RUN apt install -y gettext-base
 RUN apt install -y wget
 RUN wget https://download.oracle.com/java/20/latest/jdk-20_linux-x64_bin.deb
 RUN apt -y install ./jdk-20_linux-x64_bin.deb

--- a/operator/docker/scripts/log4j-console-only.yaml
+++ b/operator/docker/scripts/log4j-console-only.yaml
@@ -1,0 +1,12 @@
+Configuration:
+  name: Log4JWithKafka
+  Appenders:
+    Console:
+      Name: console
+      PatternLayout:
+        Pattern: "%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n"
+  Loggers:
+    Root:
+      level: INFO
+      AppenderRef:
+        - ref: console

--- a/operator/docker/scripts/log4j-with-kafka.yaml
+++ b/operator/docker/scripts/log4j-with-kafka.yaml
@@ -1,0 +1,29 @@
+Configuration:
+  name: Log4JWithKafka
+  Appenders:
+    Kafka:
+      Name: kafka
+      Topic: ${LOGGING_TOPIC}
+      JsonLayout:
+        compact: true
+      property:
+        - name: bootstrap.servers
+          value: ${LOGGING_KAFKA_EP}
+        - name: sasl.jaas.config
+          value: dev.responsive.kafka.auth.PropertiesFileLoginModule required properties='${LOGGING_KAFKA_KEY_FILE}';
+        - name: security.protocol
+          value: SASL_SSL
+        - name: sasl.mechanism
+          value: PLAIN
+        - name: client.dns.lookup
+          value: use_all_dns_ips
+    Console:
+      Name: console
+      PatternLayout:
+        Pattern: "%d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n"
+  Loggers:
+    Root:
+      level: INFO
+      AppenderRef:
+        - ref: kafka
+        - ref: console

--- a/operator/docker/scripts/run-operator
+++ b/operator/docker/scripts/run-operator
@@ -1,1 +1,9 @@
-java -Dorg.apache.logging.log4j.level=INFO -cp "/usr/share/java/responsive-operator/*" dev.responsive.k8s.operator.OperatorMain -controllerUrl ${CONTROLLER_EP} -secretsFile "/etc/responsive-operator/secrets.properties"
+if [ -z $LOGGING_KAFKA_EP ]
+then
+    LOG4J_CONFIG_PATH=/log4j-console-only.yaml
+else
+    cat /log4j-with-kafka.yaml | envsubst > log4j-with-kafka-filled.yaml
+    LOG4J_CONFIG_PATH=/log4j-with-kafka-filled.yaml
+fi
+
+java -Dlog4j2.configurationFile=file:${LOG4J_CONFIG_PATH} -cp "/usr/share/java/responsive-operator/*" dev.responsive.k8s.operator.OperatorMain -controllerUrl ${CONTROLLER_EP} -secretsFile "/etc/responsive-operator/secrets.properties"

--- a/operator/src/main/helm/templates/deployment.yaml
+++ b/operator/src/main/helm/templates/deployment.yaml
@@ -33,17 +33,34 @@ spec:
           env:
               - name: CONTROLLER_EP
                 value: {{ .Values.controllerEndpoint }}
+              - name: LOGGING_KAFKA_EP
+                value: {{ .Values.logging.kafka.endpoint }}
+              - name: LOGGING_TOPIC
+                value: {{ .Values.logging.kafka.topic }}
+              - name: LOGGING_KAFKA_KEY_FILE
+                value: /etc/responsive-operator/logging_kafka/key.properties
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:
             - name: cfg
               mountPath: /etc/responsive-operator/
               readOnly: true
+            {{- if ne .Values.logging.kafka.keySecret "" }}
+            - name: logging-kafka-key
+              mountPath: /etc/responsive-operator/logging_kafka/
+              readOnly: true
+            {{- end }}
       volumes:
         - name: cfg
           secret:
             secretName: {{ .Values.controllerSecret }}
             optional: true
+        {{- if ne .Values.logging.kafka.keySecret "" }}
+        - name: logging-kafka-key
+          secret:
+            secretName: {{ .Values.logging.kafka.keySecret }}
+            optional: true
+        {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/operator/src/main/helm/values.yaml
+++ b/operator/src/main/helm/values.yaml
@@ -24,6 +24,13 @@ serviceAccount:
   # If not set and create is true, a name is generated using the fullname template
   name: ""
 
+
+logging:
+    kafka:
+       keySecret: ""
+       endpoint: ""
+       topic: ""
+
 controllerEndpoint: dns:///controller:4242
 
 controllerSecret: ctl-secret

--- a/operator/src/main/java/dev/responsive/k8s/operator/OperatorMain.java
+++ b/operator/src/main/java/dev/responsive/k8s/operator/OperatorMain.java
@@ -39,6 +39,7 @@ public class OperatorMain {
   private static final String SECRET_CONFIG = "responsive.platform.api.secret";
 
   public static void main(String[] args) {
+    LOGGER.info("Starting main");
 
     final Options options = OperatorOptions.OPTIONS;
     final CommandLineParser parser = new DefaultParser();

--- a/operator/src/main/java/dev/responsive/kafka/auth/PropertiesFileLoginModule.java
+++ b/operator/src/main/java/dev/responsive/kafka/auth/PropertiesFileLoginModule.java
@@ -1,0 +1,70 @@
+package dev.responsive.kafka.auth;
+
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Map;
+import java.util.Properties;
+import javax.security.auth.Subject;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.spi.LoginModule;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class PropertiesFileLoginModule implements LoginModule {
+  private static final Logger LOGGER = LoggerFactory.getLogger(PropertiesFileLoginModule.class);
+
+  private static final String PROPERTIES_FILE = "properties";
+  private static final String USERNAME_CONFIG = "username";
+  private static final String PASSWORD_CONFIG = "password";
+
+  @Override
+  public void initialize(
+      final Subject subject,
+      final CallbackHandler callbackHandler,
+      final Map<String, ?> sharedState,
+      final Map<String, ?> options
+  ) {
+    final String propertiesPath = (String) options.get(PROPERTIES_FILE);
+    if (propertiesPath == null) {
+      LOGGER.info("no properties file specified in JAAS config");
+      return;
+    }
+    final Properties properties = new Properties();
+    try (InputStream in = new FileInputStream(propertiesPath)) {
+      properties.load(in);
+    } catch (final IOException e) {
+      LOGGER.info("error loading properties file", e);
+    }
+    String username = properties.getProperty(USERNAME_CONFIG);
+    if (username != null) {
+      LOGGER.info("login using name " + username);
+      subject.getPublicCredentials().add(username);
+    }
+    String password = properties.getProperty(PASSWORD_CONFIG);
+    if (password != null) {
+      subject.getPrivateCredentials().add(password);
+    }
+  }
+
+  @Override
+  public boolean login() {
+    return true;
+  }
+
+  @Override
+  public boolean logout() {
+    return true;
+  }
+
+  @Override
+  public boolean commit() {
+    return true;
+  }
+
+  @Override
+  public boolean abort() {
+    return false;
+  }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -38,6 +38,7 @@ dependencyResolutionManagement {
             version("grpc", "1.52.1")
             version("protobuf-java", "3.22.3")
             version("slf4j", "1.7.5")
+            version("log4j2", "2.20.0")
 
             library("jackson", "com.fasterxml.jackson.datatype", "jackson-datatype-jdk8").versionRef("jackson")
 
@@ -71,9 +72,9 @@ dependencyResolutionManagement {
             // do not include these in jars that are distributed - these
             // should only be used when the distributed artifact is deployable (e.g.
             // a docker image)
-            library("slf4j", "org.slf4j", "slf4j-log4j12").versionRef("slf4j")
-            library("log4j-core", "org.apache.logging.log4j:log4j-core:2.17.1")
-            bundle("logging", listOf("slf4j", "log4j-core"))
+            library("slf4j-log4j2", "org.apache.logging.log4j", "log4j-slf4j-impl").versionRef("log4j2")
+            library("log4j-core", "org.apache.logging.log4j", "log4j-core").versionRef("log4j2")
+            bundle("logging", listOf("slf4j-log4j2", "log4j-core"))
         }
 
         create("testlibs") {


### PR DESCRIPTION
This patch sets operator deployments up to log to our logging pipeline:
- packages operator with log4j2, which ships with a maintained kafka appender
- adds a customized login module for authenticating with ccloud brokers. It reads username/password from a separate file (rather than the log4j properties file). This way we can put the api key/secret in a k8s secret.
- docker run script sets up a log4j properties file that logs to kafka, if configured to do so.
- helm chart mounts kafka secret and sets up environment variables so that log4j with kafka can be used.

Tested using local operator in kind running against a real observability stack"