### PR TITLE
map kafka partitions into multiple remote partitions

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/db/CassandraClient.java
+++ b/kafka-client/src/main/java/dev/responsive/db/CassandraClient.java
@@ -25,6 +25,7 @@ import static dev.responsive.db.ColumnNames.PERMIT;
 import static dev.responsive.db.ColumnNames.WINDOW_START;
 
 import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
 import com.datastax.oss.driver.api.core.cql.BoundStatement;
 import com.datastax.oss.driver.api.core.cql.PreparedStatement;
 import com.datastax.oss.driver.api.core.cql.ResultSet;
@@ -44,6 +45,7 @@ import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
 import org.apache.kafka.common.utils.Bytes;
@@ -130,6 +132,16 @@ public class CassandraClient {
    */
   public ResultSet execute(final Statement<?> statement) {
     return session.execute(statement);
+  }
+
+  /**
+   * An asynchronous execution of an arbitrary statement directly
+   * with Cassandra.
+   *
+   * @see #execute(Statement)
+   */
+  public CompletionStage<AsyncResultSet> executeAsync(final Statement<?> statement) {
+    return session.executeAsync(statement);
   }
 
   /**

--- a/kafka-client/src/main/java/dev/responsive/kafka/config/ResponsiveDriverConfig.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/config/ResponsiveDriverConfig.java
@@ -64,6 +64,14 @@ public class ResponsiveDriverConfig extends AbstractConfig {
       + "responsive server. This applies both to metadata requests and query execution.";
   private static final long REQUEST_TIMEOUT_MS_DEFAULT = 5000L;
 
+  // ------------------- other configurations ---------------------------------
+  public static final String PARTITION_EXPLODE_FACTOR_CONFIG = "responsive.partition"
+      + ".explode.factor";
+  public static final String PARTITION_EXPLODE_FACTOR_DOC = "Explodes kafka partitions "
+      + "into remote partition counts";
+  public static final int PARTITION_EXPLODE_FACTOR_DEFAULT = 31;
+
+  public static final String INTERNAL_PARTITIONER = "__internal.responsive.partitioner__";
 
   // ------------------ required StreamsConfig overrides ----------------------
 
@@ -123,6 +131,12 @@ public class ResponsiveDriverConfig extends AbstractConfig {
           REQUEST_TIMEOUT_MS_DEFAULT,
           Importance.MEDIUM,
           REQUEST_TIMEOUT_MS_DOC
+      ).define(
+          PARTITION_EXPLODE_FACTOR_CONFIG,
+          Type.INT,
+          PARTITION_EXPLODE_FACTOR_DEFAULT,
+          Importance.MEDIUM,
+          PARTITION_EXPLODE_FACTOR_DOC
       );
 
   private static class NonEmptyPassword implements Validator {

--- a/kafka-client/src/main/java/dev/responsive/kafka/config/ResponsiveDriverConfig.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/config/ResponsiveDriverConfig.java
@@ -71,8 +71,6 @@ public class ResponsiveDriverConfig extends AbstractConfig {
       + "into remote partition counts";
   public static final int PARTITION_EXPLODE_FACTOR_DEFAULT = 31;
 
-  public static final String INTERNAL_PARTITIONER = "__internal.responsive.partitioner__";
-
   // ------------------ required StreamsConfig overrides ----------------------
 
   public static final int NUM_STANDBYS_OVERRIDE = 0;

--- a/kafka-client/src/main/java/dev/responsive/utils/ExplodePartitioner.java
+++ b/kafka-client/src/main/java/dev/responsive/utils/ExplodePartitioner.java
@@ -40,7 +40,7 @@ public class ExplodePartitioner {
     this(factor, k -> SALT * Murmur3.hash32(k.get()));
   }
 
-  ExplodePartitioner(
+  public ExplodePartitioner(
       final int factor,
       final Function<Bytes, Integer> hasher
   ) {

--- a/kafka-client/src/main/java/dev/responsive/utils/ExplodePartitioner.java
+++ b/kafka-client/src/main/java/dev/responsive/utils/ExplodePartitioner.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.utils;
+
+import org.apache.kafka.streams.processor.StreamPartitioner;
+
+/**
+ * {@code ExplodePartitioner} allows mapping a smaller subset of partitions
+ * into a larger partition space.
+ */
+public class ExplodePartitioner<K, V> {
+
+  private final StreamPartitioner<K, V> base;
+  private final int factor;
+  private final int numPartitions;
+  private final String topic;
+
+  public ExplodePartitioner(
+      final StreamPartitioner<K, V> base,
+      final String topic,
+      final int factor,
+      final int numPartitions
+  ) {
+    if (factor != 1 && factor == numPartitions) {
+      // we don't necessarily have to use the same partitioner for the
+      // second round of hashing as we do for the first one, but we'll
+      // leave that as a follow-up and just throw an exception for now
+      throw new IllegalArgumentException("Cannot explode by the same "
+          + "number as original partitions " + numPartitions
+          + " as that will ensure collisions.");
+    }
+    this.base = base;
+    this.topic = topic;
+    this.factor = factor;
+    this.numPartitions = numPartitions;
+  }
+
+  @SuppressWarnings("deprecation")
+  public int repartition(final K key, final V value) {
+    // map the original partition to a new base by multiplying it by factor
+    // and then determine the sub-partition within the new base by partitioning
+    // it as if there were that many partitions
+    return base.partition(topic, key, value, numPartitions) * factor
+        + base.partition(topic, key, value, factor);
+  }
+
+  public int getFactor() {
+    return factor;
+  }
+
+  public int mapToBase(final int partition) {
+    return partition * factor;
+  }
+}

--- a/kafka-client/src/test/java/dev/responsive/kafka/store/CommitBufferTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/store/CommitBufferTest.java
@@ -27,6 +27,8 @@ import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.querybuilder.SchemaBuilder;
 import dev.responsive.db.CassandraClient;
 import dev.responsive.utils.ContainerExtension;
+import dev.responsive.utils.ExplodePartitioner;
+import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -57,12 +59,14 @@ import org.testcontainers.containers.CassandraContainer;
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class CommitBufferTest {
 
-  private static final Bytes KEY = Bytes.wrap(new byte[]{1});
+  private static final Bytes KEY = Bytes.wrap(ByteBuffer.allocate(4).putInt(0).array());
+  private static final Bytes KEY2 = Bytes.wrap(ByteBuffer.allocate(4).putInt(1).array());
   private static final byte[] VALUE = new byte[]{1};
 
   private CqlSession session;
   private CassandraClient client;
   private TopicPartition changelogTp;
+  private ExplodePartitioner<Bytes, byte[]> partitioner;
 
   private String name;
   @Mock private RecordCollector.Supplier supplier;
@@ -79,6 +83,7 @@ public class CommitBufferTest {
         .build();
     client = new CassandraClient(session);
     changelogTp = new TopicPartition("log", 0);
+    setPartitioner(1, 1);
 
     client.createDataTable(name);
     client.prepareStatements(name);
@@ -88,6 +93,15 @@ public class CommitBufferTest {
         .thenReturn(Collections.singletonMap(new TopicPartition("log", 0), 100L));
     when(admin.deleteRecords(Mockito.any()))
         .thenReturn(new DeleteRecordsResult(Map.of()));
+  }
+
+  private void setPartitioner(final int numPartitions, final int factor) {
+    partitioner = new ExplodePartitioner<>(
+        (topic, key, value, np) -> ByteBuffer.wrap(key.get()).getInt() % np,
+        changelogTp.topic(),
+        factor,
+        numPartitions
+    );
   }
 
   @AfterEach
@@ -100,33 +114,78 @@ public class CommitBufferTest {
   public void shouldFlushAndUpdateOffsetWhenLargerOffset() {
     // Given:
     final String tableName = name;
-    client.initializeOffset(tableName, 0);
     final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
-        client, tableName, changelogTp, supplier, admin, ResponsiveStore.PLUGIN);
+        client, tableName, changelogTp, supplier, admin, ResponsiveStore.PLUGIN, partitioner);
 
     // When:
     for (int i = 0; i < CommitBuffer.MAX_BATCH_SIZE * 1.5; i++) {
-      buffer.put(KEY, VALUE);
+      buffer.put(new Bytes(ByteBuffer.allocate(4).putInt(i).array()), VALUE);
     }
     buffer.flush();
 
     // Then:
-    final byte[] value = client.get(tableName, 0, KEY);
+    final byte[] key = ByteBuffer.allocate(4).putInt(0).array();
+    final byte[] value = client.get(tableName, 0, Bytes.wrap(key));
     assertThat(value, is(VALUE));
     assertThat(client.getOffset(tableName, 0).offset, is(100L));
+  }
+
+  @Test
+  public void shouldExplodeFlushAndUpdateOffsetWhenLargerOffset() {
+    // Given:
+    setPartitioner(1, 2);
+    final String tableName = name;
+    final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
+        client, tableName, changelogTp, supplier, admin, ResponsiveStore.PLUGIN, partitioner);
+
+    // When:
+    for (int i = 0; i < CommitBuffer.MAX_BATCH_SIZE * 2.5; i++) {
+      final byte[] array = ByteBuffer.allocate(4).putInt(i).array();
+      buffer.put(new Bytes(array), VALUE);
+    }
+    buffer.flush();
+
+    // Then:
+    assertThat(client.get(tableName, 0, KEY), is(VALUE));
+    assertThat(client.get(tableName, 1, KEY2), is(VALUE));
+
+    assertThat(client.getOffset(tableName, 0).offset, is(100L));
+    assertThat(client.getOffset(tableName, 1).offset, is(100L));
+  }
+
+  @Test
+  public void shouldExplodeFlushWhenThereAreEmptyPartitionSets() {
+    // Given:
+    setPartitioner(1, 2);
+    final String tableName = name;
+    final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
+        client, tableName, changelogTp, supplier, admin, ResponsiveStore.PLUGIN, partitioner);
+
+    // When:
+    for (int i = 0; i < CommitBuffer.MAX_BATCH_SIZE * 1.5; i++) {
+      // i << 1 ensures they all go to partition 0
+      final byte[] array = ByteBuffer.allocate(4).putInt(i << 1).array();
+      buffer.put(new Bytes(array), VALUE);
+    }
+    buffer.flush();
+
+    // Then:
+    assertThat(client.get(tableName, 0, KEY), is(VALUE));
+
+    assertThat(client.getOffset(tableName, 0).offset, is(100L));
+    assertThat(client.getOffset(tableName, 1).offset, is(100L));
   }
 
   @Test
   public void shouldDeleteRowInCassandraWithTombstone() {
     // Given:
     final String table = name;
-    client.initializeOffset(table, 0);
     client.insertData(table, 0, KEY, VALUE);
     final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
-        client, table, changelogTp, supplier, admin, ResponsiveStore.PLUGIN);
+        client, table, changelogTp, supplier, admin, ResponsiveStore.PLUGIN, partitioner);
 
     // When:
