### PR TITLE
use context to implicitly create global stores

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveGlobalStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveGlobalStore.java
@@ -19,7 +19,6 @@ package dev.responsive.kafka.store;
 import dev.responsive.db.CassandraClient;
 import dev.responsive.kafka.clients.SharedClients;
 import dev.responsive.utils.RemoteMonitor;
-import dev.responsive.utils.StoreUtil;
 import dev.responsive.utils.TableName;
 import java.time.Duration;
 import java.util.List;

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsivePartitionedStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsivePartitionedStore.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.kafka.store;
+
+import static org.apache.kafka.streams.processor.internals.ProcessorContextUtils.asInternalProcessorContext;
+import static org.apache.kafka.streams.processor.internals.ProcessorContextUtils.changelogFor;
+
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
+import dev.responsive.db.CassandraClient;
+import dev.responsive.kafka.api.InternalConfigs;
+import dev.responsive.kafka.clients.SharedClients;
+import dev.responsive.model.Result;
+import dev.responsive.utils.RemoteMonitor;
+import dev.responsive.utils.StoreUtil;
+import dev.responsive.utils.TableName;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.TimeoutException;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.errors.ProcessorStateException;
+import org.apache.kafka.streams.processor.ProcessorContext;
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.processor.StateStoreContext;
+import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
+import org.apache.kafka.streams.processor.internals.RecordCollector;
+import org.apache.kafka.streams.processor.internals.RecordCollector.Supplier;
+import org.apache.kafka.streams.query.Position;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.internals.StoreQueryUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ResponsivePartitionedStore implements KeyValueStore<Bytes, byte[]> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ResponsivePartitionedStore.class);
+
+  // visible for testing
+  static final Plugin PLUGIN = new Plugin();
+
+  private CassandraClient client;
+
+  private final TableName name;
+  private final Position position;
+  private ResponsiveStoreRegistry storeRegistry;
+  private ResponsiveStoreRegistration registration;
+
+  private boolean open;
+  private CommitBuffer<Bytes> buffer;
+
+  @SuppressWarnings("rawtypes")
+  private InternalProcessorContext context;
+  private int partition;
+
+  public ResponsivePartitionedStore(
+      final TableName name
+  ) {
+    this.name = name;
+    this.position = Position.emptyPosition();
+  }
+
+  @Override
+  public String name() {
+    return name.kafkaName();
+  }
+
+  @Override
+  @SuppressWarnings("deprecation")
+  public void init(final ProcessorContext context, final StateStore root) {
+    if (context instanceof StateStoreContext) {
+      init((StateStoreContext) context, root);
+    } else {
+      throw new UnsupportedOperationException(
+          "Use ResponsiveStore#init(StateStoreContext, StateStore) instead."
+      );
+    }
+  }
+
+  @Override
+  public void init(final StateStoreContext context, final StateStore root) {
+    try {
+      LOG.info("Initializing state store {}", name);
+      StoreUtil.validateTopologyOptimizationConfig(context.appConfigs());
+      this.context = asInternalProcessorContext(context);
+      partition = context.taskId().partition();
+
+      final SharedClients sharedClients = new SharedClients(context.appConfigs());
+      client = sharedClients.cassandraClient;
+
+      final RemoteMonitor monitor = client.awaitTable(name.cassandraName(), sharedClients.executor);
+      client.createDataTable(name.cassandraName());
+      monitor.await(Duration.ofSeconds(60));
+      LOG.info("Remote table {} is available for querying.", name.cassandraName());
+
+      client.prepareStatements(name.cassandraName());
+      client.initializeOffset(name.cassandraName(), partition);
+
+      final TopicPartition topicPartition =  new TopicPartition(
+          changelogFor(context, name.kafkaName(), false),
+          partition
+      );
+      buffer = new CommitBuffer<>(
+          client,
+          name.cassandraName(),
+          topicPartition,
+          asRecordCollector(context),
+          sharedClients.admin,
+          PLUGIN,
+          StoreUtil.shouldTruncateChangelog(
+              topicPartition.topic(),
+              sharedClients.admin,
+              context.appConfigs()
+          )
+      );
+
+      open = true;
+
+      context.register(root, buffer);
+      final long offset = buffer.offset();
+      registration = new ResponsiveStoreRegistration(
+          name.kafkaName(),
+          topicPartition,
+          offset == -1 ? 0 : offset
+      );
+      storeRegistry = InternalConfigs.loadStoreRegistry(context.appConfigs());
+      storeRegistry.registerStore(registration);
+    } catch (InterruptedException | TimeoutException e) {
+      throw new ProcessorStateException("Failed to initialize store.", e);
+    }
+  }
+
+  private Supplier asRecordCollector(final StateStoreContext context) {
+    return ((RecordCollector.Supplier) context);
+  }
+
+  @Override
+  public boolean isOpen() {
+    return open;
+  }
+
+  @Override
+  public boolean persistent() {
+    // Kafka Streams uses this to determine whether it
+    // needs to create and lock state directories. since
+    // the Responsive Client doesn't require flushing state
+    // to disk, we return false even though the store is
+    // persistent in a remote store
+    return false;
+  }
+
+  @Override
+  public void put(final Bytes key, final byte[] value) {
+    buffer.put(key, value);
+    StoreQueryUtils.updatePosition(position, context);
+  }
+
+  @Override
+  public byte[] putIfAbsent(final Bytes key, final byte[] value) {
+    // since there's only a single writer, we don't need to worry
+    // about the concurrency aspects here (e.g. it's not possible
+    // that between the get(key) and put(key, value) another write
+    // comes in unless this client is fenced, in which case this
+    // batch will not be committed to remote storage)
+    final byte[] old = get(key);
+    if (old == null) {
+      put(key, value);
+    }
+    return old;
+  }
+
+  @Override
+  public void putAll(final List<KeyValue<Bytes, byte[]>> entries) {
+    entries.forEach(kv -> put(kv.key, kv.value));
+    StoreQueryUtils.updatePosition(position, context);
+  }
+
+  @Override
+  public byte[] delete(final Bytes key) {
+    // single writer prevents races (see putIfAbsent)
+    final byte[] old = get(key);
+    buffer.tombstone(key);
+    return old;
+  }
+
+  @Override
+  public byte[] get(final Bytes key) {
+    // try the buffer first, it acts as a local cache
+    // but this is also necessary for correctness as
+    // it is possible that the data is either uncommitted
+    // or not yet pushed to the remote store
+    final Result<Bytes> result = buffer.get(key);
+    if (result != null) {
+      return result.isTombstone ? null : result.value;
+    }
+
+    return client.get(name.cassandraName(), partition, key);
+  }
+
+  @Override
+  public KeyValueIterator<Bytes, byte[]> range(final Bytes from, final Bytes to) {
+    return new LocalRemoteKvIterator<>(
+        buffer.range(from, to),
+        client.range(name.cassandraName(), partition, from, to),
+        PLUGIN
+    );
+  }
+
+  @Override
+  public KeyValueIterator<Bytes, byte[]> all() {
+    return new LocalRemoteKvIterator<>(
+        buffer.all(),
+        client.all(name.cassandraName(), partition),
+        PLUGIN
+    );
+  }
+
+  @Override
+  public Position getPosition() {
+    return position;
+  }
+
+  @Override
+  public long approximateNumEntries() {
+    return client.count(name.cassandraName(), partition);
+  }
+
+  @Override
+  public void flush() {
+    buffer.flush();
+  }
+
+  @Override
+  public void close() {
+    if (storeRegistry != null) {
+      storeRegistry.deregisterStore(registration);
+    }
+    // the client is shared across state stores, so only the
+    // buffer needs to be flushed
+    flush();
+  }
+
+  private static class Plugin implements BufferPlugin<Bytes> {
+
+    @Override
+    public Bytes keyFromRecord(final ConsumerRecord<byte[], byte[]> record) {
+      return Bytes.wrap(record.key());
+    }
+
+    @Override
+    public BoundStatement insertData(
+        final CassandraClient client,
+        final String tableName,
+        final int partition,
+        final Bytes key,
+        final byte[] value
+    ) {
+      return client.insertData(tableName, partition, key, value);
+    }
+
+    @Override
+    public BoundStatement deleteData(
+        final CassandraClient client,
+        final String tableName,
+        final int partition,
+        final Bytes key
+    ) {
+      return client.deleteData(tableName, partition, key);
+    }
+
+    @Override
+    public int compare(final Bytes o1, final Bytes o2) {
+      return o1.compareTo(o2);
+    }
+  }
+}

