### PR TITLE
optimize restore and support compacted changelogs

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/api/CassandraClientFactory.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/CassandraClientFactory.java
@@ -1,0 +1,12 @@
+package dev.responsive.kafka.api;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import dev.responsive.db.CassandraClient;
+import dev.responsive.kafka.config.ResponsiveDriverConfig;
+import java.util.Map;
+
+public interface CassandraClientFactory {
+  CqlSession createCqlSession(ResponsiveDriverConfig config);
+
+  CassandraClient createCassandraClient(CqlSession session);
+}

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/DefaultCassandraClientFactory.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/DefaultCassandraClientFactory.java
@@ -1,0 +1,41 @@
+package dev.responsive.kafka.api;
+
+import static dev.responsive.kafka.config.ResponsiveDriverConfig.CLIENT_ID_CONFIG;
+import static dev.responsive.kafka.config.ResponsiveDriverConfig.CLIENT_SECRET_CONFIG;
+import static dev.responsive.kafka.config.ResponsiveDriverConfig.STORAGE_DATACENTER_CONFIG;
+import static dev.responsive.kafka.config.ResponsiveDriverConfig.STORAGE_HOSTNAME_CONFIG;
+import static dev.responsive.kafka.config.ResponsiveDriverConfig.STORAGE_PORT_CONFIG;
+import static dev.responsive.kafka.config.ResponsiveDriverConfig.TENANT_ID_CONFIG;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import dev.responsive.db.CassandraClient;
+import dev.responsive.kafka.config.ResponsiveDriverConfig;
+import dev.responsive.utils.SessionUtil;
+import java.net.InetSocketAddress;
+import org.apache.kafka.common.config.types.Password;
+
+public class DefaultCassandraClientFactory implements CassandraClientFactory {
+  @Override
+  public CqlSession createCqlSession(final ResponsiveDriverConfig config) {
+    final InetSocketAddress address = InetSocketAddress.createUnresolved(
+        config.getString(STORAGE_HOSTNAME_CONFIG),
+        config.getInt(STORAGE_PORT_CONFIG)
+    );
+    final String datacenter = config.getString(STORAGE_DATACENTER_CONFIG);
+    final String clientId = config.getString(CLIENT_ID_CONFIG);
+    final Password clientSecret = config.getPassword(CLIENT_SECRET_CONFIG);
+    final String tenant = config.getString(TENANT_ID_CONFIG);
+    return SessionUtil.connect(
+        address,
+        datacenter,
+        tenant,
+        clientId,
+        clientSecret == null ? null : clientSecret.value()
+    );
+  }
+
+  @Override
+  public CassandraClient createCassandraClient(final CqlSession session) {
+    return new CassandraClient(session);
+  }
+}

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/InternalConfigs.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/InternalConfigs.java
@@ -2,9 +2,11 @@ package dev.responsive.kafka.api;
 
 import dev.responsive.db.CassandraClient;
 import dev.responsive.kafka.store.ResponsiveStoreRegistry;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.streams.TopologyDescription;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,6 +19,9 @@ public final class InternalConfigs {
           "__internal.responsive.admin.client__";
   private static final String INTERNAL_EXECUTOR_CLIENT_CONFIG =
               "__internal.responsive.executor.client__";
+
+  private static final String TOPOLOGY_DESCRIPITON_CONFIG
+      = "__internal.responsive.topology.description__";
 
   public static <T> T loadFromConfig(
       final Map<String, Object> configs,
@@ -41,6 +46,12 @@ public final class InternalConfigs {
   }
 
   private InternalConfigs() {
+  }
+
+  public static TopologyDescription loadTopologyDescription(final Map<String, Object> config) {
+    return loadFromConfig(
+        config, TOPOLOGY_DESCRIPITON_CONFIG, TopologyDescription.class, "Topology description"
+    );
   }
 
   public static CassandraClient loadCassandraClient(final Map<String, Object> configs) {
@@ -79,17 +90,52 @@ public final class InternalConfigs {
     );
   }
 
+  public static class Builder {
+    private Map<String, Object> configs = new HashMap<>();
+
+    public Builder withCassandraClient(final CassandraClient cassandraClient) {
+      configs.put(INTERNAL_CASSANDRA_CLIENT_CONFIG, cassandraClient);
+      return this;
+    }
+
+    public Builder withKafkaAdmin(final Admin admin) {
+      configs.put(INTERNAL_ADMIN_CLIENT_CONFIG, admin);
+      return this;
+    }
+
+    public Builder withExecutorService(final ScheduledExecutorService executorService) {
+      configs.put(INTERNAL_EXECUTOR_CLIENT_CONFIG, executorService);
+      return this;
+    }
+
+    public Builder withStoreRegistry(final ResponsiveStoreRegistry storeRegistry) {
+      configs.put(STORE_REGISTRY_CONFIG, storeRegistry);
+      return this;
+    }
+
+    public Builder withTopologyDescription(final TopologyDescription topologyDescription) {
+      configs.put(TOPOLOGY_DESCRIPITON_CONFIG, topologyDescription);
+      return this;
+    }
+
+    public Map<String, Object> build() {
+      return Map.copyOf(configs);
+    }
+  }
+
   public static Map<String, Object> getConfigs(
       final CassandraClient cassandraClient,
       final Admin admin,
       final ScheduledExecutorService executor,
-      final ResponsiveStoreRegistry registry
+      final ResponsiveStoreRegistry registry,
+      final TopologyDescription topologyDescription
   ) {
     return Map.of(
         INTERNAL_CASSANDRA_CLIENT_CONFIG, cassandraClient,
         INTERNAL_ADMIN_CLIENT_CONFIG, admin,
         INTERNAL_EXECUTOR_CLIENT_CONFIG, executor,
-        STORE_REGISTRY_CONFIG, registry
+        STORE_REGISTRY_CONFIG, registry,
+        TOPOLOGY_DESCRIPITON_CONFIG, topologyDescription
     );
   }
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/clients/ResponsiveKafkaClientSupplier.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/clients/ResponsiveKafkaClientSupplier.java
@@ -181,7 +181,10 @@ public final class ResponsiveKafkaClientSupplier implements KafkaClientSupplier 
 
   @Override
   public Consumer<byte[], byte[]> getRestoreConsumer(final Map<String, Object> config) {
-    return wrapped.getRestoreConsumer(config);
+    return new ResponsiveRestoreConsumer<>(
+        wrapped.getRestoreConsumer(config),
+        storeRegistry::getCommittedOffset
+    );
   }
 
   @Override

--- a/kafka-client/src/main/java/dev/responsive/kafka/clients/ResponsiveRestoreConsumer.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/clients/ResponsiveRestoreConsumer.java
@@ -1,0 +1,86 @@
+package dev.responsive.kafka.clients;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+import java.util.OptionalLong;
+import java.util.function.Function;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+
+/**
+ * Consumer implementation to use for restoring Responsive stores. This Restore Consumer emulates
+ * consumping a topic that has been truncated up to some offset on a subset of topic partitions.
+ * The specific offsets are provided by a function mapping the topic partition to the start
+ * offset. This consumer is used in conjunction with Responsive Stores, which provide a safe
+ * starting offset that has been committed to a remote storage system. This is useful for
+ * minimizing the length of restores when using a Responsive Store over a compacted changelog
+ * topic (which cannot be truncated).
+ *
+ * @param <K> Type of the record keys
+ * @param <V> Type of the record values
+ */
+public class ResponsiveRestoreConsumer<K, V> extends DelegatingConsumer<K, V> {
+  final Function<TopicPartition, OptionalLong> startOffsets;
+
+  public ResponsiveRestoreConsumer(
+      final Consumer<K, V> delegate,
+      final Function<TopicPartition, OptionalLong> startOffsets
+  ) {
+    super(delegate);
+    this.startOffsets = Objects.requireNonNull(startOffsets);
+  }
+
+  private List<TopicPartition> seekInitial(final Collection<TopicPartition> partitions) {
+    final List<TopicPartition> notFound = new LinkedList<>();
+    for (final TopicPartition p : partitions) {
+      final OptionalLong start = startOffsets.apply(p);
+      if (start.isPresent()) {
+        delegate.seek(p, start.getAsLong());
+      } else {
+        notFound.add(p);
+      }
+    }
+    return Collections.unmodifiableList(notFound);
+  }
+
+  @Override
+  public void assign(Collection<TopicPartition> partitions) {
+    super.assign(partitions);
+    seekInitial(partitions);
+  }
+
+  @Override
+  public void seek(final TopicPartition partition, final long offset) {
+    super.seek(partition, Math.max(offset, startOffsets.apply(partition).orElse(offset)));
+  }
+
+  @Override
+  public void seek(final TopicPartition partition, final OffsetAndMetadata offsetAndMetadata) {
+    super.seek(
+        partition,
+        new OffsetAndMetadata(
+            Math.max(
+                offsetAndMetadata.offset(),
+                startOffsets.apply(partition).orElse(offsetAndMetadata.offset())
+            ),
+            offsetAndMetadata.leaderEpoch(),
+            offsetAndMetadata.metadata()
+        )
+    );
+  }
+
+  @Override
+  public void seekToBeginning(final Collection<TopicPartition> partitions) {
+    final Collection<TopicPartition> withUncachedPosition = seekInitial(partitions);
+    if (withUncachedPosition.size() > 0) {
+      // Make sure to only do this if the list of partitions without cached start positions
+      // is not empty. If it's empty, KafkaConsumer will seek to the actual beginning of _all_
+      // partitions.
+      super.seekToBeginning(withUncachedPosition);
+    }
+  }
+}

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveGlobalStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveGlobalStore.java
@@ -80,7 +80,6 @@ public class ResponsiveGlobalStore implements KeyValueStore<Bytes, byte[]> {
   public void init(final StateStoreContext context, final StateStore root) {
     try {
       LOG.info("Initializing global state store {}", name);
-      StoreUtil.validateTopologyOptimizationConfig(context.appConfigs());
       this.context = context;
       // this is bad, but the assumption is that global tables are small
       // and can fit in a single partition - all writers will write using

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveStore.java
@@ -123,16 +123,22 @@ public class ResponsiveStore implements KeyValueStore<Bytes, byte[]> {
           topicPartition,
           asRecordCollector(context),
           sharedClients.admin,
-          PLUGIN
+          PLUGIN,
+          StoreUtil.shouldTruncateChangelog(
+              topicPartition.topic(),
+              sharedClients.admin,
+              context.appConfigs()
+          )
       );
 
       open = true;
 
       context.register(root, buffer);
+      final long offset = buffer.offset();
       registration = new ResponsiveStoreRegistration(
           name.kafkaName(),
           topicPartition,
-          0
+          offset == -1 ? 0 : offset
       );
       storeRegistry = InternalConfigs.loadStoreRegistry(context.appConfigs());
       storeRegistry.registerStore(registration);

--- a/kafka-client/src/main/java/dev/responsive/utils/StoreUtil.java
+++ b/kafka-client/src/main/java/dev/responsive/utils/StoreUtil.java
@@ -16,12 +16,28 @@
 
 package dev.responsive.utils;
 
+import dev.responsive.kafka.api.InternalConfigs;
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ExecutionException;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.Config;
+import org.apache.kafka.clients.admin.ConfigEntry;
+import org.apache.kafka.clients.admin.DescribeConfigsResult;
+import org.apache.kafka.common.config.ConfigResource;
 import org.apache.kafka.common.config.TopicConfig;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.TopologyDescription;
+import org.apache.kafka.streams.TopologyDescription.Node;
+import org.apache.kafka.streams.TopologyDescription.Source;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public final class StoreUtil {
+  private static final Logger LOG = LoggerFactory.getLogger(StoreUtil.class);
+
   public static void validateTopologyOptimizationConfig(final Map<String, Object> configs) {
     final String optimizations = new StreamsConfig(configs)
         .getString(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG);
@@ -64,5 +80,74 @@ public final class StoreUtil {
     } catch (final ArithmeticException e) {
       throw new IllegalArgumentException(errorMsgPrefix + " due to arithmetic exception", e);
     }
+  }
+
+  private StoreUtil() {
+  }
+
+  private static Optional<Boolean> isCompacted(final String topicName, final Admin admin) {
+    final ConfigResource resource = new ConfigResource(ConfigResource.Type.TOPIC, topicName);
+    final List<ConfigResource> request = List.of(resource);
+    final DescribeConfigsResult result = admin.describeConfigs(request);
+    final Map<ConfigResource, Config> topicConfigs;
+    try {
+      topicConfigs = result.all().get();
+    } catch (final InterruptedException | ExecutionException e) {
+      throw new RuntimeException(e);
+    }
+    if (!topicConfigs.containsKey(resource)) {
+      return Optional.empty();
+    }
+    final Config topicConfig = topicConfigs.get(resource);
+    final ConfigEntry cleanupPolicyEntry = topicConfig.get(TopicConfig.CLEANUP_POLICY_CONFIG);
+    boolean compaction = cleanupPolicyEntry != null
+        && cleanupPolicyEntry.value().contains(TopicConfig.CLEANUP_POLICY_COMPACT);
+    return Optional.of(compaction);
+  }
+
+  private static boolean changelogIsSource(
+      final TopologyDescription description,
+      final String topicName
+  ) {
+    for (final var subtopology : description.subtopologies()) {
+      for (final Node node : subtopology.nodes()) {
+        if (node instanceof Source) {
+          // We ignore the topic regex field here because tables can only source a single topic
+          if (((Source) node).topicSet().contains(topicName)) {
+            return true;
+          }
+        }
+      }
+    }
+    return false;
+  }
+
+  public static boolean shouldTruncateChangelog(
+      final String changelogTopic,
+      final Admin admin,
+      final Map<String, Object> appConfigs
+  ) {
+    // TODO: this is doing a lot of admin calls - we should cache the result
+    final Optional<Boolean> compacted = isCompacted(changelogTopic, admin);
+    final boolean source = changelogIsSource(
+        InternalConfigs.loadTopologyDescription(appConfigs),
+        changelogTopic
+    );
+    LOG.info("Changelog topic {}: compacted({}), source({})", changelogTopic, compacted, source);
+    if (compacted.isEmpty()) {
+      LOG.warn("Could not find topic {}. This should not happen. Will not truncate.",
+          changelogTopic
+      );
+      return false;
+    }
+    if (compacted.get()) {
+      LOG.info("Topic {} is compacted. Will not truncate.", changelogTopic);
+      return false;
+    }
+    if (source) {
+      LOG.info("Topic {} is a source topic. Will not truncate.", changelogTopic);
+      return false;
+    }
+    return true;
   }
 }

--- a/kafka-client/src/test/java/dev/responsive/kafka/clients/ResponsiveRestoreConsumerTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/clients/ResponsiveRestoreConsumerTest.java
@@ -1,0 +1,128 @@
+package dev.responsive.kafka.clients;
+
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.util.List;
+import java.util.OptionalLong;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+
+public class ResponsiveRestoreConsumerTest {
+  private static final TopicPartition TOPIC_PARTITION1 = new TopicPartition("blue", 1);
+  private static final TopicPartition TOPIC_PARTITION2 = new TopicPartition("green", 2);
+  private static final TopicPartition TOPIC_PARTITION_NOT_CACHED = new TopicPartition("foo", 3);
+  @Mock
+  private Consumer<?, ?> wrapped;
+
+  private ResponsiveRestoreConsumer<?, ?> restoreConsumer;
+
+  @BeforeEach
+  public void setup() {
+    restoreConsumer = new ResponsiveRestoreConsumer<>(
+        wrapped,
+        tp -> {
+          if (tp.equals(TOPIC_PARTITION1)) {
+            return OptionalLong.of(123L);
+          }
+          if (tp.equals(TOPIC_PARTITION2)) {
+            return OptionalLong.of(456L);
+          }
+          return OptionalLong.empty();
+        });
+  }
+
+  @Test
+  public void shouldSetPositionOnAssign() {
+    // when:
+    restoreConsumer.assign(List.of(TOPIC_PARTITION1, TOPIC_PARTITION2));
+
+    // then:
+    verify(wrapped).seek(TOPIC_PARTITION1, 123L);
+    verify(wrapped).seek(TOPIC_PARTITION2, 456L);
+  }
+
+  @Test
+  public void shouldNotSetPositionOnAssignPartitionWithNoCachedPosition() {
+    // when:
+    restoreConsumer.assign(List.of(TOPIC_PARTITION_NOT_CACHED));
+
+    // then:
+    verify(wrapped).assign(List.of(TOPIC_PARTITION_NOT_CACHED));
+    verifyNoMoreInteractions(wrapped);
+  }
+
+  @Test
+  public void shouldApplyFloorOnSeek() {
+    // when:
+    restoreConsumer.assign(List.of(TOPIC_PARTITION1));
+    clearConsumerInvocations();
+    restoreConsumer.seek(TOPIC_PARTITION1, 10L);
+
+    // then:
+    verify(wrapped).seek(TOPIC_PARTITION1, 123L);
+    verifyNoMoreInteractions(wrapped);
+  }
+
+  @Test
+  public void shouldApplyFloorOnSeekWithMetadata() {
+    // when:
+    restoreConsumer.assign(List.of(TOPIC_PARTITION1));
+    clearConsumerInvocations();
+    restoreConsumer.seek(TOPIC_PARTITION1, new OffsetAndMetadata(10L, "bla"));
+
+    // then:
+    verify(wrapped).seek(TOPIC_PARTITION1, new OffsetAndMetadata(123L, "bla"));
+    verifyNoMoreInteractions(wrapped);
+  }
+
+  @Test
+  public void shouldApplyFloorOnSeekToBeginning() {
+    // when:
+    restoreConsumer.assign(List.of(TOPIC_PARTITION1));
+    clearConsumerInvocations();
+    restoreConsumer.seekToBeginning(List.of(TOPIC_PARTITION1));
+
+    // then:
+    verify(wrapped).seek(TOPIC_PARTITION1, 123L);
+    verifyNoMoreInteractions(wrapped);
+  }
+
+  @Test
+  public void shouldNotApplyFloorForPartitionWithNoCachedPosition() {
+    // when:
+    restoreConsumer.assign(List.of(TOPIC_PARTITION_NOT_CACHED));
+    clearConsumerInvocations();
+    restoreConsumer.seek(TOPIC_PARTITION_NOT_CACHED, 10L);
+
+    // then:
+    verify(wrapped).seek(TOPIC_PARTITION_NOT_CACHED, 10L);
+    verifyNoMoreInteractions(wrapped);
+  }
+
+  @Test
+  public void shouldNotApplyFloorOnSeekToBeginningForPartitionWithNoCachedPosition() {
+    // when:
+    restoreConsumer.assign(List.of(TOPIC_PARTITION_NOT_CACHED));
+    clearConsumerInvocations();
+    restoreConsumer.seekToBeginning(List.of(TOPIC_PARTITION_NOT_CACHED));
+
+    // then:
+    verify(wrapped).seekToBeginning(List.of(TOPIC_PARTITION_NOT_CACHED));
+    verifyNoMoreInteractions(wrapped);
+  }
+
+  @SuppressWarnings("unchecked")
+  private void clearConsumerInvocations() {
+    clearInvocations(wrapped);
+  }
+}

--- a/kafka-client/src/test/java/dev/responsive/kafka/store/CommitBufferTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/store/CommitBufferTest.java
@@ -21,6 +21,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.datastax.oss.driver.api.core.CqlSession;
@@ -102,7 +105,7 @@ public class CommitBufferTest {
     final String tableName = name;
     client.initializeOffset(tableName, 0);
     final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
-        client, tableName, changelogTp, supplier, admin, ResponsiveStore.PLUGIN);
+        client, tableName, changelogTp, supplier, admin, ResponsiveStore.PLUGIN, true);
 
     // When:
     for (int i = 0; i < CommitBuffer.MAX_BATCH_SIZE * 1.5; i++) {
@@ -117,13 +120,49 @@ public class CommitBufferTest {
   }
 
   @Test
+  public void shouldTruncateTopicAfterFlushIfTruncateEnabled() {
+    // Given:
+    final String tableName = name;
+    client.initializeOffset(tableName, 0);
+    final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
+        client, tableName, changelogTp, supplier, admin, ResponsiveStore.PLUGIN, true);
+    for (int i = 0; i < CommitBuffer.MAX_BATCH_SIZE * 1.5; i++) {
+      buffer.put(KEY, VALUE);
+    }
+
+    // when:
+    buffer.flush();
+
+    // Then:
+    verify(admin).deleteRecords(any());
+  }
+
+  @Test
+  public void shouldNotTruncateTopicAfterFlushIfTruncateDisabled() {
+    // Given:
+    final String tableName = name;
+    client.initializeOffset(tableName, 0);
+    final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
+        client, tableName, changelogTp, supplier, admin, ResponsiveStore.PLUGIN, false);
+    for (int i = 0; i < CommitBuffer.MAX_BATCH_SIZE * 1.5; i++) {
+      buffer.put(KEY, VALUE);
+    }
+
+    // when:
+    buffer.flush();
+
+    // Then:
+    verifyNoInteractions(admin);
+  }
+
+  @Test
   public void shouldDeleteRowInCassandraWithTombstone() {
     // Given:
     final String table = name;
     client.initializeOffset(table, 0);
     client.insertData(table, 0, KEY, VALUE);
     final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
-        client, table, changelogTp, supplier, admin, ResponsiveStore.PLUGIN);
+        client, table, changelogTp, supplier, admin, ResponsiveStore.PLUGIN, true);
 
     // When:
     buffer.tombstone(Bytes.wrap(new byte[]{1}));
@@ -141,7 +180,7 @@ public class CommitBufferTest {
     client.initializeOffset(tableName, 0);
     client.execute(client.revokePermit(tableName, 0, 101));
     final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
-        client, tableName, changelogTp, supplier, admin, ResponsiveStore.PLUGIN);
+        client, tableName, changelogTp, supplier, admin, ResponsiveStore.PLUGIN, true);
 
     // Expect
     // When:
@@ -158,7 +197,7 @@ public class CommitBufferTest {
     client.initializeOffset(tableName, 0);
     client.execute(client.acquirePermit(tableName, 0, UNSET_PERMIT, UUID.randomUUID(), 1));
     final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
-        client, tableName, changelogTp, supplier, admin, ResponsiveStore.PLUGIN);
+        client, tableName, changelogTp, supplier, admin, ResponsiveStore.PLUGIN, true);
 
     // Expect
     // When:
@@ -175,7 +214,7 @@ public class CommitBufferTest {
     client.initializeOffset(tableName, 0);
     client.execute(client.revokePermit(tableName, 0, 100));
     final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
-        client, tableName, changelogTp, supplier, admin, ResponsiveStore.PLUGIN);
+        client, tableName, changelogTp, supplier, admin, ResponsiveStore.PLUGIN, true);
 
     // Expect
     // When:
@@ -192,7 +231,7 @@ public class CommitBufferTest {
     client.initializeOffset(tableName, 0);
     client.execute(client.revokePermit(tableName, 0, 100));
     final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
-        client, tableName, changelogTp, supplier, admin, ResponsiveStore.PLUGIN);
+        client, tableName, changelogTp, supplier, admin, ResponsiveStore.PLUGIN, true);
 
     final ConsumerRecord<byte[], byte[]> ignored = new ConsumerRecord<>(
         changelogTp.topic(), changelogTp.partition(), 100, new byte[]{1}, new byte[]{1});
@@ -214,7 +253,7 @@ public class CommitBufferTest {
     client.initializeOffset(tableName, 0);
     client.execute(client.revokePermit(tableName, 0, 100));
     final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
-        client, tableName, changelogTp, supplier, admin, ResponsiveStore.PLUGIN);
+        client, tableName, changelogTp, supplier, admin, ResponsiveStore.PLUGIN, true);
 
     final CountDownLatch latch1 = new CountDownLatch(0);
     final CountDownLatch latch2 = new CountDownLatch(0);