-    buffer.tombstone(Bytes.wrap(new byte[]{1}));
+    buffer.tombstone(KEY);
     buffer.flush();
 
     // Then:
@@ -138,10 +197,9 @@ public class CommitBufferTest {
   public void shouldThrowErrorOnFlushWhenSmallerOffset() {
     // Given:
     final String tableName = name;
-    client.initializeOffset(tableName, 0);
-    client.execute(client.revokePermit(tableName, 0, 101));
     final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
-        client, tableName, changelogTp, supplier, admin, ResponsiveStore.PLUGIN);
+        client, tableName, changelogTp, supplier, admin, ResponsiveStore.PLUGIN, partitioner);
+    client.execute(client.revokePermit(tableName, 0, 101));
 
     // Expect
     // When:
@@ -155,10 +213,9 @@ public class CommitBufferTest {
   public void shouldThrowErrorOnFlushWhenDifferentTxnIdIsSet() {
     // Given:
     final String tableName = name;
-    client.initializeOffset(tableName, 0);
-    client.execute(client.acquirePermit(tableName, 0, UNSET_PERMIT, UUID.randomUUID(), 1));
     final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
-        client, tableName, changelogTp, supplier, admin, ResponsiveStore.PLUGIN);
+        client, tableName, changelogTp, supplier, admin, ResponsiveStore.PLUGIN, partitioner);
+    client.execute(client.acquirePermit(tableName, 0, UNSET_PERMIT, UUID.randomUUID(), 1));
 
     // Expect
     // When:
@@ -172,10 +229,9 @@ public class CommitBufferTest {
   public void shouldThrowErrorOnFlushWhenEqualOffset() {
     // Given:
     final String tableName = name;
-    client.initializeOffset(tableName, 0);
-    client.execute(client.revokePermit(tableName, 0, 100));
     final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
-        client, tableName, changelogTp, supplier, admin, ResponsiveStore.PLUGIN);
+        client, tableName, changelogTp, supplier, admin, ResponsiveStore.PLUGIN, partitioner);
+    client.execute(client.revokePermit(tableName, 0, 100));
 
     // Expect
     // When:
@@ -189,15 +245,14 @@ public class CommitBufferTest {
   public void shouldRestoreRecordsGreaterThanCassandraOffset() {
     // Given:
     final String tableName = name;
-    client.initializeOffset(tableName, 0);
-    client.execute(client.revokePermit(tableName, 0, 100));
     final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
-        client, tableName, changelogTp, supplier, admin, ResponsiveStore.PLUGIN);
+        client, tableName, changelogTp, supplier, admin, ResponsiveStore.PLUGIN, partitioner);
+    client.execute(client.revokePermit(tableName, 0, 100));
 
     final ConsumerRecord<byte[], byte[]> ignored = new ConsumerRecord<>(
-        changelogTp.topic(), changelogTp.partition(), 100, new byte[]{1}, new byte[]{1});
+        changelogTp.topic(), changelogTp.partition(), 100, KEY.get(), new byte[]{1});
     final ConsumerRecord<byte[], byte[]> restored = new ConsumerRecord<>(
-        changelogTp.topic(), changelogTp.partition(), 101, new byte[]{2}, new byte[]{2});
+        changelogTp.topic(), changelogTp.partition(), 101, KEY2.get(), new byte[]{2});
 
     // When:
     buffer.restoreBatch(List.of(ignored, restored));
