### PR TITLE
Make sure the Admin client supplied to each global consumer is closed

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/clients/ResponsiveGlobalConsumer.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/clients/ResponsiveGlobalConsumer.java
@@ -147,6 +147,18 @@ public class ResponsiveGlobalConsumer extends DelegatingConsumer<byte[], byte[]>
     }
   }
 
+  @Override
+  public void close() {
+    super.close();
+    admin.close();
+  }
+  
+  @Override
+  public void close(final Duration timeout) {
+    super.close(timeout);
+    admin.close();
+  }
+
   /**
    * A hack that will return all records that were polled when calling
    * {@link #records(TopicPartition)}.


### PR DESCRIPTION
Minor thing I missed before -- if we create a new admin with the client supplier just to be passed in to the global consumer, we need to make sure that admin client also gets closed.