--- a/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsiveStoreRegistryTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsiveStoreRegistryTest.java
@@ -1,10 +1,8 @@
 package dev.responsive.kafka.store;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 
-import java.util.List;
 import java.util.OptionalLong;
 import org.apache.kafka.common.TopicPartition;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,14 +29,6 @@ class ResponsiveStoreRegistryTest {
   }
 
   @Test
-  public void shouldGetRegisteredStoreForChangelog() {
-    assertThat(
-        registry.getRegisteredStoresForChangelog(TOPIC_PARTITION),
-        is(List.of(REGISTRATION))
-    );
-  }
-
-  @Test
   public void shouldReturnEmptyCommittedOffsetFromNotRegisteredStore() {
     assertThat(
         registry.getCommittedOffset(new TopicPartition("foo", 1)),
@@ -52,10 +42,9 @@ class ResponsiveStoreRegistryTest {
     registry.deregisterStore(REGISTRATION);
 
     // when:
-    final List<ResponsiveStoreRegistration> registered
-        = registry.getRegisteredStoresForChangelog(TOPIC_PARTITION);
+    final OptionalLong offset = registry.getCommittedOffset(TOPIC_PARTITION);
 
     // then:
-    assertThat(registered, is(empty()));
+    assertThat(offset, is(OptionalLong.empty()));
   }
 }

--- a/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsiveStoreRestoreIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsiveStoreRestoreIntegrationTest.java
@@ -1,0 +1,478 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.kafka.store;
+
+import static dev.responsive.kafka.config.ResponsiveDriverConfig.STORAGE_DATACENTER_CONFIG;
+import static dev.responsive.kafka.config.ResponsiveDriverConfig.STORAGE_HOSTNAME_CONFIG;
+import static dev.responsive.kafka.config.ResponsiveDriverConfig.STORAGE_PORT_CONFIG;
+import static dev.responsive.kafka.config.ResponsiveDriverConfig.TENANT_ID_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.ISOLATION_LEVEL_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.TRANSACTION_TIMEOUT_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.APPLICATION_ID_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.BOOTSTRAP_SERVERS_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.COMMIT_INTERVAL_MS_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.EXACTLY_ONCE_V2;
+import static org.apache.kafka.streams.StreamsConfig.InternalConfig.INTERNAL_TASK_ASSIGNOR_CLASS;
+import static org.apache.kafka.streams.StreamsConfig.NUM_STREAM_THREADS_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.OPTIMIZE;
+import static org.apache.kafka.streams.StreamsConfig.PROCESSING_GUARANTEE_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.consumerPrefix;
+import static org.apache.kafka.streams.StreamsConfig.producerPrefix;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.lessThan;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.spy;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.cql.BatchStatement;
+import com.datastax.oss.driver.api.core.cql.Statement;
+import dev.responsive.db.CassandraClient;
+import dev.responsive.kafka.api.CassandraClientFactory;
+import dev.responsive.kafka.api.DefaultCassandraClientFactory;
+import dev.responsive.kafka.api.ResponsiveKafkaStreams;
+import dev.responsive.kafka.api.ResponsiveStores;
+import dev.responsive.kafka.config.ResponsiveDriverConfig;
+import dev.responsive.utils.ContainerExtension;
+import dev.responsive.utils.IntegrationTestUtils;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import java.util.stream.LongStream;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.admin.OffsetSpec;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.IsolationLevel;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.config.TopicConfig;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.LongDeserializer;
+import org.apache.kafka.common.serialization.LongSerializer;
+import org.apache.kafka.common.serialization.Serdes.LongSerde;
+import org.apache.kafka.streams.KafkaClientSupplier;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier;
+import org.apache.kafka.streams.processor.internals.assignment.StickyTaskAssignor;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.testcontainers.containers.CassandraContainer;
+import org.testcontainers.containers.KafkaContainer;
+
+@ExtendWith(ContainerExtension.class)
+public class ResponsiveStoreRestoreIntegrationTest {
+
+  private static final int MAX_POLL_MS = 5000;
+  private static final String INPUT_TOPIC = "input";
+  private static final String INPUT_TBL_TOPIC = "input_tbl";
+  private static final String OUTPUT_TOPIC = "output";
+  private static final String OUTPUT_JOINED = "output_join";
+
+  private final Map<String, Object> responsiveProps = new HashMap<>();
+
+  private String name;
+  private String bootstrapServers;
+  private Admin admin;
+
+  @BeforeEach
+  public void before(
+      final TestInfo info,
+      final CassandraContainer<?> cassandra,
+      final KafkaContainer kafka
+  ) {
+    name = info.getTestMethod().orElseThrow().getName();
+    bootstrapServers = kafka.getBootstrapServers();
+
+    responsiveProps.put(STORAGE_HOSTNAME_CONFIG, cassandra.getContactPoint().getHostName());
+    responsiveProps.put(STORAGE_PORT_CONFIG, cassandra.getContactPoint().getPort());
+    responsiveProps.put(STORAGE_DATACENTER_CONFIG, cassandra.getLocalDatacenter());
+    responsiveProps.put(TENANT_ID_CONFIG, "responsive_clients");   // keyspace is expected to exist
+    responsiveProps.put(INTERNAL_TASK_ASSIGNOR_CLASS, StickyTaskAssignor.class.getName());
+
+    admin = Admin.create(Map.of(BOOTSTRAP_SERVERS_CONFIG, bootstrapServers));
+    admin.createTopics(
+        List.of(
+            new NewTopic(INPUT_TOPIC, Optional.of(1), Optional.empty()),
+            new NewTopic(INPUT_TBL_TOPIC, Optional.of(1), Optional.empty())
+                .configs(Map.of(
+                    TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT)),
+            new NewTopic(OUTPUT_TOPIC, Optional.of(1), Optional.empty()),
+            new NewTopic(OUTPUT_JOINED, Optional.of(1), Optional.empty())
+        )
+    );
+  }
+
+  @AfterEach
+  public void after() {
+    admin.deleteTopics(List.of(INPUT_TOPIC, INPUT_TBL_TOPIC, OUTPUT_TOPIC, OUTPUT_JOINED));
+    admin.close();
+  }
+
+  @Test
+  public void shouldRestoreUnflushedChangelog() throws Exception {
+    final Map<String, Object> properties = getMutableProperties();
+    final KafkaProducer<Long, Long> producer = new KafkaProducer<>(properties);
+    final KafkaClientSupplier defaultClientSupplier = new DefaultKafkaClientSupplier();
+    final CassandraClientFactory defaultFactory = new DefaultCassandraClientFactory();
+    final TopicPartition inputTbl = new TopicPartition(INPUT_TBL_TOPIC, 0);
+    final TopicPartition input = new TopicPartition(INPUT_TOPIC, 0);
+
+    try (final ResponsiveKafkaStreams streams
+             = buildAggregatorApp(properties, defaultClientSupplier, defaultFactory)) {
+      IntegrationTestUtils.startAppAndAwaitRunning(Duration.ofSeconds(10), streams);
+      // Send some data through
+      pipeInput(producer, INPUT_TBL_TOPIC, System::currentTimeMillis, 0, 10, 0, 1, 2, 3);
+      waitTillFullyConsumed(inputTbl, Duration.ofSeconds(120));
+      pipeInput(producer, INPUT_TOPIC, System::currentTimeMillis, 0, 10, 0);
+      // Wait for it to be processed
+      waitTillFullyConsumed(input, Duration.ofSeconds(120));
+    }
+
+    // restart with fault injecting cassandra client
+    final FaultInjectingCassandraClientSupplier cassandraFaultInjector
+        = new FaultInjectingCassandraClientSupplier();
+    try (final ResponsiveKafkaStreams streams
+             = buildAggregatorApp(properties, defaultClientSupplier, cassandraFaultInjector)) {
+      IntegrationTestUtils.startAppAndAwaitRunning(Duration.ofSeconds(10), streams);
+
+      // Inject a fault into cassandra client so it fails the next flush
+      final Fault fault = new Fault(new RuntimeException("oops"));
+      cassandraFaultInjector.fault.set(fault);
+
+      // Send some more data through and wait for it to be committed
+      final long endInput = endOffset(input);
+      pipeInput(producer, INPUT_TOPIC, System::currentTimeMillis, 10, 20, 0);
+      producer.flush();
+      waitTillConsumedPast(input, endInput + 1, Duration.ofSeconds(30));
+    }
+
+    // Make sure changelog is ahead of cassandra
+    final CassandraClient cassandraClient = defaultFactory.createCassandraClient(
+        defaultFactory.createCqlSession(new ResponsiveDriverConfig(properties))
+    );
+    final long cassandraOffset = cassandraClient.getOffset("testagg", 0).offset;
+    assertThat(cassandraOffset, greaterThan(0L));
+    final TopicPartition outputTp = new TopicPartition(OUTPUT_TOPIC, 0);
+    final long changelogOffset = admin.listOffsets(Map.of(outputTp, OffsetSpec.latest())).all()
+        .get()
+        .get(outputTp)
+        .offset();
+    assertThat(cassandraOffset, lessThan(changelogOffset));
+
+    // Restart with restore recorder
+    final TestKafkaClientSupplier recordingClientSupplier = new TestKafkaClientSupplier();
+    try (final ResponsiveKafkaStreams streams
+             = buildAggregatorApp(properties, recordingClientSupplier, defaultFactory)) {
+      IntegrationTestUtils.startAppAndAwaitRunning(Duration.ofSeconds(30), streams);
+      // Send some more data through and check output
+      pipeInput(producer, INPUT_TOPIC, System::currentTimeMillis, 20, 30, 0);
+      producer.flush();
+      waitTillFullyConsumed(input, Duration.ofSeconds(120));
+    }
+
+    // Assert that the final aggregation result is correct
+    final Optional<ConsumerRecord<Long, Long>> lastRecord = readLastOutputRecord(properties);
+    assertThat(lastRecord.isPresent(), is(true));
+    assertThat(lastRecord.get().key(), is(0L));
+    assertThat(lastRecord.get().value(), is(LongStream.range(0, 30).sum()));
+    final TopicPartition changelog = new TopicPartition(name + "-testagg-changelog", 0);
+    assertThat(recordingClientSupplier.restoreRecords.keySet(), hasItem(changelog));
+    assertThat(recordingClientSupplier.restoreRecords.get(changelog), not(empty()));
+    // Assert that we never restored from an offset earlier than committed to Cassandra
+    for (final ConsumerRecord<?, ?> r :  recordingClientSupplier.restoreRecords.get(changelog)) {
+      assertThat(r.offset(), greaterThanOrEqualTo(cassandraOffset));
+    }
+    // Assert that our source table is never truncated and the changelog table is
+    assertThat(firstOffset(inputTbl), is(0L));
+    assertThat(firstOffset(changelog), greaterThan(0L));
+  }
+
+  private Optional<ConsumerRecord<Long, Long>> readLastOutputRecord(
+      final Map<String, Object> properties
+  ) {
+    final List<ConsumerRecord<Long, Long>> all
+        = slurpPartition(new TopicPartition(OUTPUT_TOPIC, 0), properties);
+    return all.size() == 0 ? Optional.empty() : Optional.of(all.get(all.size() - 1));
+  }
+
+  private List<ConsumerRecord<Long, Long>> slurpPartition(
+      final TopicPartition partition,
+      final Map<String, Object> originals
+  ) {
+    final Map<String, Object> properties = new HashMap<>(originals);
+    properties.put(
+        ISOLATION_LEVEL_CONFIG,
+        IsolationLevel.READ_COMMITTED.name().toLowerCase(Locale.ROOT)
+    );
+    final List<ConsumerRecord<Long, Long>> allRecords = new LinkedList<>();
+    try (final KafkaConsumer<Long, Long> consumer = new KafkaConsumer<>(properties)) {
+      final long end = consumer.endOffsets(List.of(partition)).get(partition);
+      consumer.assign(List.of(partition));
+      consumer.seekToBeginning(List.of(partition));
+
+      while (consumer.position(partition) < end) {
+        final ConsumerRecords<Long, Long> records = consumer.poll(Duration.ofSeconds(30));
+        allRecords.addAll(records.records(partition));
+      }
+      return allRecords;
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private ResponsiveKafkaStreams buildAggregatorApp(
+      final Map<String, Object> originals,
+      final KafkaClientSupplier clientSupplier,
+      final CassandraClientFactory cassandraClientFactory
+  ) {
+    final Map<String, Object> properties = new HashMap<>(originals);
+
+    final StreamsBuilder builder = new StreamsBuilder();
+
+    final KStream<Long, Long> input = builder.stream(INPUT_TOPIC);
+    final KTable<Long, Long> inputTbl = builder.table(
+        INPUT_TBL_TOPIC,
+        Materialized.as(ResponsiveStores.keyValueStore("inputTbl"))
+    );
+    input
+        .groupByKey()
+        .aggregate(
+            () -> 0L,
+            (k, v, va) -> v + va,
+            (Materialized) Materialized.as(ResponsiveStores.keyValueStore("testagg"))
+                .withLoggingEnabled(
+                    Map.of(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_DELETE)))
+        .toStream()
+        .to(OUTPUT_TOPIC);
+    input.join(inputTbl, Long::sum);
+
+    final Properties builderProperties = new Properties();
+    builderProperties.putAll(properties);
+    return ResponsiveKafkaStreams.create(
+        builder.build(builderProperties),
+        properties,
+        clientSupplier,
+        cassandraClientFactory
+    );
+  }
+
+  private static class Fault {
+    final RuntimeException exception;
+
+    private Fault(final RuntimeException exception) {
+      this.exception = exception;
+    }
+
+    private void fire() {
+      throw exception;
+    }
+  }
+
+  private static class FaultInjectingCassandraClientSupplier implements CassandraClientFactory {
+    private final CassandraClientFactory wrappedFactory = new DefaultCassandraClientFactory();
+    private final AtomicReference<Fault> fault = new AtomicReference<>(null);
+
+    @Override
+    public CqlSession createCqlSession(ResponsiveDriverConfig config) {
+      final CqlSession wrapped = wrappedFactory.createCqlSession(config);
+      final var spy = spy(wrapped);
+      doAnswer(a -> {
+        final Fault fault = this.fault.get();
+        if (fault != null && a.getArgument(0) instanceof BatchStatement) {
+          fault.fire();
+        }
+        return wrapped.execute((Statement<?>) a.getArgument(0));
+      }).when(spy).execute(any(Statement.class));
+      return spy;
+    }
+
+    @Override
+    public CassandraClient createCassandraClient(CqlSession session) {
+      return wrappedFactory.createCassandraClient(session);
+    }
+  }
+
+  private static class TestKafkaClientSupplier extends DefaultKafkaClientSupplier {
+    private final Map<TopicPartition, Collection<ConsumerRecord<byte[], byte[]>>> restoreRecords
+        = new ConcurrentHashMap<>();
+
+    @Override
+    public Consumer<byte[], byte[]> getRestoreConsumer(final Map<String, Object> config) {
+      return new RestoreRecordRecordingConsumer(config, restoreRecords);
+    }
+  }
+
+  private static class RestoreRecordRecordingConsumer extends KafkaConsumer<byte[], byte[]> {
+    private final Map<TopicPartition, Collection<ConsumerRecord<byte[], byte[]>>> recorded;
+
+    public RestoreRecordRecordingConsumer(
+        final Map<String, Object> configs,
+        final Map<TopicPartition, Collection<ConsumerRecord<byte[], byte[]>>> recorded
+    ) {
+      super(configs, new ByteArrayDeserializer(), new ByteArrayDeserializer());
+      this.recorded = recorded;
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    public ConsumerRecords<byte[], byte[]> poll(long timeoutMs) {
+      return record(super.poll(timeoutMs));
+    }
+
+    @Override
+    public ConsumerRecords<byte[], byte[]> poll(Duration timeout) {
+      return record(super.poll(timeout));
+    }
+
+    public ConsumerRecords<byte[], byte[]> record(final ConsumerRecords<byte[], byte[]> records) {
+      for (final var p : records.partitions()) {
+        recorded.computeIfAbsent(p, k -> new ConcurrentLinkedQueue<>()).addAll(records.records(p));
+      }
+      return records;
+    }
+  }
+
+  private Map<String, Object> getMutableProperties() {
+    final Map<String, Object> properties = new HashMap<>(responsiveProps);
+
+    properties.put(BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+    properties.put(KEY_SERIALIZER_CLASS_CONFIG, LongSerializer.class);
+    properties.put(VALUE_SERIALIZER_CLASS_CONFIG, LongSerializer.class);
+    properties.put(KEY_DESERIALIZER_CLASS_CONFIG, LongDeserializer.class);
+    properties.put(VALUE_DESERIALIZER_CLASS_CONFIG, LongDeserializer.class);
+
+    properties.put(APPLICATION_ID_CONFIG, name);
+    properties.put(DEFAULT_KEY_SERDE_CLASS_CONFIG, LongSerde.class.getName());
+    properties.put(DEFAULT_VALUE_SERDE_CLASS_CONFIG, LongSerde.class.getName());
+    properties.put(PROCESSING_GUARANTEE_CONFIG, EXACTLY_ONCE_V2);
+    properties.put(NUM_STREAM_THREADS_CONFIG, 1);
+
+    properties.put(COMMIT_INTERVAL_MS_CONFIG, 0);
+    properties.put(STATESTORE_CACHE_MAX_BYTES_CONFIG, 0);
+    properties.put(producerPrefix(TRANSACTION_TIMEOUT_CONFIG), 20_000);
+
+    properties.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 1);
+    properties.put(consumerPrefix(ConsumerConfig.METADATA_MAX_AGE_CONFIG), "1000");
+    properties.put(consumerPrefix(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG), "earliest");
+    properties.put(consumerPrefix(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG), MAX_POLL_MS);
+    properties.put(consumerPrefix(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG), MAX_POLL_MS);
+    properties.put(consumerPrefix(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG), MAX_POLL_MS - 1);
+
+    return properties;
+  }
+
+  private void pipeInput(
+      final KafkaProducer<Long, Long> producer,
+      final String input,
+      final Supplier<Long> timestamp,
+      final long valFrom,
+      final long valTo,
+      final long... keys
+  ) {
+    for (final long k : keys) {
+      for (long v = valFrom; v < valTo; v++) {
+        producer.send(new ProducerRecord<>(
+            input,
+            0,
+            timestamp.get(),
+            k,
+            v
+        ));
+      }
+    }
+  }
+
+  private long endOffset(final TopicPartition topic)
+      throws ExecutionException, InterruptedException {
+    return admin.listOffsets(Map.of(topic, OffsetSpec.latest())).all().get()
+        .get(topic)
+        .offset();
+  }
+
+  private long firstOffset(final TopicPartition topic)
+      throws ExecutionException, InterruptedException {
+    return admin.listOffsets(Map.of(topic, OffsetSpec.earliest())).all().get()
+        .get(topic)
+        .offset();
+  }
+
+  private void waitTillFullyConsumed(
+      final TopicPartition partition,
+      final Duration timeout
+  ) throws ExecutionException, InterruptedException, TimeoutException {
+    waitTillConsumedPast(partition, endOffset(partition), timeout);
+  }
+
+  private void waitTillConsumedPast(
+      final TopicPartition partition,
+      final long offset,
+      final Duration timeout
+  ) throws ExecutionException, InterruptedException, TimeoutException {
+    final Instant start = Instant.now();
+    while (Instant.now().isBefore(start.plus(timeout))) {
+      final Map<String, Map<TopicPartition, OffsetAndMetadata>> listing
+          = admin.listConsumerGroupOffsets(name).all().get();
+      if (listing.get(name).containsKey(partition)) {
+        final long committed = listing.get(name).get(partition).offset();
+        if (committed >= offset) {
+          return;
+        }
+      }
+      Thread.sleep(1000);
+    }
+    throw new TimeoutException("timed out waiting for app to fully consume input");
+  }
+}

--- a/kafka-client/src/test/java/dev/responsive/utils/IntegrationTestUtils.java
+++ b/kafka-client/src/test/java/dev/responsive/utils/IntegrationTestUtils.java
@@ -1,0 +1,64 @@
+package dev.responsive.utils;
+
+import dev.responsive.kafka.api.ResponsiveKafkaStreams;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KafkaStreams.State;
+import org.apache.kafka.streams.KafkaStreams.StateListener;
+
+public final class IntegrationTestUtils {
+  private IntegrationTestUtils() {
+  }
+
+  public static void startAppAndAwaitRunning(
+      final Duration timeout,
+      final ResponsiveKafkaStreams... streams
+  ) throws Exception {
+    final ReentrantLock lock = new ReentrantLock();
+    final Condition onRunning = lock.newCondition();
+    final AtomicBoolean[] running = new AtomicBoolean[streams.length];
+
+    for (int i = 0; i < streams.length; i++) {
+      running[i] = new AtomicBoolean(false);
+      final int idx = i;
+      final StateListener oldListener = streams[i].stateListener();
+      final StateListener listener = (newState, oldState) -> {
+        if (oldListener != null) {
+          oldListener.onChange(newState, oldState);
+        }
+
+        lock.lock();
+        try {
+          running[idx].set(newState == State.RUNNING);
+          onRunning.signalAll();
+        } finally {
+          lock.unlock();
+        }
+      };
+      streams[i].setStateListener(listener);
+    }
+
+    for (final KafkaStreams stream : streams) {
+      stream.start();
+    }
+
+    final long end = System.nanoTime() + timeout.toNanos();
+    lock.lock();
+    try {
+      while (Arrays.stream(running).anyMatch(b -> !b.get())) {
+        if (System.nanoTime() > end
+            || !onRunning.await(end - System.nanoTime(), TimeUnit.NANOSECONDS)) {
+          throw new TimeoutException("Not all streams were running after " + timeout);
+        }
+      }
+    } finally {
+      lock.unlock();
+    }
+  }
+}

--- a/kafka-client/src/test/java/dev/responsive/utils/StoreUtilTest.java
+++ b/kafka-client/src/test/java/dev/responsive/utils/StoreUtilTest.java
@@ -1,13 +1,40 @@
 package dev.responsive.utils;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import dev.responsive.kafka.api.InternalConfigs;
+import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.Config;
+import org.apache.kafka.clients.admin.ConfigEntry;
+import org.apache.kafka.clients.admin.DescribeConfigsResult;
+import org.apache.kafka.common.config.ConfigResource;
+import org.apache.kafka.common.config.ConfigResource.Type;
+import org.apache.kafka.common.config.TopicConfig;
+import org.apache.kafka.common.internals.KafkaFutureImpl;
+import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.TopologyDescription;
+import org.apache.kafka.streams.kstream.KGroupedStream;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KTable;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 class StoreUtilTest {
+  @Mock
+  private Admin admin;
 
   @Test
   public void shouldThrowOnEnableAllOptimizations() {
@@ -39,5 +66,91 @@ class StoreUtilTest {
         StreamsConfig.APPLICATION_ID_CONFIG, "foo",
         CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "foo.bar")
     );
+  }
+
+  @Test
+  public void shouldNotTruncateChangelogIfCompacted() {
+    // given:
+    givenTopicCleanupPolicy("compacted-changelog", TopicConfig.CLEANUP_POLICY_COMPACT);
+    final TopologyDescription description = givenTopologyWithTableSource("table-source");
+    final Map<String, Object> configs = new InternalConfigs.Builder()
+        .withTopologyDescription(description)
+        .build();
+
+    // when:
+    final boolean compact = StoreUtil.shouldTruncateChangelog(
+        "compacted-changelog",
+        admin,
+        configs
+    );
+
+    // then:
+    assertThat(compact, is(false));
+  }
+
+  @Test
+  public void shouldNotTruncateChanglogIfSource() {
+    // given:
+    givenTopicCleanupPolicy("table-source", TopicConfig.CLEANUP_POLICY_DELETE);
+    final TopologyDescription description = givenTopologyWithTableSource("table-source");
+    final Map<String, Object> configs = new InternalConfigs.Builder()
+        .withTopologyDescription(description)
+        .build();
+
+    // when:
+    final boolean compact = StoreUtil.shouldTruncateChangelog(
+        "table-source",
+        admin,
+        configs
+    );
+
+    // then:
+    assertThat(compact, is(false));
+  }
+
+  @Test
+  public void shouldTruncateChangelogIfSafe() {
+    // given:
+    givenTopicCleanupPolicy("changelog", TopicConfig.CLEANUP_POLICY_DELETE);
+    final TopologyDescription description = givenTopologyWithTableSource("table-source");
+    final Map<String, Object> configs = new InternalConfigs.Builder()
+        .withTopologyDescription(description)
+        .build();
+
+    // when:
+    final boolean compact = StoreUtil.shouldTruncateChangelog(
+        "changelog",
+        admin,
+        configs
+    );
+
+    // then:
+    assertThat(compact, is(true));
+  }
+
+  private void givenTopicCleanupPolicy(final String topic, final String policy) {
+    givenTopicConfig(topic, TopicConfig.CLEANUP_POLICY_CONFIG, policy);
+  }
+
+  private void givenTopicConfig(final String topic, final String config, final String value) {
+    final ConfigResource resource = new ConfigResource(Type.TOPIC, topic);
+    final KafkaFutureImpl<Map<ConfigResource, Config>> configFuture = new KafkaFutureImpl<>();
+    configFuture.complete(Map.of(resource, new Config(List.of(new ConfigEntry(config, value)))));
+    final DescribeConfigsResult result = mock(DescribeConfigsResult.class);
+    when(result.all()).thenReturn(configFuture);
+    when(admin.describeConfigs(List.of(new ConfigResource(Type.TOPIC, topic)))).thenReturn(result);
+  }
+
+  private TopologyDescription givenTopologyWithTableSource(final String tableSourceTopic) {
+    final StreamsBuilder builder = new StreamsBuilder();
+    final KStream<Long, Long> stream = builder.stream("stream-source");
+    final KTable<Long, Long> table = builder.table(tableSourceTopic);
+    stream.join(table, Long::sum);
+    final KGroupedStream<Long, Long> grouped = stream.groupBy((k, v) -> v);
+    grouped.count();
+    final Properties props = new Properties();
+    props.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.OPTIMIZE);
+    final Topology topology = builder.build(props);
+    return topology.describe();
   }
 }


### PR DESCRIPTION
optimize restore and support compacted changelogs

- When restoring, fetch the last committed offset from the remote
   store, and restore starting from that offset.
- Only truncate the changelog is the changelog topic is not a
      topology source, and is not compacted.