### PR TITLE
dont use OnCommitCallback

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveStore.java
@@ -124,19 +124,7 @@ public class ResponsiveStore implements KeyValueStore<Bytes, byte[]> {
 
       open = true;
 
-      // TODO: commits won't trigger the `onCommit` callback
-      // we use the CommitCallback when registering the StateStore with
-      // the StateStoreContext to trigger the flush after committing
-      // but this won't actually happen - instead it seems that flushing
-      // the state store only happens when either (1) enough events
-      // have been processed (currently hard-coded to 10K) or (2) the
-      // system is closing down. This means that this cache may grow too
-      // large in some situations
-      //
-      // we should figure out a way to flush only on commit, but
-      // perhaps not on _every_ commit as it might hit the performance
-      // issues outlined in KAFKA-9450
-      context.register(root, buffer, buffer::flush);
+      context.register(root, buffer);
     } catch (InterruptedException | TimeoutException e) {
       throw new ProcessorStateException("Failed to initialize store.", e);
     }

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveWindowStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveWindowStore.java
@@ -156,19 +156,7 @@ public class ResponsiveWindowStore implements WindowStore<Bytes, byte[]> {
 
       open = true;
 
-      // TODO: commits won't trigger the `onCommit` callback
-      // we use the CommitCallback when registering the StateStore with
-      // the StateStoreContext to trigger the flush after committing
-      // but this won't actually happen - instead it seems that flushing
-      // the state store only happens when either (1) enough events
-      // have been processed (currently hard-coded to 10K) or (2) the
-      // system is closing down. This means that this cache may grow too
-      // large in some situations
-      //
-      // we should figure out a way to flush only on commit, but
-      // perhaps not on _every_ commit as it might hit the performance
-      // issues outlined in KAFKA-9450
-      context.register(root, buffer, buffer::flush);
+      context.register(root, buffer);
     } catch (InterruptedException | TimeoutException e) {
       throw new ProcessorStateException("Failed to initialize store.", e);
     }


### PR DESCRIPTION
the on commit callback is only called when we flush anyway, so this ultimately caused us to call the `CommitBuffer#flush` method twice back to back leading to confusing statements cluttering the log (empty buffers)