### PR TITLE
add responsive store registry

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/api/InternalConfigs.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/InternalConfigs.java
@@ -1,0 +1,95 @@
+package dev.responsive.kafka.api;
+
+import dev.responsive.db.CassandraClient;
+import dev.responsive.kafka.store.ResponsiveStoreRegistry;
+import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
+import org.apache.kafka.clients.admin.Admin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class InternalConfigs {
+  private static final Logger LOG = LoggerFactory.getLogger(InternalConfigs.class);
+  private static final String STORE_REGISTRY_CONFIG = "__internal.responsive.store.registry__";
+  private static final String INTERNAL_CASSANDRA_CLIENT_CONFIG =
+      "__internal.responsive.cassandra.client__";
+  private static final String INTERNAL_ADMIN_CLIENT_CONFIG =
+          "__internal.responsive.admin.client__";
+  private static final String INTERNAL_EXECUTOR_CLIENT_CONFIG =
+              "__internal.responsive.executor.client__";
+
+  public static <T> T loadFromConfig(
+      final Map<String, Object> configs,
+      final String configName,
+      final Class<T> type,
+      final String name
+  ) {
+    final Object o = configs.get(configName);
+    if (o == null) {
+      final IllegalStateException fatalException =
+          new IllegalStateException(name + " was missing");
+      LOG.error(fatalException.getMessage(), fatalException);
+      throw fatalException;
+    } else if (!(type.isInstance(o))) {
+      final IllegalStateException fatalException = new IllegalStateException(
+          String.format("%s is not an instance of %s", o.getClass().getName(), type.getName())
+      );
+      LOG.error(fatalException.getMessage(), fatalException);
+      throw fatalException;
+    }
+    return type.cast(o);
+  }
+
+  private InternalConfigs() {
+  }
+
+  public static CassandraClient loadCassandraClient(final Map<String, Object> configs) {
+    return loadFromConfig(
+        configs,
+        InternalConfigs.INTERNAL_CASSANDRA_CLIENT_CONFIG,
+        CassandraClient.class,
+        "Shared Cassandra client"
+    );
+  }
+
+  public static ScheduledExecutorService loadExecutorService(final Map<String, Object> configs) {
+    return loadFromConfig(
+        configs,
+        InternalConfigs.INTERNAL_EXECUTOR_CLIENT_CONFIG,
+        ScheduledExecutorService.class,
+        "Shared ScheduledExecutorService client"
+    );
+  }
+
+  public static Admin loadKafkaAdmin(final Map<String, Object> configs) {
+    return loadFromConfig(
+        configs,
+        InternalConfigs.INTERNAL_ADMIN_CLIENT_CONFIG,
+        Admin.class,
+        "Shared Admin client"
+    );
+  }
+
+  public static ResponsiveStoreRegistry loadStoreRegistry(final Map<String, Object> configs) {
+    return loadFromConfig(
+        configs,
+        STORE_REGISTRY_CONFIG,
+        ResponsiveStoreRegistry.class,
+        "Store registry"
+    );
+  }
+
+  public static Map<String, Object> getConfigs(
+      final CassandraClient cassandraClient,
+      final Admin admin,
+      final ScheduledExecutorService executor,
+      final ResponsiveStoreRegistry registry
+  ) {
+    return Map.of(
+        INTERNAL_CASSANDRA_CLIENT_CONFIG, cassandraClient,
+        INTERNAL_ADMIN_CLIENT_CONFIG, admin,
+        INTERNAL_EXECUTOR_CLIENT_CONFIG, executor,
+        STORE_REGISTRY_CONFIG, registry
+    );
+  }
+}

--- a/kafka-client/src/main/java/dev/responsive/kafka/clients/ResponsiveKafkaClientSupplier.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/clients/ResponsiveKafkaClientSupplier.java
@@ -18,6 +18,7 @@ package dev.responsive.kafka.clients;
 
 import static org.apache.kafka.streams.StreamsConfig.EXACTLY_ONCE_V2;
 
+import dev.responsive.kafka.store.ResponsiveStoreRegistry;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.Arrays;
@@ -59,6 +60,7 @@ public final class ResponsiveKafkaClientSupplier implements KafkaClientSupplier 
   private static final Logger LOG = LoggerFactory.getLogger(ResponsiveKafkaClientSupplier.class);
   private final SharedListeners sharedListeners = new SharedListeners();
   private final KafkaClientSupplier wrapped;
+  private final ResponsiveStoreRegistry storeRegistry;
   private final Factories factories;
   private boolean eosV2 = false;
   private boolean configured = false;
@@ -66,24 +68,29 @@ public final class ResponsiveKafkaClientSupplier implements KafkaClientSupplier 
   private EndOffsetsPoller endOffsetsPoller;
   private String applicationId;
 