--- a/kafka-client/src/test/java/dev/responsive/kafka/store/CommitBufferTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/store/CommitBufferTest.java
@@ -105,7 +105,7 @@ public class CommitBufferTest {
     final String tableName = name;
     client.initializeOffset(tableName, 0);
     final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
-        client, tableName, changelogTp, supplier, admin, ResponsiveStore.PLUGIN, true);
+        client, tableName, changelogTp, supplier, admin, ResponsivePartitionedStore.PLUGIN, true);
 
     // When:
     for (int i = 0; i < CommitBuffer.MAX_BATCH_SIZE * 1.5; i++) {
@@ -125,7 +125,7 @@ public class CommitBufferTest {
     final String tableName = name;
     client.initializeOffset(tableName, 0);
     final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
-        client, tableName, changelogTp, supplier, admin, ResponsiveStore.PLUGIN, true);
+        client, tableName, changelogTp, supplier, admin, ResponsivePartitionedStore.PLUGIN, true);
     for (int i = 0; i < CommitBuffer.MAX_BATCH_SIZE * 1.5; i++) {
       buffer.put(KEY, VALUE);
     }
@@ -143,7 +143,7 @@ public class CommitBufferTest {
     final String tableName = name;
     client.initializeOffset(tableName, 0);
     final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
-        client, tableName, changelogTp, supplier, admin, ResponsiveStore.PLUGIN, false);
+        client, tableName, changelogTp, supplier, admin, ResponsivePartitionedStore.PLUGIN, false);
     for (int i = 0; i < CommitBuffer.MAX_BATCH_SIZE * 1.5; i++) {
       buffer.put(KEY, VALUE);
     }