@@ -211,10 +266,9 @@ public class CommitBufferTest {
   public void shouldIgnoreFlushFailuresOnRestore() {
     // Given:
     final String tableName = name;
-    client.initializeOffset(tableName, 0);
     client.execute(client.revokePermit(tableName, 0, 100));
     final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
-        client, tableName, changelogTp, supplier, admin, ResponsiveStore.PLUGIN);
+        client, tableName, changelogTp, supplier, admin, ResponsiveStore.PLUGIN, partitioner);
 
     final CountDownLatch latch1 = new CountDownLatch(0);
     final CountDownLatch latch2 = new CountDownLatch(0);

--- a/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsiveStoreEosIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsiveStoreEosIntegrationTest.java
@@ -45,6 +45,7 @@ import static org.hamcrest.Matchers.lessThan;
 
 import dev.responsive.kafka.api.ResponsiveKafkaStreams;
 import dev.responsive.kafka.api.ResponsiveStores;
+import dev.responsive.kafka.config.ResponsiveDriverConfig;
 import dev.responsive.utils.ContainerExtension;
 import dev.responsive.utils.RemoteMonitor;
 import java.time.Duration;
@@ -81,12 +82,14 @@ import org.apache.kafka.common.serialization.LongDeserializer;
 import org.apache.kafka.common.serialization.LongSerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.Serdes.LongSerde;
+import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KafkaStreams.State;
 import org.apache.kafka.streams.KafkaStreams.StateListener;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.processor.StreamPartitioner;
 import org.apache.kafka.streams.processor.api.Processor;
 import org.apache.kafka.streams.processor.api.ProcessorContext;
 import org.apache.kafka.streams.processor.api.Record;
@@ -264,6 +267,12 @@ public class ResponsiveStoreEosIntegrationTest {
     properties.put(consumerPrefix(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG), MAX_POLL_MS);
     properties.put(consumerPrefix(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG), MAX_POLL_MS);
     properties.put(consumerPrefix(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG), MAX_POLL_MS - 1);
+
+    final LongDeserializer deserializer = new LongDeserializer();
+    properties.put(
+        ResponsiveDriverConfig.INTERNAL_PARTITIONER,
+        (StreamPartitioner<Bytes, byte[]>) (t, k, v, np)
+            -> (int) ((deserializer.deserialize(t, k.get())) % np));
 
     return properties;
   }

--- a/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsiveWindowIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsiveWindowIntegrationTest.java
@@ -346,6 +346,7 @@ public class ResponsiveWindowIntegrationTest {
         ));
       }
     }
