### PR TITLE
Add timestampedKeyValueStoreBuilder to API

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/api/StreamsStoreDriver.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/StreamsStoreDriver.java
@@ -16,10 +16,13 @@
 
 package dev.responsive.kafka.api;
 
+import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
 import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.StoreBuilder;
+import org.apache.kafka.streams.state.Stores;
 import org.apache.kafka.streams.state.TimestampedKeyValueStore;
 import org.apache.kafka.streams.state.WindowBytesStoreSupplier;
 import org.apache.kafka.streams.state.WindowStore;
@@ -54,6 +57,15 @@ public interface StreamsStoreDriver {
    *        key-(timestamp/value) store that uses Responsive's storage for its backend
    */
   KeyValueBytesStoreSupplier timestampedKv(final String name);
+
+  /**
+   * @see Stores#timestampedKeyValueStoreBuilder(KeyValueBytesStoreSupplier, Serde, Serde)
+   */
+  <K, V> StoreBuilder<TimestampedKeyValueStore<K, V>> timestampedKeyValueStoreBuilder(
+      final String name,
+      final Serde<K> keySerde,
+      final Serde<V> valueSerde
+  );
 
   /**
    * Create a {@link KeyValueBytesStoreSupplier} for a global Responsive state store.

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveStoreBuilder.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveStoreBuilder.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.kafka.store;
+
+import java.util.Map;
+import org.apache.kafka.common.config.TopicConfig;
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.state.StoreBuilder;
+
+public class ResponsiveStoreBuilder<T extends StateStore> implements StoreBuilder<T> {
+
+  private final StoreBuilder<T> delegate;
+
+  public ResponsiveStoreBuilder(final StoreBuilder<T> delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public StoreBuilder<T> withCachingEnabled() {
+    delegate.withCachingEnabled();
+    return this;
+  }
+
+  @Override
+  public StoreBuilder<T> withCachingDisabled() {
+    delegate.withCachingDisabled();
+    return this;
+  }
+
+  @Override
+  public StoreBuilder<T> withLoggingEnabled(final Map<String, String> config) {
+    // TODO(rodesai): when we support the source-changelog optimization we should edit this
+    final String cleanupPolicy = config.get(TopicConfig.CLEANUP_POLICY_CONFIG);
+    if (!cleanupPolicy.equals(TopicConfig.CLEANUP_POLICY_DELETE)) {
+      throw new IllegalArgumentException(String.format("Changelogs must use %s=[%s]. Got [%s]",
+          TopicConfig.CLEANUP_POLICY_CONFIG,
+          TopicConfig.CLEANUP_POLICY_DELETE,
+          cleanupPolicy));
+    }
+
+    delegate.withLoggingEnabled(config);
+    return this;
+  }
+
+  @Override
+  public StoreBuilder<T> withLoggingDisabled() {
+    delegate.withLoggingDisabled();
+    return this;
+  }
+
+  @Override
+  public T build() {
+    return delegate.build();
+  }
+
+  @Override
+  public Map<String, String> logConfig() {
+    return delegate.logConfig();
+  }
+
+  @Override
+  public boolean loggingEnabled() {
+    return delegate.loggingEnabled();
+  }
+
+  @Override
+  public String name() {
+    return delegate.name();
+  }
+}

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/api/TestStoreDriver.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/api/TestStoreDriver.java
@@ -17,13 +17,16 @@
 package dev.responsive.kafka.api;
 
 import java.time.Duration;
+import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KafkaClientSupplier;
 import org.apache.kafka.streams.kstream.Materialized;
 import org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier;
 import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
 import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.Stores;
+import org.apache.kafka.streams.state.TimestampedKeyValueStore;
 import org.apache.kafka.streams.state.WindowBytesStoreSupplier;
 import org.apache.kafka.streams.state.WindowStore;
 
@@ -43,6 +46,16 @@ public class TestStoreDriver implements StreamsStoreDriver {
   @Override
   public KeyValueBytesStoreSupplier timestampedKv(final String name) {
     return Stores.inMemoryKeyValueStore(name);
+  }
+
+  @Override
+  public <K, V> StoreBuilder<TimestampedKeyValueStore<K, V>> timestampedKeyValueStoreBuilder(
+      final String name, final Serde<K> keySerde, final Serde<V> valueSerde) {
+    return Stores.timestampedKeyValueStoreBuilder(
+        Stores.inMemoryKeyValueStore(name),
+        keySerde,
+        valueSerde
+    );
   }
 
   @Override


### PR DESCRIPTION
Just the timestamped key-value StoreBuilder which sets the cleanup policy to `[delete]` and makes sure this doesn't get overridden accidentally afterwards