@@ -162,7 +162,7 @@ public class CommitBufferTest {
     client.initializeOffset(table, 0);
     client.insertData(table, 0, KEY, VALUE);
     final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
-        client, table, changelogTp, supplier, admin, ResponsiveStore.PLUGIN, true);
+        client, table, changelogTp, supplier, admin, ResponsivePartitionedStore.PLUGIN, true);
 
     // When:
     buffer.tombstone(Bytes.wrap(new byte[]{1}));
@@ -180,7 +180,7 @@ public class CommitBufferTest {
     client.initializeOffset(tableName, 0);
     client.execute(client.revokePermit(tableName, 0, 101));
     final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
-        client, tableName, changelogTp, supplier, admin, ResponsiveStore.PLUGIN, true);
+        client, tableName, changelogTp, supplier, admin, ResponsivePartitionedStore.PLUGIN, true);
 
     // Expect
     // When:
@@ -197,7 +197,7 @@ public class CommitBufferTest {
     client.initializeOffset(tableName, 0);
     client.execute(client.acquirePermit(tableName, 0, UNSET_PERMIT, UUID.randomUUID(), 1));
     final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
-        client, tableName, changelogTp, supplier, admin, ResponsiveStore.PLUGIN, true);
+        client, tableName, changelogTp, supplier, admin, ResponsivePartitionedStore.PLUGIN, true);
 
     // Expect
     // When:
@@ -214,7 +214,7 @@ public class CommitBufferTest {
     client.initializeOffset(tableName, 0);
     client.execute(client.revokePermit(tableName, 0, 100));
     final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
-        client, tableName, changelogTp, supplier, admin, ResponsiveStore.PLUGIN, true);
+        client, tableName, changelogTp, supplier, admin, ResponsivePartitionedStore.PLUGIN, true);
 
     // Expect
     // When:
@@ -231,7 +231,7 @@ public class CommitBufferTest {
     client.initializeOffset(tableName, 0);
     client.execute(client.revokePermit(tableName, 0, 100));
     final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
-        client, tableName, changelogTp, supplier, admin, ResponsiveStore.PLUGIN, true);
+        client, tableName, changelogTp, supplier, admin, ResponsivePartitionedStore.PLUGIN, true);
 
     final ConsumerRecord<byte[], byte[]> ignored = new ConsumerRecord<>(
         changelogTp.topic(), changelogTp.partition(), 100, new byte[]{1}, new byte[]{1});