+    producer.flush();
   }
 
   private Map<String, Object> getMutableProperties() {

--- a/kafka-client/src/test/java/dev/responsive/utils/ExplodePartitionerTest.java
+++ b/kafka-client/src/test/java/dev/responsive/utils/ExplodePartitionerTest.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.utils;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.apache.kafka.streams.processor.StreamPartitioner;
+import org.junit.jupiter.api.Test;
+
+class ExplodePartitionerTest {
+
+  @Test
+  public void shouldMapPartitionsToLargerSpace() {
+    // Given:
+    final StreamPartitioner<Integer, Integer> base = (t, k, v, np) -> k % np;
+    final ExplodePartitioner<Integer, Integer> partitioner = new ExplodePartitioner<>(
+        base,
+        "",
+        2,
+        1
+    );
+
+    // When:
+    final int zero = partitioner.repartition(0, 0);
+    final int one = partitioner.repartition(1, 0);
+    final int two = partitioner.repartition(2, 0);
+    final int three = partitioner.repartition(3, 0);
+
+    // Then:
+    assertThat(zero, is(0));
+    assertThat(one, is(1));
+    assertThat(two, is(0));
+    assertThat(three, is(1));
+  }
+
+}

--- a/kafka-client/src/test/java/dev/responsive/utils/ExplodePartitionerTest.java
+++ b/kafka-client/src/test/java/dev/responsive/utils/ExplodePartitionerTest.java
@@ -19,7 +19,7 @@ package dev.responsive.utils;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-import org.apache.kafka.streams.processor.StreamPartitioner;
+import org.apache.kafka.common.utils.Bytes;
 import org.junit.jupiter.api.Test;
 
 class ExplodePartitionerTest {
@@ -27,25 +27,19 @@ class ExplodePartitionerTest {
   @Test
   public void shouldMapPartitionsToLargerSpace() {
     // Given:
-    final StreamPartitioner<Integer, Integer> base = (t, k, v, np) -> k % np;
-    final ExplodePartitioner<Integer, Integer> partitioner = new ExplodePartitioner<>(
-        base,
-        "",
-        2,
-        1
-    );
+    final var partitioner = new ExplodePartitioner(2, k -> k.get()[0] % 2);
 
     // When:
-    final int zero = partitioner.repartition(0, 0);
-    final int one = partitioner.repartition(1, 0);
-    final int two = partitioner.repartition(2, 0);
-    final int three = partitioner.repartition(3, 0);
+    final int zero = partitioner.repartition(0, Bytes.wrap(new byte[]{0}));
+    final int one = partitioner.repartition(0, Bytes.wrap(new byte[]{1}));
+    final int two = partitioner.repartition(1, Bytes.wrap(new byte[]{2}));
+    final int three = partitioner.repartition(1, Bytes.wrap(new byte[]{3}));
 
     // Then:
     assertThat(zero, is(0));
     assertThat(one, is(1));
-    assertThat(two, is(0));
-    assertThat(three, is(1));
+    assertThat(two, is(2));
+    assertThat(three, is(3));
   }
 
 }

--- a/kafka-client/src/test/java/dev/responsive/utils/TestUtils.java
+++ b/kafka-client/src/test/java/dev/responsive/utils/TestUtils.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.utils;
+
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.NewTopic;
+
+public class TestUtils {
+
+  private TestUtils() {
+
+  }
+
+  public static void awaitTopics(final Admin admin, final List<NewTopic> topics)
+      throws TimeoutException, InterruptedException {
+    final long start = System.nanoTime();
+    while (true) {
+      try {
+        admin.createTopics(topics).all().get();
+        break;
+      } catch (ExecutionException | InterruptedException e) {
+        if (System.nanoTime() - start > TimeUnit.SECONDS.toNanos(10)) {
+          throw new TimeoutException("Failed to create topics via admin call.");
+        }
+        Thread.sleep(100);
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
commit buffer now flushes to N partitions instead of just 1 partition - the general strategy is to map the original record to `hash(key) % original_partition * explode_factor + hash(key) % explode_factor`. The first part of this formula "maps" the original partition to a new space (explodes it) and the second part finds which sub-partition within the exploded partition the key belongs to. 

the actual flushing mechanism will still start a LWT with the remote server and store the same offset for every sub-partition, even if no writes came in to that sub-partition.