-  public ResponsiveKafkaClientSupplier(final Map<String, ?> configs) {
-    this(new Factories() {}, new DefaultKafkaClientSupplier(), configs);
+  public ResponsiveKafkaClientSupplier(
+      final Map<String, ?> configs,
+      final ResponsiveStoreRegistry storeRegistry) {
+    this(new Factories() {}, new DefaultKafkaClientSupplier(), configs, storeRegistry);
   }
 
   public ResponsiveKafkaClientSupplier(
       final KafkaClientSupplier clientSupplier,
-      final Map<String, ?> configs
+      final Map<String, ?> configs,
+      final ResponsiveStoreRegistry storeRegistry
   ) {
-    this(new Factories() {}, clientSupplier, configs);
+    this(new Factories() {}, clientSupplier, configs, storeRegistry);
   }
 
   ResponsiveKafkaClientSupplier(
       final Factories factories,
       final KafkaClientSupplier wrapped,
-      final Map<String, ?> configs
+      final Map<String, ?> configs,
+      final ResponsiveStoreRegistry storeRegistry
   ) {
     this.factories = factories;
     this.wrapped = wrapped;
+    this.storeRegistry = storeRegistry;
     configure(configs);
   }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/clients/SharedClients.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/clients/SharedClients.java
@@ -1,7 +1,7 @@
 package dev.responsive.kafka.clients;
 
 import dev.responsive.db.CassandraClient;
-import java.util.HashMap;
+import dev.responsive.kafka.api.InternalConfigs;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 import org.apache.kafka.clients.admin.Admin;
@@ -12,88 +12,14 @@ import org.slf4j.LoggerFactory;
  * Basic container class for session clients and other shared resources
  */
 public class SharedClients {
-  private static final String INTERNAL_CASSANDRA_CLIENT_CONFIG =
-      "__internal.responsive.cassandra.client__";
-  private static final String INTERNAL_ADMIN_CLIENT_CONFIG =
-      "__internal.responsive.admin.client__";
-  private static final String INTERNAL_EXECUTOR_CLIENT_CONFIG =
-      "__internal.responsive.executor.client__";
-
-  private static final Logger LOG = LoggerFactory.getLogger(SharedClients.class);
-
   public final CassandraClient cassandraClient;
   public final Admin admin;
   public final ScheduledExecutorService executor;
 
   public SharedClients(final Map<String, Object> configs) {
-      {
-      final Object o = configs.get(INTERNAL_CASSANDRA_CLIENT_CONFIG);
-      if (o == null) {
-        final IllegalStateException fatalException =
-            new IllegalStateException("Shared Cassandra client was missing");
-        LOG.error(fatalException.getMessage(), fatalException);
-        throw fatalException;
-      } else if (!(o instanceof CassandraClient)) {
-        final IllegalStateException fatalException = new IllegalStateException(
-            String.format("%s is not an instance of %s",
-                          o.getClass().getName(), CassandraClient.class.getName())
-        );
-        LOG.error(fatalException.getMessage(), fatalException);
-        throw fatalException;
-      } else {
-        cassandraClient = (CassandraClient) o;
-      }
-      }
-
-      {
-      final Object o = configs.get(INTERNAL_ADMIN_CLIENT_CONFIG);
-      if (o == null) {
-        final IllegalStateException fatalException =
-            new IllegalStateException("Shared Admin client was missing");
-        LOG.error(fatalException.getMessage(), fatalException);
-        throw fatalException;
-      } else if (!(o instanceof Admin)) {
-        final IllegalStateException fatalException = new IllegalStateException(
-            String.format("%s is not an instance of %s",
-                          o.getClass().getName(), Admin.class.getName())
-        );
-        LOG.error(fatalException.getMessage(), fatalException);
-        throw fatalException;
-      } else {
-        admin = (Admin) o;
-      }
-      }
-
-      {
-      final Object o = configs.get(INTERNAL_EXECUTOR_CLIENT_CONFIG);
-      if (o == null) {
-        final IllegalStateException fatalException = new IllegalStateException(
-            "Shared ScheduledExecutorService client was missing"
-        );
-        LOG.error(fatalException.getMessage(), fatalException);
-        throw fatalException;
-      } else if (!(o instanceof ScheduledExecutorService)) {
-        final IllegalStateException fatalException = new IllegalStateException(
-            String.format("%s is not an instance of %s",
-                          o.getClass().getName(), ScheduledExecutorService.class.getName())
-        );
-        LOG.error(fatalException.getMessage(), fatalException);
-        throw fatalException;
-      } else {
-        executor = (ScheduledExecutorService) o;
-      }
-      }
+    cassandraClient = InternalConfigs.loadCassandraClient(configs);
+    admin = InternalConfigs.loadKafkaAdmin(configs);
+    executor = InternalConfigs.loadExecutorService(configs);
   }
 
-  public static Map<String, Object> sharedClientConfigs(
-      final CassandraClient cassandraClient,
-      final Admin admin,
-      final ScheduledExecutorService executor
-  ) {
-    final Map<String, Object> configs = new HashMap<>();
-    configs.put(INTERNAL_CASSANDRA_CLIENT_CONFIG, cassandraClient);
-    configs.put(INTERNAL_ADMIN_CLIENT_CONFIG, admin);
-    configs.put(INTERNAL_EXECUTOR_CLIENT_CONFIG, executor);
-    return configs;
-  }
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveStoreRegistration.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveStoreRegistration.java
@@ -1,0 +1,32 @@
+package dev.responsive.kafka.store;
+
+import java.util.Objects;
+import org.apache.kafka.common.TopicPartition;
+
+public final class ResponsiveStoreRegistration {
+  private final TopicPartition changelogTopicPartition;
+  private final long committedOffset;
+  private final String name;
+
+  ResponsiveStoreRegistration(
+      final String name,
+      final TopicPartition changelogTopicPartition,
+      final long committedOffset
+  ) {
+    this.name = Objects.requireNonNull(name);
+    this.changelogTopicPartition = Objects.requireNonNull(changelogTopicPartition);
+    this.committedOffset = committedOffset;
+  }
+
+  public long getCommittedOffset() {
+    return committedOffset;
+  }
+
+  public TopicPartition getChangelogTopicPartition() {
+    return changelogTopicPartition;
+  }
+
+  public String getName() {
+    return name;
+  }
+}

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveStoreRegistry.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveStoreRegistry.java
@@ -1,0 +1,58 @@
+package dev.responsive.kafka.store;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalLong;
+import java.util.stream.Collectors;
+import org.apache.kafka.common.TopicPartition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ResponsiveStoreRegistry {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ResponsiveStoreRegistry.class);
+
+  private final List<ResponsiveStoreRegistration> stores = new LinkedList<>();
+
+  public synchronized OptionalLong getCommittedOffset(final TopicPartition topicPartition) {
+    return getRegisteredStoresForChangelog(topicPartition).stream()
+        .mapToLong(ResponsiveStoreRegistration::getCommittedOffset)
+        .max();
+  }
+
+  public synchronized List<ResponsiveStoreRegistration> getRegisteredStoresForChangelog(
+      final TopicPartition topicPartition
+  ) {
+    return stores.stream()
+        .filter(s -> s.getChangelogTopicPartition().equals(topicPartition))
+        .collect(Collectors.toList());
+  }
+
+  public synchronized void registerStore(final ResponsiveStoreRegistration registration) {
+    validateSingleMaterialization(registration);
+    stores.add(registration);
+  }
+
+  public synchronized void deregisterStore(final ResponsiveStoreRegistration registration) {
+    stores.remove(registration);
+  }
+
+  private void validateSingleMaterialization(final ResponsiveStoreRegistration registration) {
+    final String topic = registration.getChangelogTopicPartition().topic();
+    final String name = registration.getName();
+    final Optional<ResponsiveStoreRegistration> conflicting = stores.stream()
+        .filter(si -> si.getChangelogTopicPartition().topic().equals(topic)
+            && !si.getName().equals(name))
+        .findFirst();
+    if (conflicting.isPresent()) {
+      final var err = new IllegalStateException(String.format(
+          "Found two stores that materialize the same changelog topic (%s): %s, %s",
+          topic,
+          name, conflicting.get().getName()
+      ));
+      LOGGER.error("found conflicting materialization", err);
+      throw err;
+    }
+  }
+}

--- a/kafka-client/src/test/java/dev/responsive/kafka/clients/ResponsiveKafkaClientSupplierTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/clients/ResponsiveKafkaClientSupplierTest.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import dev.responsive.kafka.clients.ResponsiveKafkaClientSupplier.Factories;
+import dev.responsive.kafka.store.ResponsiveStoreRegistry;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -94,6 +95,8 @@ class ResponsiveKafkaClientSupplierTest {
   private ArgumentCaptor<List<ResponsiveConsumer.Listener>> consumerListenerCaptor;
   private ResponsiveKafkaClientSupplier supplier;
 
+  private final ResponsiveStoreRegistry storeRegistry = new ResponsiveStoreRegistry();
+
   @BeforeEach
   @SuppressWarnings("unchecked")
   public void setup() {
@@ -111,7 +114,7 @@ class ResponsiveKafkaClientSupplierTest {
     lenient().when(factories.createMetricsPublishingCommitListener(any(), any()))
         .thenReturn(metricPublishingCommitListener);
 
-    supplier = new ResponsiveKafkaClientSupplier(factories, wrapped, CONFIGS);
+    supplier = new ResponsiveKafkaClientSupplier(factories, wrapped, CONFIGS, storeRegistry);
   }
 
   @Test
@@ -120,7 +123,8 @@ class ResponsiveKafkaClientSupplierTest {
     final var config = configsWithOverrides(
         PRODUCER_CONFIGS,
         Map.of(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.AT_LEAST_ONCE));
-    final var supplier = new ResponsiveKafkaClientSupplier(factories, wrapped, config);
+    final var supplier
+        = new ResponsiveKafkaClientSupplier(factories, wrapped, config, storeRegistry);
 
     // when:
     final var producer = supplier.getProducer(config);
@@ -135,7 +139,8 @@ class ResponsiveKafkaClientSupplierTest {
     final var config = configsWithOverrides(
         CONSUMER_CONFIGS,
         Map.of(StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.AT_LEAST_ONCE));
-    final var supplier = new ResponsiveKafkaClientSupplier(factories, wrapped, config);
+    final var supplier
+        = new ResponsiveKafkaClientSupplier(factories, wrapped, config, storeRegistry);
 
     // when:
     final var consumer = supplier.getConsumer(config);

--- a/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsiveStoreRegistryTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsiveStoreRegistryTest.java
@@ -1,0 +1,61 @@
+package dev.responsive.kafka.store;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+
+import java.util.List;
+import java.util.OptionalLong;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ResponsiveStoreRegistryTest {
+  private static final TopicPartition TOPIC_PARTITION = new TopicPartition("changelog-topic", 5);
+  private static final ResponsiveStoreRegistration REGISTRATION = new ResponsiveStoreRegistration(
+      "store",
+      TOPIC_PARTITION,
+      123L
+  );
+
+  private final ResponsiveStoreRegistry registry = new ResponsiveStoreRegistry();
+
+  @BeforeEach
+  public void setup() {
+    registry.registerStore(REGISTRATION);
+  }
+
+  @Test
+  public void shouldGetCommittedOffsetFromRegisteredStore() {
+    assertThat(registry.getCommittedOffset(TOPIC_PARTITION), is(OptionalLong.of(123L)));
+  }
+
+  @Test
+  public void shouldGetRegisteredStoreForChangelog() {
+    assertThat(
+        registry.getRegisteredStoresForChangelog(TOPIC_PARTITION),
+        is(List.of(REGISTRATION))
+    );
+  }
+
+  @Test
+  public void shouldReturnEmptyCommittedOffsetFromNotRegisteredStore() {
+    assertThat(
+        registry.getCommittedOffset(new TopicPartition("foo", 1)),
+        is(OptionalLong.empty())
+    );
+  }
+
+  @Test
+  public void shouldDeregisterStore() {
+    // given:
+    registry.deregisterStore(REGISTRATION);
+
+    // when:
+    final List<ResponsiveStoreRegistration> registered
+        = registry.getRegisteredStoresForChangelog(TOPIC_PARTITION);
+
+    // then:
+    assertThat(registered, is(empty()));
+  }
+}

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/api/ResponsiveTopologyTestDriver.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/api/ResponsiveTopologyTestDriver.java
@@ -1,8 +1,9 @@
 package dev.responsive.kafka.api;
 
-import static dev.responsive.kafka.clients.SharedClients.sharedClientConfigs;
+import static dev.responsive.kafka.api.InternalConfigs.getConfigs;
 
 import dev.responsive.db.CassandraClient;
+import dev.responsive.kafka.store.ResponsiveStoreRegistry;
 import java.time.Instant;
 import java.util.Properties;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
@@ -65,11 +66,12 @@ public class ResponsiveTopologyTestDriver extends TopologyTestDriver {
   private static Properties testDriverProps(final Properties baseProps) {
     final Properties props = new Properties();
     props.putAll(baseProps);
-    props.putAll(sharedClientConfigs(
+    props.putAll(getConfigs(
         new CassandraClientStub(),
         new MockAdminClient(),
-        new ScheduledThreadPoolExecutor(1))
-    );
+        new ScheduledThreadPoolExecutor(1),
+        new ResponsiveStoreRegistry()
+    ));
     return props;
   }
 


### PR DESCRIPTION
This patch adds a collection of all created Responsive state stores called ResponsiveStoreRegistry. The collection is updated as stores are created and deleted, and is shared amongst various components - like the stores ad the client supplier - via an intenral config.