@@ -253,7 +253,7 @@ public class CommitBufferTest {
     client.initializeOffset(tableName, 0);
     client.execute(client.revokePermit(tableName, 0, 100));
     final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
-        client, tableName, changelogTp, supplier, admin, ResponsiveStore.PLUGIN, true);
+        client, tableName, changelogTp, supplier, admin, ResponsivePartitionedStore.PLUGIN, true);
 
     final CountDownLatch latch1 = new CountDownLatch(0);
     final CountDownLatch latch2 = new CountDownLatch(0);

--- a/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsiveGlobalStoreIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsiveGlobalStoreIntegrationTest.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.kafka.store;
+
+import static dev.responsive.utils.IntegrationTestUtils.pipeInput;
+import static dev.responsive.utils.IntegrationTestUtils.readOutput;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.APPLICATION_ID_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.COMMIT_INTERVAL_MS_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.NUM_STREAM_THREADS_CONFIG;
+
+import dev.responsive.kafka.api.ResponsiveKafkaStreams;
+import dev.responsive.kafka.api.ResponsiveStores;
+import dev.responsive.utils.ContainerExtension;
+import dev.responsive.utils.IntegrationTestUtils;
+import dev.responsive.utils.ResponsiveConfigParam;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.common.serialization.LongDeserializer;
+import org.apache.kafka.common.serialization.LongSerializer;
+import org.apache.kafka.common.serialization.Serdes.LongSerde;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.kstream.GlobalKTable;
+import org.apache.kafka.streams.kstream.KStream;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ExtendWith(ContainerExtension.class)
+public class ResponsiveGlobalStoreIntegrationTest {
+
+  private static final Logger LOG
+      = LoggerFactory.getLogger(ResponsivePartitionedStoreEosIntegrationTest.class);
+
+  private static final int MAX_POLL_MS = 5000;
+  private static final String INPUT_TOPIC = "input";
+  private static final String GLOBAL_TOPIC = "global";
+  private static final String OUTPUT_TOPIC = "output";
+  private static final String STORE_NAME = "global-store";
+
+  private final Map<String, Object> responsiveProps = new HashMap<>();
+
+  private String name;
+  private Admin admin;
+
+  @BeforeEach
+  public void before(
+      final TestInfo info,
+      final Admin admin,
+      @ResponsiveConfigParam final Map<String, Object> responsiveProps
+  ) {
+    name = info.getTestMethod().orElseThrow().getName();
+    this.responsiveProps.putAll(responsiveProps);
+
+    this.admin = admin;
+    admin.createTopics(
+        List.of(
+            new NewTopic(INPUT_TOPIC, Optional.of(2), Optional.empty()),
+            new NewTopic(GLOBAL_TOPIC, Optional.of(2), Optional.empty()),
+            new NewTopic(OUTPUT_TOPIC, Optional.of(1), Optional.empty())
+        )
+    );
+  }
+
+  @AfterEach
+  public void after() {
+    admin.deleteTopics(List.of(INPUT_TOPIC, GLOBAL_TOPIC, OUTPUT_TOPIC));
+  }
+
+  @Test
+  public void shouldUseGlobalTable() throws Exception {
+    // Given:
+    final Map<String, Object> properties = getMutableProperties();
+    final KafkaProducer<Long, Long> producer = new KafkaProducer<>(properties);
+
+    try (
+        final var streams = buildStreams(properties)
+    ) {
+      // When:
+      pipeInput(GLOBAL_TOPIC, producer, System::currentTimeMillis, 0, 3, 0, 1);
+      IntegrationTestUtils.startAppAndAwaitRunning(Duration.ofSeconds(10), streams);
+      pipeInput(INPUT_TOPIC, producer, System::currentTimeMillis, 0, 10, 0, 1);
+
+      // Then:
+      final Set<KeyValue<Long, Long>> result = new HashSet<>(
+          readOutput(OUTPUT_TOPIC, 0, 20, false, properties));
+
+      for (int k = 0; k < 2; k++) {
+        for (int i = 0; i < 10; i++) {
+          MatcherAssert.assertThat(result, Matchers.hasItem(new KeyValue<>((long) k, i + 2L)));
+        }
+      }
+    }
+  }
+
+  private Map<String, Object> getMutableProperties() {
+    final Map<String, Object> properties = new HashMap<>(responsiveProps);
+
+    properties.put(KEY_SERIALIZER_CLASS_CONFIG, LongSerializer.class);
+    properties.put(VALUE_SERIALIZER_CLASS_CONFIG, LongSerializer.class);
+    properties.put(KEY_DESERIALIZER_CLASS_CONFIG, LongDeserializer.class);
+    properties.put(VALUE_DESERIALIZER_CLASS_CONFIG, LongDeserializer.class);
+
+    properties.put(APPLICATION_ID_CONFIG, name);
+    properties.put(DEFAULT_KEY_SERDE_CLASS_CONFIG, LongSerde.class.getName());
+    properties.put(DEFAULT_VALUE_SERDE_CLASS_CONFIG, LongSerde.class.getName());
+    properties.put(NUM_STREAM_THREADS_CONFIG, 1);
+
+    // this ensures we can control the commits by explicitly requesting a commit
+    properties.put(COMMIT_INTERVAL_MS_CONFIG, 100);
+
+    return properties;
+  }
+
+  private ResponsiveKafkaStreams buildStreams(
+      final Map<String, Object> properties
+  ) {
+    final StreamsBuilder builder = new StreamsBuilder();
+
+    final GlobalKTable<Long, Long> globalTable = builder.globalTable(
+        GLOBAL_TOPIC,
+        ResponsiveStores.materialized(STORE_NAME)
+    );
+
+    final KStream<Long, Long> stream = builder.stream(INPUT_TOPIC);
+    stream.join(globalTable, (k, v) -> k, Long::sum)
+        .to(OUTPUT_TOPIC);
+
+    return ResponsiveKafkaStreams.create(builder.build(), properties);
+  }
+
+}

