### PR TITLE
support more store names

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveGlobalKeyValueBytesStoreSupplier.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveGlobalKeyValueBytesStoreSupplier.java
@@ -19,6 +19,7 @@ package dev.responsive.kafka.api;
 import dev.responsive.db.CassandraClient;
 import dev.responsive.kafka.store.ResponsiveGlobalStore;
 import dev.responsive.utils.RemoteMonitor;
+import dev.responsive.utils.TableName;
 import java.util.concurrent.ScheduledExecutorService;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
@@ -27,7 +28,7 @@ import org.apache.kafka.streams.state.KeyValueStore;
 public class ResponsiveGlobalKeyValueBytesStoreSupplier implements KeyValueBytesStoreSupplier {
 
   private final CassandraClient client;
-  private final String name;
+  private final TableName name;
   private final RemoteMonitor awaitTable;
 
   public ResponsiveGlobalKeyValueBytesStoreSupplier(
@@ -36,18 +37,13 @@ public class ResponsiveGlobalKeyValueBytesStoreSupplier implements KeyValueBytes
       final ScheduledExecutorService executorService
   ) {
     this.client = client;
-    this.name = name;
-
-    // we maintain the name without quotes because quotes are
-    // not valid in Kafka topics, but on the other hand they
-    // are necessary to ensure that Cassandra can accept whatever
-    // the client tosses at it
-    awaitTable = client.awaitTable('"' + name + '"', executorService);
+    this.name = new TableName(name);
+    awaitTable = client.awaitTable(this.name.cassandraName(), executorService);
   }
 
   @Override
   public String name() {
-    return name;
+    return name.kafkaName();
   }
 
   @Override

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveKeyValueBytesStoreSupplier.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveKeyValueBytesStoreSupplier.java
@@ -19,6 +19,7 @@ package dev.responsive.kafka.api;
 import dev.responsive.db.CassandraClient;
 import dev.responsive.kafka.store.ResponsiveStore;
 import dev.responsive.utils.RemoteMonitor;
+import dev.responsive.utils.TableName;
 import java.util.concurrent.ScheduledExecutorService;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.common.utils.Bytes;
@@ -28,7 +29,7 @@ import org.apache.kafka.streams.state.KeyValueStore;
 public class ResponsiveKeyValueBytesStoreSupplier implements KeyValueBytesStoreSupplier {
 
   private final CassandraClient client;
-  private final String name;
+  private final TableName name;
   private final RemoteMonitor awaitTable;
   private final Admin admin;
 
@@ -39,19 +40,14 @@ public class ResponsiveKeyValueBytesStoreSupplier implements KeyValueBytesStoreS
       final Admin admin
   ) {
     this.client = client;
-    this.name = name;
+    this.name = new TableName(name);
     this.admin = admin;
-
-    // we maintain the name without quotes because quotes are
-    // not valid in Kafka topics, but on the other hand they
-    // are necessary to ensure that Cassandra can accept whatever
-    // the client tosses at it
-    awaitTable = client.awaitTable('"' + name + '"', executorService);
+    awaitTable = client.awaitTable(this.name.cassandraName(), executorService);
   }
 
   @Override
   public String name() {
-    return name;
+    return name.kafkaName();
   }
 
   @Override

--- a/kafka-client/src/main/java/dev/responsive/utils/TableName.java
+++ b/kafka-client/src/main/java/dev/responsive/utils/TableName.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.utils;
+
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+/**
+ * {@code TableName} represents the name for a table and all variations
+ * of it - some characters that are valid for Kafka names are not valid
+ * as Cassandra table names.
+ */
+public class TableName {
+
+  // cassandra names are case-insensitive and can only contain
+  // alphanumeric and underscore characters
+  private static final Pattern INVALID_CASSANDRA_CHARS =
+      Pattern.compile("[^a-zA-Z0-9_]");
+
+  private final String kafkaName;
+  private final String cassandraName;
+
+  public TableName(final String kafkaName) {
+    this.kafkaName = kafkaName;
+    cassandraName = INVALID_CASSANDRA_CHARS
+        .matcher(kafkaName)
+        .replaceAll("_")
+        .toLowerCase();
+  }
+
+  public String kafkaName() {
+    return kafkaName;
+  }
+
+  public String cassandraName() {
+    return cassandraName;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final TableName tableName = (TableName) o;
+    return Objects.equals(kafkaName, tableName.kafkaName)
+        && Objects.equals(cassandraName, tableName.cassandraName);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(kafkaName, cassandraName);
+  }
+
+  @Override
+  public String toString() {
+    return kafkaName + "(" + cassandraName + ")";
+  }
+}

--- a/kafka-client/src/main/java/dev/responsive/utils/TableName.java
+++ b/kafka-client/src/main/java/dev/responsive/utils/TableName.java
@@ -36,8 +36,9 @@ public class TableName {
 
   public TableName(final String kafkaName) {
     this.kafkaName = kafkaName;
+    final var escaped = kafkaName.replaceAll("_", "__"); // escape existing underscores
     cassandraName = INVALID_CASSANDRA_CHARS
-        .matcher(kafkaName)
+        .matcher(escaped)
         .replaceAll("_")
         .toLowerCase();
   }

--- a/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsiveStoreEosIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsiveStoreEosIntegrationTest.java
@@ -112,7 +112,7 @@ public class ResponsiveStoreEosIntegrationTest {
   private static final int MAX_POLL_MS = 5000;
   private static final String INPUT_TOPIC = "input";
   private static final String OUTPUT_TOPIC = "output";
-  private static final String STORE_NAME = "store";
+  private static final String STORE_NAME = "store-Name"; // use non-valid cassandra chars (-)
 
   private String name;
   private String bootstrapServers;

--- a/kafka-client/src/test/java/dev/responsive/utils/TableNameTest.java
+++ b/kafka-client/src/test/java/dev/responsive/utils/TableNameTest.java
@@ -33,7 +33,7 @@ class TableNameTest {
     final var name = new TableName(kafkaName);
 
     // Then:
-    MatcherAssert.assertThat(name.cassandraName(), Matchers.is("foo_Bar_baz_qux"));
+    MatcherAssert.assertThat(name.cassandraName(), Matchers.is("foo_bar_baz_qux"));
   }
 
 }

--- a/kafka-client/src/test/java/dev/responsive/utils/TableNameTest.java
+++ b/kafka-client/src/test/java/dev/responsive/utils/TableNameTest.java
@@ -16,8 +16,6 @@
 
 package dev.responsive.utils;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -33,7 +31,7 @@ class TableNameTest {
     final var name = new TableName(kafkaName);
 
     // Then:
-    MatcherAssert.assertThat(name.cassandraName(), Matchers.is("foo_bar_baz_qux"));
+    MatcherAssert.assertThat(name.cassandraName(), Matchers.is("foo_bar_baz__qux"));
   }
 
 }

--- a/kafka-client/src/test/java/dev/responsive/utils/TableNameTest.java
+++ b/kafka-client/src/test/java/dev/responsive/utils/TableNameTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.utils;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+class TableNameTest {
+
+  @Test
+  public void shouldReplaceInvalidCharsWithUnderscores() {
+    // Given:
+    final var kafkaName = "foo.Bar-baz_qux";
+
+    // When:
+    final var name = new TableName(kafkaName);
+
+    // Then:
+    MatcherAssert.assertThat(name.cassandraName(), Matchers.is("foo_Bar_baz_qux"));
+  }
+
+}


### PR DESCRIPTION
this PR will replace all characters that are passed in as the store name that are invalid in cassandra with `_`. it also removes the `"` (cc @ableegoldman 😆) and just deals with case insensitivity (which I think was the reason for adding them in first place).