--- a/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsiveStoreTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsiveStoreTest.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.kafka.store;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import dev.responsive.db.CassandraClient;
+import dev.responsive.db.CassandraClient.OffsetRow;
+import dev.responsive.kafka.api.InternalConfigs;
+import dev.responsive.utils.RemoteMonitor;
+import dev.responsive.utils.TableName;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.DescribeConfigsResult;
+import org.apache.kafka.common.KafkaFuture;
+import org.apache.kafka.common.serialization.Serdes.StringSerde;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.TopologyDescription;
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.processor.StateStoreContext;
+import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.processor.internals.GlobalProcessorContextImpl;
+import org.apache.kafka.streams.processor.internals.ProcessorContextImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+public class ResponsiveStoreTest {
+
+  private static final TableName NAME = new TableName("table");
+
+  @Mock
+  private CassandraClient client;
+  @Mock
+  private RemoteMonitor monitor;
+  @Mock
+  private Admin admin;
+  @Mock
+  private StateStore root;
+  @Mock
+  private ScheduledExecutorService executor;
+  @Mock
+  private DescribeConfigsResult describeConfigs;
+  @Mock
+  private TopologyDescription description;
+  @Mock
+  private ResponsiveStoreRegistry registry;
+
+  private Map<String, Object> config;
+
+  @BeforeEach
+  public void before() {
+    when(client.awaitTable(any(), any())).thenReturn(monitor);
+    when(client.getOffset(any(), anyInt())).thenReturn(new OffsetRow(0, null));
+    when(admin.describeConfigs(any())).thenReturn(describeConfigs);
+    when(describeConfigs.all()).thenReturn(KafkaFuture.completedFuture(Map.of()));
+    config = new HashMap<>(Map.of(
+        StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092",
+        StreamsConfig.APPLICATION_ID_CONFIG, "test",
+        StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, StringSerde.class,
+        StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, StringSerde.class
+    ));
+    config.putAll(
+        new InternalConfigs.Builder()
+            .withCassandraClient(client)
+            .withKafkaAdmin(admin)
+            .withExecutorService(executor)
+            .withTopologyDescription(description)
+            .withStoreRegistry(registry)
+            .build()
+    );
+  }
+
+  @Test
+  public void shouldCreateGlobalStoreWhenPassedGlobalStoreContext() {
+    // Given:
+    final StateStoreContext context = Mockito.mock(GlobalProcessorContextImpl.class);
+    when(context.appConfigs()).thenReturn(config);
+    final var store = new ResponsiveStore(NAME);
+
+    // When:
+    store.init(context, root);
+
+    // Then:
+    assertThat(store.getDelegate(), instanceOf(ResponsiveGlobalStore.class));
+    verify(context).register(eq(root), any());
+  }
+
+  @Test
+  public void shouldCreatePartitionedStoreWhenPassedStoreContext() {
+    // Given:
+    final StateStoreContext context = Mockito.mock(ProcessorContextImpl.class);
+    when(context.appConfigs()).thenReturn(config);
+    when(context.taskId()).thenReturn(new TaskId(0, 0));
+    final var store = new ResponsiveStore(NAME);
+
+    // When:
+    store.init(context, root);
+
+    // Then:
+    assertThat(store.getDelegate(), instanceOf(ResponsivePartitionedStore.class));
+    verify(context).register(eq(root), any());
+  }
+
+}

--- a/kafka-client/src/test/java/dev/responsive/utils/IntegrationTestUtils.java
+++ b/kafka-client/src/test/java/dev/responsive/utils/IntegrationTestUtils.java
@@ -1,19 +1,93 @@
 package dev.responsive.utils;
 
+import static org.apache.kafka.clients.consumer.ConsumerConfig.ISOLATION_LEVEL_CONFIG;
+
 import dev.responsive.kafka.api.ResponsiveKafkaStreams;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.IsolationLevel;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KafkaStreams.State;
 import org.apache.kafka.streams.KafkaStreams.StateListener;
+import org.apache.kafka.streams.KeyValue;
 
 public final class IntegrationTestUtils {
+
   private IntegrationTestUtils() {
+  }
+
+  public static void pipeInput(
+      final String topic,
+      final KafkaProducer<Long, Long> producer,
+      final Supplier<Long> timestamp,
+      final long valFrom,
+      final long valTo,
+      final long... keys
+  ) {
+    for (final long k : keys) {
+      for (long v = valFrom; v < valTo; v++) {
+        producer.send(new ProducerRecord<>(
+            topic,
+            (int) k % 2,
+            timestamp.get(),
+            k,
+            v
+        ));
+      }
+    }
+    producer.flush();
+  }
+
+  public static List<KeyValue<Long, Long>> readOutput(
+      final String topic,
+      final long from,
+      final long numEvents,
+      final boolean readUncommitted,
+      final Map<String, Object> originals
+  ) throws TimeoutException {
+    final Map<String, Object> properties = new HashMap<>(originals);
+    properties.put(ISOLATION_LEVEL_CONFIG, readUncommitted
+        ? IsolationLevel.READ_UNCOMMITTED.name().toLowerCase(Locale.ROOT)
+        : IsolationLevel.READ_COMMITTED.name().toLowerCase(Locale.ROOT));
+
+    try (final KafkaConsumer<Long, Long> consumer = new KafkaConsumer<>(properties)) {
+      final TopicPartition output = new TopicPartition(topic, 0);
+      consumer.assign(List.of(output));
+      consumer.seek(output, from);
+
+      final long end = System.nanoTime() + TimeUnit.SECONDS.toNanos(30);
+      final List<KeyValue<Long, Long>> result = new ArrayList<>();
+      while (result.size() < numEvents) {
+        // this is configured to only poll one record at a time, so we
+        // can guarantee we won't accidentally poll more than numEvents
+        final ConsumerRecords<Long, Long> polled = consumer.poll(Duration.ofSeconds(30));
+        for (ConsumerRecord<Long, Long> rec : polled) {
+          result.add(new KeyValue<>(rec.key(), rec.value()));
+        }
+        if (System.nanoTime() > end) {
+          throw new TimeoutException(
+              "Timed out trying to read " + numEvents + " events from " + output);
+        }
+      }
+      return result;
+    }
   }
 
   public static void startAppAndAwaitRunning(

--- a/kafka-client/src/test/java/dev/responsive/utils/ResponsiveConfigParam.java
+++ b/kafka-client/src/test/java/dev/responsive/utils/ResponsiveConfigParam.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.utils;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface ResponsiveConfigParam {
+
+}


### PR DESCRIPTION
`ResponsiveStore` is now just a wrapper that delegates to either `ResponsivePartitionedStore` or `ResponsiveGlobalStore` depending on the context passed in during initialization.

This allows us to remove the `globalX` methods in our API and match the existing streams apis.