### PR TITLE
flush state stores on every commit

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveKafkaStreams.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveKafkaStreams.java
@@ -1,22 +1,13 @@
 package dev.responsive.kafka.api;
 
-import static dev.responsive.kafka.api.InternalConfigs.getConfigs;
-import static dev.responsive.kafka.config.ResponsiveDriverConfig.CLIENT_ID_CONFIG;
-import static dev.responsive.kafka.config.ResponsiveDriverConfig.CLIENT_SECRET_CONFIG;
 import static dev.responsive.kafka.config.ResponsiveDriverConfig.NUM_STANDBYS_OVERRIDE;
-import static dev.responsive.kafka.config.ResponsiveDriverConfig.STORAGE_DATACENTER_CONFIG;
-import static dev.responsive.kafka.config.ResponsiveDriverConfig.STORAGE_HOSTNAME_CONFIG;
-import static dev.responsive.kafka.config.ResponsiveDriverConfig.STORAGE_PORT_CONFIG;
 import static dev.responsive.kafka.config.ResponsiveDriverConfig.TASK_ASSIGNOR_CLASS_OVERRIDE;
-import static dev.responsive.kafka.config.ResponsiveDriverConfig.TENANT_ID_CONFIG;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import dev.responsive.db.CassandraClient;
 import dev.responsive.kafka.clients.ResponsiveKafkaClientSupplier;
 import dev.responsive.kafka.config.ResponsiveDriverConfig;
 import dev.responsive.kafka.store.ResponsiveStoreRegistry;
-import dev.responsive.utils.SessionUtil;
-import java.net.InetSocketAddress;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Properties;
@@ -24,7 +15,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.common.config.ConfigException;
-import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.streams.KafkaClientSupplier;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsConfig;
@@ -97,16 +87,6 @@ public class ResponsiveKafkaStreams extends KafkaStreams {
       final CassandraClientFactory cassandraClientFactory
   ) {
     final ResponsiveDriverConfig responsiveConfigs = new ResponsiveDriverConfig(configs);
-
-    final InetSocketAddress address = InetSocketAddress.createUnresolved(
-        responsiveConfigs.getString(STORAGE_HOSTNAME_CONFIG),
-        responsiveConfigs.getInt(STORAGE_PORT_CONFIG)
-    );
-
-    final String datacenter = responsiveConfigs.getString(STORAGE_DATACENTER_CONFIG);
-    final String clientId = responsiveConfigs.getString(CLIENT_ID_CONFIG);
-    final Password clientSecret = responsiveConfigs.getPassword(CLIENT_SECRET_CONFIG);
-    final String tenant = responsiveConfigs.getString(TENANT_ID_CONFIG);
 
     final CqlSession session = cassandraClientFactory.createCqlSession(responsiveConfigs);
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/clients/MetricPublishingCommitListener.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/clients/MetricPublishingCommitListener.java
@@ -72,7 +72,7 @@ public class MetricPublishingCommitListener implements ResponsiveConsumer.Listen
   ) {
     this.metrics = Objects.requireNonNull(metrics);
     this.threadId = Objects.requireNonNull(threadId);
-    offsetRecorder.addCommitCallback(this::onCommit);
+    offsetRecorder.addCommitCallback(this::commitCallback);
   }
 
   private MetricName metricName(final RecordingKey k) {
@@ -88,7 +88,7 @@ public class MetricPublishingCommitListener implements ResponsiveConsumer.Listen
     return new MetricName("committed-offset", "responsive.streams", "", tags);
   }
 
-  public void onCommit(
+  private void commitCallback(
       final Map<RecordingKey, Long> committedOffsets,
       final Map<TopicPartition, Long> unused
   ) {

--- a/kafka-client/src/main/java/dev/responsive/kafka/clients/MetricPublishingCommitListener.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/clients/MetricPublishingCommitListener.java
@@ -16,7 +16,7 @@
 
 package dev.responsive.kafka.clients;
 
-import dev.responsive.kafka.clients.ResponsiveProducer.RecordingKey;
+import dev.responsive.kafka.clients.OffsetRecorder.RecordingKey;
 import java.io.Closeable;
 import java.util.Collection;
 import java.util.HashMap;
@@ -41,8 +41,7 @@ import org.slf4j.LoggerFactory;
  *
  * Synchronization: All shared access goes through the "offsets" map.
  */
-public class MetricPublishingCommitListener
-    implements ResponsiveProducer.Listener, ResponsiveConsumer.Listener, Closeable {
+public class MetricPublishingCommitListener implements ResponsiveConsumer.Listener, Closeable {
   private static final Logger LOG = LoggerFactory.getLogger(MetricPublishingCommitListener.class);
   private final Metrics metrics;
   private final String threadId;
@@ -66,9 +65,14 @@ public class MetricPublishingCommitListener
     }
   }
 
-  public MetricPublishingCommitListener(final Metrics metrics, final String threadId) {
+  public MetricPublishingCommitListener(
+      final Metrics metrics,
+      final String threadId,
+      final OffsetRecorder offsetRecorder
+  ) {
     this.metrics = Objects.requireNonNull(metrics);
     this.threadId = Objects.requireNonNull(threadId);
+    offsetRecorder.addCommitCallback(this::onCommit);
   }
 
   private MetricName metricName(final RecordingKey k) {
@@ -84,8 +88,10 @@ public class MetricPublishingCommitListener
     return new MetricName("committed-offset", "responsive.streams", "", tags);
   }
 
-  @Override
-  public void onCommit(final Map<RecordingKey, Long> committedOffsets) {
+  public void onCommit(
+      final Map<RecordingKey, Long> committedOffsets,
+      final Map<TopicPartition, Long> unused
+  ) {
     for (final var e : committedOffsets.entrySet()) {
       offsets.computeIfPresent(
           e.getKey().getPartition(),
@@ -104,10 +110,6 @@ public class MetricPublishingCommitListener
           }
       );
     }
-  }
-
-  @Override
-  public void onClose() {
   }
 
   @Override

--- a/kafka-client/src/main/java/dev/responsive/kafka/clients/OffsetRecorder.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/clients/OffsetRecorder.java
@@ -1,0 +1,163 @@
+package dev.responsive.kafka.clients;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.TopicPartition;
+
+/**
+ * Record offsets written to kafka and committed to consumer groups. When a commit happens,
+ * notify listeners about the set of offsets.
+ *
+ * The callbacks here need to be synchronized. Almost all the callbacks happen on the stream
+ * thread. The lone exception is the Send callback, which happens on Producer I/O threads.
+ */
+class OffsetRecorder {
+  private final Map<RecordingKey, Long> uncommitted = new HashMap<>();
+  private final Map<TopicPartition, Long> written = new HashMap<>();
+  private final ProducerListener producerListener = new ProducerListener();
+  private final ConsumerListener consumerListener = new ConsumerListener();
+  private final List<CommitCallback> commitCallback = new LinkedList<>();
+  private final boolean eos;
+
+  OffsetRecorder(final boolean eos) {
+    this.eos = eos;
+  }
+
+  public synchronized void addCommitCallback(final CommitCallback callback) {
+    commitCallback.add(callback);
+  }
+
+  public synchronized void recordConsumedOffsets(
+      final String consumerGroup,
+      final TopicPartition partition,
+      final long offset
+  ) {
+    uncommitted.put(new RecordingKey(partition, consumerGroup), offset);
+  }
+
+  public synchronized void recordProduce(final RecordMetadata recordMetadata) {
+    final TopicPartition partition
+        = new TopicPartition(recordMetadata.topic(), recordMetadata.partition());
+    written.compute(
+        partition,
+        (k, v) -> v == null ? recordMetadata.offset() : Math.max(recordMetadata.offset(), v)
+    );
+  }
+
+  public synchronized void recordCommit() {
+    final Map<RecordingKey, Long> committedOffsets = Map.copyOf(uncommitted);
+    final Map<TopicPartition, Long> writtenOffsets = Map.copyOf(written);
+    commitCallback.forEach(c -> c.onCommit(committedOffsets, writtenOffsets));
+    uncommitted.clear();
+    written.clear();
+  }
+
+  public synchronized void recordAbort() {
+    uncommitted.clear();
+    written.clear();
+  }
+
+  public ResponsiveProducer.Listener getProducerListener() {
+    return producerListener;
+  }
+
+  public ResponsiveConsumer.Listener getConsumerListener() {
+    return consumerListener;
+  }
+
+  @FunctionalInterface
+  interface CommitCallback {
+    void onCommit(
+        final Map<RecordingKey, Long> committedOffsets,
+        final Map<TopicPartition, Long> lastWrittenOffsets
+    );
+  }
+
+  private class ConsumerListener implements ResponsiveConsumer.Listener {
+    @Override
+    public void onCommit(final Map<TopicPartition, OffsetAndMetadata> offsets) {
+      if (eos) {
+        throw new IllegalStateException("consumer commit is not expected with EOS");
+      }
+      offsets.forEach((p, o) -> recordConsumedOffsets("", p, o.offset()));
+      recordCommit();
+    }
+  }
+
+  private class ProducerListener implements ResponsiveProducer.Listener {
+    @Override
+    public void onSendOffsetsToTransaction(Map<TopicPartition, OffsetAndMetadata> offsets,
+                                           String consumerGroupId) {
+      if (!eos) {
+        throw new IllegalStateException("producer commit is not expected with alos");
+      }
+      offsets.forEach((p, o) -> recordConsumedOffsets(consumerGroupId, p, o.offset()));
+    }
+
+    @Override
+    public void onCommit() {
+      // TODO: throw if not eos
+      recordCommit();
+    }
+
+    @Override
+    public void onAbort() {
+      recordAbort();
+    }
+
+    @Override
+    public void onSendCompleted(final RecordMetadata recordMetadata) {
+      recordProduce(recordMetadata);
+    }
+  }
+
+  public static class RecordingKey {
+    private final TopicPartition partition;
+    private final String consumerGroup;
+
+    public RecordingKey(
+        final TopicPartition partition,
+        final String consumerGroup
+    ) {
+      this.partition = partition;
+      this.consumerGroup = consumerGroup;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      final RecordingKey that = (RecordingKey) o;
+      return Objects.equals(partition, that.partition)
+          && Objects.equals(consumerGroup, that.consumerGroup);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(partition, consumerGroup);
+    }
+
+    @Override
+    public String toString() {
+      return "RecordingKey{" + "partition=" + partition
+          + ", consumerGroup='" + consumerGroup + '\'' + '}';
+    }
+
+    public TopicPartition getPartition() {
+      return partition;
+    }
+
+    public String getConsumerGroup() {
+      return consumerGroup;
+    }
+  }
+}

--- a/kafka-client/src/main/java/dev/responsive/kafka/clients/ResponsiveConsumer.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/clients/ResponsiveConsumer.java
@@ -20,11 +20,14 @@ package dev.responsive.kafka.clients;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.regex.Pattern;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.OffsetCommitCallback;
 import org.apache.kafka.common.TopicPartition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -133,6 +136,45 @@ public class ResponsiveConsumer<K, V> extends DelegatingConsumer<K, V> {
     listeners.forEach(l -> ignoreException(l::onClose));
   }
 
+  @Override
+  public void commitSync() {
+    throw new UnsupportedOperationException("ResponsiveConsumer only supports commit with offsets");
+  }
+
+  @Override
+  public void commitSync(Duration timeout) {
+    throw new UnsupportedOperationException("ResponsiveConsumer only supports commit with offsets");
+  }
+
+  @Override
+  public void commitSync(Map<TopicPartition, OffsetAndMetadata> offsets) {
+    delegate.commitSync(offsets);
+    listeners.forEach(l -> l.onCommit(offsets));
+  }
+
+  @Override
+  public void commitSync(Map<TopicPartition, OffsetAndMetadata> offsets,
+                         Duration timeout) {
+    delegate.commitSync(offsets, timeout);
+    listeners.forEach(l -> l.onCommit(offsets));
+  }
+
+  @Override
+  public void commitAsync() {
+    throw new UnsupportedOperationException("ResponsiveConsumer only supports commit with offsets");
+  }
+
+  @Override
+  public void commitAsync(OffsetCommitCallback callback) {
+    throw new UnsupportedOperationException("ResponsiveConsumer only supports commit with offsets");
+  }
+
+  @Override
+  public void commitAsync(Map<TopicPartition, OffsetAndMetadata> offsets,
+                          OffsetCommitCallback callback) {
+    throw new UnsupportedOperationException("ResponsiveConsumer only supports commitSync");
+  }
+
   private void ignoreException(final Runnable r) {
     ignoreException(logger, r);
   }
@@ -153,6 +195,9 @@ public class ResponsiveConsumer<K, V> extends DelegatingConsumer<K, V> {
     }
 
     default void onPartitionsLost(Collection<TopicPartition> partitions) {
+    }
+
+    default void onCommit(final Map<TopicPartition, OffsetAndMetadata> offsets) {
     }
 
     default void onClose() {

--- a/kafka-client/src/main/java/dev/responsive/kafka/clients/ResponsiveKafkaClientSupplier.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/clients/ResponsiveKafkaClientSupplier.java
@@ -96,8 +96,8 @@ public final class ResponsiveKafkaClientSupplier implements KafkaClientSupplier 
   }
 
   @SuppressWarnings("deprecation")
-  private void verifyNotEosV1(final Map<String, ?> configs) {
-    if (EXACTLY_ONCE.equals(configs.get(StreamsConfig.PROCESSING_GUARANTEE_CONFIG))) {
+  private void verifyNotEosV1(final StreamsConfig streamsConfig) {
+    if (EXACTLY_ONCE.equals(streamsConfig.getString(StreamsConfig.PROCESSING_GUARANTEE_CONFIG))) {
       throw new IllegalStateException("Responsive driver can only be used with ALOS/EOS-V2");
     }
   }
@@ -109,8 +109,10 @@ public final class ResponsiveKafkaClientSupplier implements KafkaClientSupplier 
             .map(e -> e.getKey() + ":" + e.getValue())
             .collect(Collectors.joining("\n"))
     );
-    verifyNotEosV1(configs);
-    eos = !AT_LEAST_ONCE.equals(configs.get(StreamsConfig.PROCESSING_GUARANTEE_CONFIG));
+    final StreamsConfig streamsConfig = new StreamsConfig(configs);
+    verifyNotEosV1(streamsConfig);
+    eos = !(AT_LEAST_ONCE.equals(
+        streamsConfig.getString(StreamsConfig.PROCESSING_GUARANTEE_CONFIG)));
     final JmxReporter jmxReporter = new JmxReporter();
     jmxReporter.configure(configs);
     final MetricsContext metricsContext

--- a/kafka-client/src/main/java/dev/responsive/kafka/clients/ResponsiveKafkaClientSupplier.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/clients/ResponsiveKafkaClientSupplier.java
@@ -16,7 +16,8 @@
 
 package dev.responsive.kafka.clients;
 
-import static org.apache.kafka.streams.StreamsConfig.EXACTLY_ONCE_V2;
+import static org.apache.kafka.streams.StreamsConfig.AT_LEAST_ONCE;
+import static org.apache.kafka.streams.StreamsConfig.EXACTLY_ONCE;
 
 import dev.responsive.kafka.store.ResponsiveStoreRegistry;
 import java.io.Closeable;
@@ -62,11 +63,11 @@ public final class ResponsiveKafkaClientSupplier implements KafkaClientSupplier 
   private final KafkaClientSupplier wrapped;
   private final ResponsiveStoreRegistry storeRegistry;
   private final Factories factories;
-  private boolean eosV2 = false;
   private boolean configured = false;
   private Metrics metrics;
   private EndOffsetsPoller endOffsetsPoller;
   private String applicationId;
+  private boolean eos = false;
 
   public ResponsiveKafkaClientSupplier(
       final Map<String, ?> configs,
@@ -94,6 +95,12 @@ public final class ResponsiveKafkaClientSupplier implements KafkaClientSupplier 
     configure(configs);
   }
 
+  @SuppressWarnings("deprecation")
+  private void verifyNotEosV1(final Map<String, ?> configs) {
+    if (EXACTLY_ONCE.equals(configs.get(StreamsConfig.PROCESSING_GUARANTEE_CONFIG))) {
+      throw new IllegalStateException("Responsive driver can only be used with ALOS/EOS-V2");
+    }
+  }
 
   private void configure(final Map<String, ?> configs) {
     LOG.trace(
@@ -102,7 +109,8 @@ public final class ResponsiveKafkaClientSupplier implements KafkaClientSupplier 
             .map(e -> e.getKey() + ":" + e.getValue())
             .collect(Collectors.joining("\n"))
     );
-    eosV2 = EXACTLY_ONCE_V2.equals(configs.get(StreamsConfig.PROCESSING_GUARANTEE_CONFIG));
+    verifyNotEosV1(configs);
+    eos = !AT_LEAST_ONCE.equals(configs.get(StreamsConfig.PROCESSING_GUARANTEE_CONFIG));
     final JmxReporter jmxReporter = new JmxReporter();
     jmxReporter.configure(configs);
     final MetricsContext metricsContext
@@ -128,15 +136,14 @@ public final class ResponsiveKafkaClientSupplier implements KafkaClientSupplier 
     if (!configured) {
       throw new IllegalStateException("must be configured before supplying clients");
     }
-    if (!eosV2) {
-      return wrapped.getProducer(config);
-    }
     LOG.info("Creating responsive producer");
     final String tid = threadIdFromProducerConfig(config);
     final ListenersForThread tc = sharedListeners.getAndMaybeInitListenersForThread(
+        eos,
         tid,
         metrics,
         endOffsetsPoller,
+        storeRegistry,
         factories
     );
     return factories.createResponsiveProducer(
@@ -144,7 +151,7 @@ public final class ResponsiveKafkaClientSupplier implements KafkaClientSupplier 
         wrapped.getProducer(config),
         Collections.unmodifiableList(
             Arrays.asList(
-                tc.commitListener,
+                tc.offsetRecorder.getProducerListener(),
                 new CloseListener(tid)
             )
         )
@@ -156,15 +163,14 @@ public final class ResponsiveKafkaClientSupplier implements KafkaClientSupplier 
     if (!configured) {
       throw new IllegalStateException("must be configured before supplying clients");
     }
-    if (!eosV2) {
-      return wrapped.getConsumer(config);
-    }
     LOG.info("Creating responsive consumer");
     final String tid = threadIdFromConsumerConfig(config);
     final ListenersForThread tc = sharedListeners.getAndMaybeInitListenersForThread(
+        eos,
         tid,
         metrics,
         endOffsetsPoller,
+        storeRegistry,
         factories
     );
     // TODO: the end offsets poller call is kind of heavy for a synchronized block
@@ -172,7 +178,8 @@ public final class ResponsiveKafkaClientSupplier implements KafkaClientSupplier 
         (String) config.get(CommonClientConfigs.CLIENT_ID_CONFIG),
         wrapped.getConsumer(config),
         List.of(
-            tc.commitListener,
+            tc.committedOffsetMetricListener,
+            tc.offsetRecorder.getConsumerListener(),
             tc.endOffsetsPollerListener,
             new CloseListener(tid)
         )
@@ -240,9 +247,11 @@ public final class ResponsiveKafkaClientSupplier implements KafkaClientSupplier 
         = new HashMap<>();
 
     private synchronized ListenersForThread getAndMaybeInitListenersForThread(
+        final boolean eos,
         final String threadId,
         final Metrics metrics,
         final EndOffsetsPoller endOffsetsPoller,
+        final ResponsiveStoreRegistry storeRegistry,
         final Factories factories
     ) {
       if (threadListeners.containsKey(threadId)) {
@@ -250,11 +259,14 @@ public final class ResponsiveKafkaClientSupplier implements KafkaClientSupplier 
         tl.ref();
         return tl.getVal();
       }
+      final var offsetRecorder = factories.createOffsetRecorder(eos);
       final var tl = new ReferenceCounted<>(
           String.format("ListenersForThread(%s)", threadId),
           new ListenersForThread(
               threadId,
-              factories.createMetricsPublishingCommitListener(metrics, threadId),
+              offsetRecorder,
+              factories.createMetricsPublishingCommitListener(metrics, threadId, offsetRecorder),
+              new StoreCommitListener(storeRegistry, offsetRecorder),
               endOffsetsPoller.addForThread(threadId)
           )
       );
@@ -271,20 +283,26 @@ public final class ResponsiveKafkaClientSupplier implements KafkaClientSupplier 
 
   private static class ListenersForThread implements Closeable {
     final String threadId;
-    final MetricPublishingCommitListener commitListener;
+    final OffsetRecorder offsetRecorder;
+    final MetricPublishingCommitListener committedOffsetMetricListener;
+    final StoreCommitListener storeCommitListener;
     final EndOffsetsPoller.Listener endOffsetsPollerListener;
 
     public ListenersForThread(
         final String threadId,
-        final MetricPublishingCommitListener commitListener,
+        final OffsetRecorder offsetRecorder,
+        final MetricPublishingCommitListener committedOffsetMetricListener,
+        final StoreCommitListener storeCommitListener,
         final EndOffsetsPoller.Listener endOffsetsPollerListener) {
       this.threadId = threadId;
-      this.commitListener = commitListener;
+      this.offsetRecorder = offsetRecorder;
+      this.committedOffsetMetricListener = committedOffsetMetricListener;
+      this.storeCommitListener = storeCommitListener;
       this.endOffsetsPollerListener = endOffsetsPollerListener;
     }
 
     public void close() {
-      commitListener.close();
+      committedOffsetMetricListener.close();
       endOffsetsPollerListener.close();
     }
   }
@@ -357,11 +375,16 @@ public final class ResponsiveKafkaClientSupplier implements KafkaClientSupplier 
       return new ResponsiveConsumer<>(clientId, wrapped, listeners);
     }
 
+    default OffsetRecorder createOffsetRecorder(boolean eos) {
+      return new OffsetRecorder(eos);
+    }
+
     default MetricPublishingCommitListener createMetricsPublishingCommitListener(
         final Metrics metrics,
-        final String threadId
+        final String threadId,
+        final OffsetRecorder offsetRecorder
     ) {
-      return new MetricPublishingCommitListener(metrics, threadId);
+      return new MetricPublishingCommitListener(metrics, threadId, offsetRecorder);
     }
   }
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/clients/StoreCommitListener.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/clients/StoreCommitListener.java
@@ -1,0 +1,42 @@
+package dev.responsive.kafka.clients;
+
+import dev.responsive.kafka.clients.OffsetRecorder.RecordingKey;
+import dev.responsive.kafka.store.ResponsiveStoreRegistration;
+import dev.responsive.kafka.store.ResponsiveStoreRegistry;
+import java.util.Map;
+import java.util.Objects;
+import org.apache.kafka.common.TopicPartition;
+
+public class StoreCommitListener {
+  private final ResponsiveStoreRegistry storeRegistry;
+
+  public StoreCommitListener(
+      final ResponsiveStoreRegistry storeRegistry,
+      final OffsetRecorder offsetRecorder
+  ) {
+    this.storeRegistry = Objects.requireNonNull(storeRegistry);
+    offsetRecorder.addCommitCallback(this::onCommit);
+  }
+
+  private void onCommit(
+      final Map<RecordingKey, Long> committedOffsets,
+      final Map<TopicPartition, Long> writtenOffsets
+  ) {
+    // TODO: this is kind of inefficient (iterates over stores a lot). Not a huge deal
+    //       as we only run this on each commit. Can fix by indexing stores in registry
+    for (final var e : committedOffsets.entrySet()) {
+      final TopicPartition p = e.getKey().getPartition();
+      for (final ResponsiveStoreRegistration storeRegistration
+          : storeRegistry.getRegisteredStoresForChangelog(p)) {
+        storeRegistration.getOnCommit().accept(e.getValue());
+      }
+    }
+    for (final var e : writtenOffsets.entrySet()) {
+      final TopicPartition p = e.getKey();
+      for (final ResponsiveStoreRegistration storeRegistration
+          : storeRegistry.getRegisteredStoresForChangelog(p)) {
+        storeRegistration.getOnCommit().accept(e.getValue());
+      }
+    }
+  }
+}

--- a/kafka-client/src/main/java/dev/responsive/kafka/config/ResponsiveDriverConfig.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/config/ResponsiveDriverConfig.java
@@ -65,8 +65,8 @@ public class ResponsiveDriverConfig extends AbstractConfig {
   //       transaction sizes.
   public static final String STORE_FLUSH_RECORDS_THRESHOLD
       = "responsive.store.flush.records.interval";
-  public static final String STORE_FLUSH_RECORDS_THRESHOLD_DOC = "The number of records to" +
-      " accumulate in each store before flushing to remote";
+  public static final String STORE_FLUSH_RECORDS_THRESHOLD_DOC = "The number of records to"
+      + " accumulate in each store before flushing to remote";
   public static final int STORE_FLUSH_RECORDS_THRESHOLD_DEFAULT = 10000;
 
   // ------------------ request configurations --------------------------------

--- a/kafka-client/src/main/java/dev/responsive/kafka/config/ResponsiveDriverConfig.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/config/ResponsiveDriverConfig.java
@@ -57,6 +57,18 @@ public class ResponsiveDriverConfig extends AbstractConfig {
   public static final String CLIENT_SECRET_CONFIG = "responsive.client.secret";
   private static final String CLIENT_SECRET_DOC = "The client secret for authenticated access";
 
+  // ------------------ store tuning parameters -------------------------------
+
+  // TODO: we should have another config that's applied globally, that sets a size bound on
+  //       the total amount of buffered data. That config can be used to keep a bound on
+  //       memory usage and restore times. This config sets a store-level threshold for optimal
+  //       transaction sizes.
+  public static final String STORE_FLUSH_RECORDS_THRESHOLD
+      = "responsive.store.flush.records.interval";
+  public static final String STORE_FLUSH_RECORDS_THRESHOLD_DOC = "The number of records to" +
+      " accumulate in each store before flushing to remote";
+  public static final int STORE_FLUSH_RECORDS_THRESHOLD_DEFAULT = 10000;
+
   // ------------------ request configurations --------------------------------
 
   public static final String REQUEST_TIMEOUT_MS_CONFIG = "responsive.request.timeout.ms";
@@ -123,6 +135,12 @@ public class ResponsiveDriverConfig extends AbstractConfig {
           REQUEST_TIMEOUT_MS_DEFAULT,
           Importance.MEDIUM,
           REQUEST_TIMEOUT_MS_DOC
+      ).define(
+          STORE_FLUSH_RECORDS_THRESHOLD,
+          Type.INT,
+          STORE_FLUSH_RECORDS_THRESHOLD_DEFAULT,
+          Importance.MEDIUM,
+          STORE_FLUSH_RECORDS_THRESHOLD_DOC
       );
 
   private static class NonEmptyPassword implements Validator {

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsivePartitionedStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsivePartitionedStore.java
@@ -120,7 +120,6 @@ public class ResponsivePartitionedStore implements KeyValueStore<Bytes, byte[]> 
           client,
           name.cassandraName(),
           topicPartition,
-          asRecordCollector(context),
           sharedClients.admin,
           PLUGIN,
           StoreUtil.shouldTruncateChangelog(
@@ -137,7 +136,8 @@ public class ResponsivePartitionedStore implements KeyValueStore<Bytes, byte[]> 
       registration = new ResponsiveStoreRegistration(
           name.kafkaName(),
           topicPartition,
-          offset == -1 ? 0 : offset
+          offset == -1 ? 0 : offset,
+          buffer::flush
       );
       storeRegistry = InternalConfigs.loadStoreRegistry(context.appConfigs());
       storeRegistry.registerStore(registration);
@@ -146,8 +146,8 @@ public class ResponsivePartitionedStore implements KeyValueStore<Bytes, byte[]> 
     }
   }
 
-  private Supplier asRecordCollector(final StateStoreContext context) {
-    return ((RecordCollector.Supplier) context);
+  @Override
+  public void flush() {
   }
 
   @Override
@@ -239,11 +239,6 @@ public class ResponsivePartitionedStore implements KeyValueStore<Bytes, byte[]> 
   @Override
   public long approximateNumEntries() {
     return client.count(name.cassandraName(), partition);
-  }
-
-  @Override
-  public void flush() {
-    buffer.flush();
   }
 
   @Override

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsivePartitionedStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsivePartitionedStore.java
@@ -23,6 +23,7 @@ import com.datastax.oss.driver.api.core.cql.BoundStatement;
 import dev.responsive.db.CassandraClient;
 import dev.responsive.kafka.api.InternalConfigs;
 import dev.responsive.kafka.clients.SharedClients;
+import dev.responsive.kafka.config.ResponsiveDriverConfig;
 import dev.responsive.model.Result;
 import dev.responsive.utils.RemoteMonitor;
 import dev.responsive.utils.StoreUtil;
@@ -98,6 +99,7 @@ public class ResponsivePartitionedStore implements KeyValueStore<Bytes, byte[]> 
     try {
       LOG.info("Initializing state store {}", name);
       StoreUtil.validateTopologyOptimizationConfig(context.appConfigs());
+      final ResponsiveDriverConfig driverConfig = new ResponsiveDriverConfig(context.appConfigs());
       this.context = asInternalProcessorContext(context);
       partition = context.taskId().partition();
 
@@ -126,7 +128,8 @@ public class ResponsivePartitionedStore implements KeyValueStore<Bytes, byte[]> 
               topicPartition.topic(),
               sharedClients.admin,
               context.appConfigs()
-          )
+          ),
+          driverConfig.getInt(ResponsiveDriverConfig.STORE_FLUSH_RECORDS_THRESHOLD)
       );
 
       open = true;

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveStoreRegistration.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveStoreRegistration.java
@@ -1,21 +1,27 @@
 package dev.responsive.kafka.store;
 
+import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting;
 import java.util.Objects;
+import java.util.function.Consumer;
 import org.apache.kafka.common.TopicPartition;
 
 public final class ResponsiveStoreRegistration {
   private final TopicPartition changelogTopicPartition;
   private final long committedOffset;
   private final String name;
+  private final Consumer<Long> onCommit;
 
-  ResponsiveStoreRegistration(
+  @VisibleForTesting
+  public ResponsiveStoreRegistration(
       final String name,
       final TopicPartition changelogTopicPartition,
-      final long committedOffset
+      final long committedOffset,
+      final Consumer<Long> onCommit
   ) {
     this.name = Objects.requireNonNull(name);
     this.changelogTopicPartition = Objects.requireNonNull(changelogTopicPartition);
     this.committedOffset = committedOffset;
+    this.onCommit = Objects.requireNonNull(onCommit);
   }
 
   public long getCommittedOffset() {
@@ -28,5 +34,9 @@ public final class ResponsiveStoreRegistration {
 
   public String getName() {
     return name;
+  }
+
+  public Consumer<Long> getOnCommit() {
+    return onCommit;
   }
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveWindowStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveWindowStore.java
@@ -165,10 +165,11 @@ public class ResponsiveWindowStore implements WindowStore<Bytes, byte[]> {
           ),
           driverConfig.getInt(ResponsiveDriverConfig.STORE_FLUSH_RECORDS_THRESHOLD)
       );
+      final long offset = buffer.offset();
       registration = new ResponsiveStoreRegistration(
           name.kafkaName(),
           topicPartition,
-          0,
+          offset == -1 ? 0 : offset,
           buffer::flush
       );
       registry.registerStore(registration);

--- a/kafka-client/src/test/java/dev/responsive/kafka/clients/OffsetRecorderTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/clients/OffsetRecorderTest.java
@@ -1,0 +1,144 @@
+package dev.responsive.kafka.clients;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
+
+import dev.responsive.kafka.clients.OffsetRecorder.RecordingKey;
+import java.util.Map;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class OffsetRecorderTest {
+  private static final TopicPartition TOPIC_PARTITION1 = new TopicPartition("yogi", 1);
+  private static final TopicPartition TOPIC_PARTITION2 = new TopicPartition("bear", 2);
+
+  private Map<RecordingKey, Long> committedOffsets;
+  private Map<TopicPartition, Long> writtenOffsets;
+  private final OffsetRecorder eosRecorder = new OffsetRecorder(true);
+  private final OffsetRecorder alosRecorder = new OffsetRecorder(false);
+
+  @BeforeEach
+  public void setup() {
+    eosRecorder.addCommitCallback((c, w) -> {
+      committedOffsets = c;
+      writtenOffsets = w;
+    });
+    alosRecorder.addCommitCallback((c, w) -> {
+      committedOffsets = c;
+      writtenOffsets = w;
+    });
+  }
+
+  @Test
+  public void shouldRecordTransactionalOffsets() {
+    // given:
+    eosRecorder.getProducerListener().onSendOffsetsToTransaction(
+        Map.of(
+            TOPIC_PARTITION1, new OffsetAndMetadata(123L),
+            TOPIC_PARTITION2, new OffsetAndMetadata(456L)
+        ),
+        "group"
+    );
+
+    // when:
+    eosRecorder.getProducerListener().onCommit();
+
+    // then:
+    assertThat(getCommittedOffsetsSentToCallback(), is(Map.of(
+        new RecordingKey(TOPIC_PARTITION1, "group"), 123L,
+        new RecordingKey(TOPIC_PARTITION2, "group"), 456L
+    )));
+  }
+
+  @Test
+  public void shouldRecordProducedOffsets() {
+    // given:
+    eosRecorder.getProducerListener().onSendCompleted(
+        new RecordMetadata(TOPIC_PARTITION1, 123L, 0, 0, 0, 0)
+    );
+    eosRecorder.getProducerListener().onSendCompleted(
+        new RecordMetadata(TOPIC_PARTITION2, 456L, 0, 0, 0, 0)
+    );
+
+    // when:
+    eosRecorder.getProducerListener().onCommit();
+
+    // then:
+    assertThat(getWrittenOffsetsSentToCallback(), is(Map.of(
+        TOPIC_PARTITION1, 123L,
+        TOPIC_PARTITION2, 456L
+    )));
+  }
+
+  @Test
+  public void shouldResetOffsetsOnAbort() {
+    // given:
+    eosRecorder.getProducerListener().onSendOffsetsToTransaction(
+        Map.of(
+            TOPIC_PARTITION1, new OffsetAndMetadata(123L),
+            TOPIC_PARTITION2, new OffsetAndMetadata(456L)
+        ),
+        "group"
+    );
+    eosRecorder.getProducerListener().onSendCompleted(
+        new RecordMetadata(TOPIC_PARTITION1, 123L, 0, 0, 0, 0)
+    );
+    eosRecorder.getProducerListener().onSendCompleted(
+        new RecordMetadata(TOPIC_PARTITION2, 456L, 0, 0, 0, 0)
+    );
+
+    // when:
+    eosRecorder.getProducerListener().onAbort();
+    eosRecorder.getProducerListener().onCommit();
+
+    // then:
+    assertThat(getWrittenOffsetsSentToCallback().entrySet(), is(empty()));
+    assertThat(getCommittedOffsetsSentToCallback().entrySet(), is(empty()));
+  }
+
+  @Test
+  public void shouldRecordOffsetsCommittedByConsumer() {
+    // when:
+    alosRecorder.getConsumerListener().onCommit(
+        Map.of(
+            TOPIC_PARTITION1, new OffsetAndMetadata(123L),
+            TOPIC_PARTITION2, new OffsetAndMetadata(456L)
+        )
+    );
+
+    // then:
+    assertThat(getCommittedOffsetsSentToCallback(), is(Map.of(
+        new RecordingKey(TOPIC_PARTITION1, ""), 123L,
+        new RecordingKey(TOPIC_PARTITION2, ""), 456L
+    )));
+  }
+
+  @Test
+  public void shouldThrowIfCommitFromConsumerOnEos() {
+    assertThrows(
+        IllegalStateException.class,
+        () -> eosRecorder.getConsumerListener().onCommit(Map.of())
+    );
+  }
+
+  @Test
+  public void shouldThrowIfTransactionalOffsetsSentOnAlos() {
+    assertThrows(
+        IllegalStateException.class,
+        () -> alosRecorder.getProducerListener().onSendOffsetsToTransaction(Map.of(), "")
+    );
+  }
+
+  private Map<RecordingKey, Long> getCommittedOffsetsSentToCallback() {
+    return committedOffsets;
+  }
+
+  private Map<TopicPartition, Long> getWrittenOffsetsSentToCallback() {
+    return writtenOffsets;
+  }
+}

--- a/kafka-client/src/test/java/dev/responsive/kafka/clients/ResponsiveKafkaClientSupplierTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/clients/ResponsiveKafkaClientSupplierTest.java
@@ -55,7 +55,9 @@ class ResponsiveKafkaClientSupplierTest {
       ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, BytesDeserializer.class,
       ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, BytesSerializer.class,
       ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, BytesSerializer.class,
-      StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_V2
+      StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_V2,
+      StreamsConfig.APPLICATION_ID_CONFIG, "appid",
+      StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092"
   );
   private static final Map<String, Object> PRODUCER_CONFIGS = configsWithOverrides(
       Map.of(

--- a/kafka-client/src/test/java/dev/responsive/kafka/clients/ResponsiveKafkaClientSupplierTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/clients/ResponsiveKafkaClientSupplierTest.java
@@ -17,9 +17,9 @@
 package dev.responsive.kafka.clients;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -88,11 +88,14 @@ class ResponsiveKafkaClientSupplierTest {
   @Mock
   private ResponsiveConsumer<byte[], byte[]> responsiveConsumer;
   @Mock
-  private MetricPublishingCommitListener metricPublishingCommitListener;
+  private MetricPublishingCommitListener commitMetricListener;
+  @Mock
+  private ResponsiveProducer.Listener commitMetricProducerListener;
   @Captor
   private ArgumentCaptor<List<ResponsiveProducer.Listener>> producerListenerCaptor;
   @Captor
   private ArgumentCaptor<List<ResponsiveConsumer.Listener>> consumerListenerCaptor;
+  private final OffsetRecorder offsetRecorder = new OffsetRecorder(true);
   private ResponsiveKafkaClientSupplier supplier;
 
   private final ResponsiveStoreRegistry storeRegistry = new ResponsiveStoreRegistry();
@@ -111,14 +114,15 @@ class ResponsiveKafkaClientSupplierTest {
     lenient().when(
         factories.createResponsiveConsumer(any(), (ResponsiveConsumer<byte[], byte[]>) any(), any())
     ).thenReturn(responsiveConsumer);
-    lenient().when(factories.createMetricsPublishingCommitListener(any(), any()))
-        .thenReturn(metricPublishingCommitListener);
+    lenient().when(factories.createMetricsPublishingCommitListener(any(), any(), any()))
+        .thenReturn(commitMetricListener);
+    lenient().when(factories.createOffsetRecorder(anyBoolean())).thenReturn(offsetRecorder);
 
     supplier = new ResponsiveKafkaClientSupplier(factories, wrapped, CONFIGS, storeRegistry);
   }
 
   @Test
-  public void shouldNotWrapProducerIfNotEosV2() {
+  public void shouldWrapProducerIfAlos() {
     // given:
     final var config = configsWithOverrides(
         PRODUCER_CONFIGS,
@@ -130,11 +134,11 @@ class ResponsiveKafkaClientSupplierTest {
     final var producer = supplier.getProducer(config);
 
     // then:
-    assertThat(producer, is(wrappedProducer));
+    assertThat(producer, is(responsiveProducer));
   }
 
   @Test
-  public void shouldNotWrapConsumerIfNotEosV2() {
+  public void shouldWrapConsumerIfAlos() {
     // given:
     final var config = configsWithOverrides(
         CONSUMER_CONFIGS,
@@ -146,7 +150,7 @@ class ResponsiveKafkaClientSupplierTest {
     final var consumer = supplier.getConsumer(config);
 
     // then:
-    assertThat(consumer, is(wrappedConsumer));
+    assertThat(consumer, is(responsiveConsumer));
   }
 
   @Test
@@ -159,14 +163,18 @@ class ResponsiveKafkaClientSupplierTest {
   }
 
   @Test
-  public void shouldAddMetricPublishingCommitListenerToProducer() {
+  public void shouldAddOffsetRecorderCommitListenerToProducer() {
     // when:
     supplier.getProducer(PRODUCER_CONFIGS);
 
     // then:
     verify(factories).createResponsiveProducer(any(), any(), producerListenerCaptor.capture());
-    assertThat(producerListenerCaptor.getValue(), Matchers.hasItem(metricPublishingCommitListener));
-    verify(factories).createMetricsPublishingCommitListener(metrics, "StreamThread-0");
+    assertThat(
+        producerListenerCaptor.getValue(),
+        Matchers.hasItem(offsetRecorder.getProducerListener())
+    );
+    verify(factories)
+        .createMetricsPublishingCommitListener(metrics, "StreamThread-0", offsetRecorder);
   }
 
   @Test
@@ -176,8 +184,9 @@ class ResponsiveKafkaClientSupplierTest {
 
     // then:
     verify(factories).createResponsiveConsumer(any(), any(), consumerListenerCaptor.capture());
-    assertThat(consumerListenerCaptor.getValue(), Matchers.hasItem(metricPublishingCommitListener));
-    verify(factories).createMetricsPublishingCommitListener(metrics, "StreamThread-0");
+    assertThat(consumerListenerCaptor.getValue(), Matchers.hasItem(commitMetricListener));
+    verify(factories)
+        .createMetricsPublishingCommitListener(metrics, "StreamThread-0", offsetRecorder);
   }
 
   @Test
@@ -194,9 +203,9 @@ class ResponsiveKafkaClientSupplierTest {
 
     // then:
     verify(factories, times(1))
-        .createMetricsPublishingCommitListener(metrics, "StreamThread-0");
+        .createMetricsPublishingCommitListener(metrics, "StreamThread-0", offsetRecorder);
     verify(factories, times(1))
-        .createMetricsPublishingCommitListener(metrics, "StreamThread-1");
+        .createMetricsPublishingCommitListener(metrics, "StreamThread-1", offsetRecorder);
   }
 
   @Test
@@ -218,10 +227,10 @@ class ResponsiveKafkaClientSupplierTest {
     // then:
     verify(factories).createResponsiveConsumer(any(), any(), consumerListenerCaptor.capture());
     consumerListenerCaptor.getValue().forEach(ResponsiveConsumer.Listener::onClose);
-    verify(metricPublishingCommitListener, times(0)).close();
+    verify(commitMetricListener, times(0)).close();
     verify(factories).createResponsiveProducer(any(), any(), producerListenerCaptor.capture());
     producerListenerCaptor.getValue().forEach(ResponsiveProducer.Listener::onClose);
-    verify(metricPublishingCommitListener).close();
+    verify(commitMetricListener).close();
   }
 
   private static Map<String, Object> configsWithOverrides(final Map<String, Object> overrides) {

--- a/kafka-client/src/test/java/dev/responsive/kafka/clients/ResponsiveProducerTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/clients/ResponsiveProducerTest.java
@@ -16,20 +16,34 @@
 
 package dev.responsive.kafka.clients;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import dev.responsive.kafka.clients.ResponsiveProducer.Listener;
-import dev.responsive.kafka.clients.ResponsiveProducer.RecordingKey;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.TopicPartition;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -39,12 +53,14 @@ public class ResponsiveProducerTest {
   private static final TopicPartition PARTITION2 = new TopicPartition("panda", 2);
 
   @Mock
-  private Producer<?, ?> wrapped;
+  private Producer<String, String> wrapped;
   @Mock
   private Listener listener1;
   @Mock
   private Listener listener2;
-  private ResponsiveProducer<?, ?> producer;
+  @Captor
+  private ArgumentCaptor<Callback> callbackCaptor;
+  private ResponsiveProducer<String, String> producer;
 
   @BeforeEach
   public void setup() {
@@ -53,7 +69,78 @@ public class ResponsiveProducerTest {
 
   @Test
   public void shouldNotifyOnCommit() {
+    // when:
+    producer.commitTransaction();
+
+    // then:
+    verify(listener1).onCommit();
+    verify(listener2).onCommit();
+  }
+
+  @Test
+  public void shouldNotifyOnSendCallback() {
     // given:
+    final var record = new ProducerRecord<String, String>(PARTITION1.topic(), "val");
+    final var recordRef = new AtomicReference<RecordMetadata>();
+    final var exceptionRef = new AtomicReference<Exception>();
+    producer.send(record, (rm, e) -> {
+      recordRef.set(rm);
+      exceptionRef.set(e);
+    });
+    verify(wrapped).send(same(record), callbackCaptor.capture());
+    final RecordMetadata recordMetadata = new RecordMetadata(
+        PARTITION1,
+        123L,
+        0,
+        0,
+        0,
+        0
+    );
+
+    // when:
+    callbackCaptor.getValue().onCompletion(recordMetadata, null);
+
+    // then:
+    assertThat(recordRef.get(), is(recordMetadata));
+    assertThat(exceptionRef.get(), is(nullValue()));
+    verify(listener1).onSendCompleted(recordMetadata);
+    verify(listener2).onSendCompleted(recordMetadata);
+  }
+
+  @SuppressWarnings("unchecked")
+  private Future<RecordMetadata> mockFuture() {
+    return mock(Future.class);
+  }
+
+  @Test
+  public void shouldNotifyOnSendFutureAndReturnRecordMetadata()
+      throws InterruptedException, ExecutionException {
+    // given:
+    final var future = mockFuture();
+    when(wrapped.send(any())).thenReturn(future);
+    final RecordMetadata recordMetadata = new RecordMetadata(
+        PARTITION1,
+        123L,
+        0,
+        0,
+        0,
+        0
+    );
+    when(future.get()).thenReturn(recordMetadata);
+    final var returnedFuture = producer.send(new ProducerRecord<>(PARTITION1.topic(), "val"));
+
+    // when:
+    final var returnedMetadata = returnedFuture.get();
+
+    // then:
+    assertThat(returnedMetadata, is(recordMetadata));
+    verify(listener1).onSendCompleted(recordMetadata);
+    verify(listener2).onSendCompleted(recordMetadata);
+  }
+
+  @Test
+  public void shouldNotifyOnSendOffsetsToTransaction() {
+    // when:
     producer.sendOffsetsToTransaction(
         Map.of(
             PARTITION1, new OffsetAndMetadata(10),
@@ -62,66 +149,23 @@ public class ResponsiveProducerTest {
         "foo"
     );
 
-    // when:
-    producer.commitTransaction();
-
     // then:
     final var expected = Map.of(
-        new RecordingKey(PARTITION1, "foo"), 10L,
-        new RecordingKey(PARTITION2, "foo"), 11L
+        PARTITION1, new OffsetAndMetadata(10L),
+        PARTITION2, new OffsetAndMetadata(11L)
     );
-    verify(listener1).onCommit(expected);
-    verify(listener2).onCommit(expected);
+    verify(listener1).onSendOffsetsToTransaction(expected, "foo");
+    verify(listener2).onSendOffsetsToTransaction(expected, "foo");
   }
 
   @Test
-  public void shouldClearOffsetsOnAbort() {
+  public void shouldThrowExceptionFromCommitCallback() {
     // given:
     producer.sendOffsetsToTransaction(Map.of(PARTITION1, new OffsetAndMetadata(10)), "foo");
+    doThrow(new RuntimeException("oops")).when(listener1).onCommit();
 
-    // when:
-    producer.abortTransaction();
-
-    // then:
-    producer.sendOffsetsToTransaction(Map.of(PARTITION2, new OffsetAndMetadata(11)), "foo");
-    producer.commitTransaction();
-    final var expected = Map.of(new RecordingKey(PARTITION2, "foo"), 11L);
-    verify(listener1).onCommit(expected);
-    verify(listener2).onCommit(expected);
-  }
-
-  @Test
-  public void shouldClearOffsetsOnCommit() {
-    // given:
-    producer.sendOffsetsToTransaction(Map.of(PARTITION1, new OffsetAndMetadata(10)), "foo");
-
-    // when:
-    producer.commitTransaction();
-
-    // then:
-    producer.sendOffsetsToTransaction(Map.of(PARTITION2, new OffsetAndMetadata(11)), "foo");
-    producer.commitTransaction();
-    final var expected1 = Map.of(new RecordingKey(PARTITION1, "foo"), 10L);
-    final var expected2 = Map.of(new RecordingKey(PARTITION2, "foo"), 11L);
-    verify(listener1).onCommit(expected1);
-    verify(listener2).onCommit(expected1);
-    verify(listener1).onCommit(expected2);
-    verify(listener2).onCommit(expected2);
-  }
-
-  @Test
-  public void shouldIgnoreExceptionFromCommitCallback() {
-    // given:
-    producer.sendOffsetsToTransaction(Map.of(PARTITION1, new OffsetAndMetadata(10)), "foo");
-    doThrow(new RuntimeException("oops")).when(listener1).onCommit(any());
-
-    // when:
-    producer.commitTransaction();
-
-    // then:
-    final var expected = Map.of(new RecordingKey(PARTITION1, "foo"), 10L);
-    verify(listener1).onCommit(expected);
-    verify(listener2).onCommit(expected);
+    // when/then:
+    assertThrows(RuntimeException.class, () -> producer.commitTransaction());
   }
 
   @Test

--- a/kafka-client/src/test/java/dev/responsive/kafka/clients/StoreCommitListenerTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/clients/StoreCommitListenerTest.java
@@ -1,0 +1,93 @@
+package dev.responsive.kafka.clients;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import dev.responsive.kafka.store.ResponsiveStoreRegistration;
+import dev.responsive.kafka.store.ResponsiveStoreRegistry;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class StoreCommitListenerTest {
+  private static final TopicPartition PARTITION1 = new TopicPartition("yogi", 1);
+  private static final TopicPartition PARTITION2 = new TopicPartition("booboo", 2);
+
+  @Mock
+  private Consumer<Long> store1Flush;
+  @Mock
+  private Consumer<Long> store2Flush;
+  private final ResponsiveStoreRegistry registry = new ResponsiveStoreRegistry();
+  private final OffsetRecorder offsetRecorder = new OffsetRecorder(true);
+  private StoreCommitListener commitListener;
+
+  @BeforeEach
+  public void setup() {
+    registry.registerStore(new ResponsiveStoreRegistration(
+        "store1",
+        PARTITION1,
+        0,
+        store1Flush
+    ));
+    registry.registerStore(new ResponsiveStoreRegistration(
+        "store2",
+        PARTITION2,
+        0,
+        store2Flush
+    ));
+    commitListener = new StoreCommitListener(registry, offsetRecorder);
+  }
+
+  @Test
+  public void shouldNotifyStoresOnCommittedChangelogOffsets() {
+    // when:
+    sendCommittedOffsets(Map.of(PARTITION1, 123L));
+
+    // then:
+    verify(store1Flush).accept(123L);
+    verifyNoInteractions(store2Flush);
+  }
+
+  @Test
+  public void shouldNotifyStoresOnCommittedChangelogWrites() {
+    // when:
+    sendWrittenOffsets(Map.of(PARTITION2, 456L));
+
+    // then:
+    verify(store2Flush).accept(456L);
+    verifyNoInteractions(store1Flush);
+  }
+
+  private void sendCommittedOffsets(final Map<TopicPartition, Long> offsets) {
+    offsetRecorder.getProducerListener().onSendOffsetsToTransaction(
+        offsets.entrySet().stream()
+            .collect(Collectors.toMap(Entry::getKey, e -> new OffsetAndMetadata(e.getValue()))),
+        "group"
+    );
+    offsetRecorder.getProducerListener().onCommit();
+  }
+
+  private void sendWrittenOffsets(final Map<TopicPartition, Long> offsets) {
+    for (final var e : offsets.entrySet()) {
+      offsetRecorder.getProducerListener().onSendCompleted(new RecordMetadata(
+          e.getKey(),
+          e.getValue(),
+          0,
+          0,
+          0,
+          0
+      ));
+    }
+    offsetRecorder.getProducerListener().onCommit();
+  }
+}

--- a/kafka-client/src/test/java/dev/responsive/kafka/store/CommitBufferTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/store/CommitBufferTest.java
@@ -30,7 +30,6 @@ import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.querybuilder.SchemaBuilder;
 import dev.responsive.db.CassandraClient;
 import dev.responsive.utils.ContainerExtension;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -43,7 +42,6 @@ import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.errors.ProcessorStateException;
-import org.apache.kafka.streams.processor.internals.RecordCollector;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -68,8 +66,6 @@ public class CommitBufferTest {
   private TopicPartition changelogTp;
 
   private String name;
-  @Mock private RecordCollector.Supplier supplier;
-  @Mock private RecordCollector collector;
   @Mock private Admin admin;
 
   @BeforeEach
@@ -86,9 +82,6 @@ public class CommitBufferTest {
     client.createDataTable(name);
     client.prepareStatements(name);
 
-    when(supplier.recordCollector()).thenReturn(collector);
-    when(collector.offsets())
-        .thenReturn(Collections.singletonMap(new TopicPartition("log", 0), 100L));
     when(admin.deleteRecords(Mockito.any()))
         .thenReturn(new DeleteRecordsResult(Map.of()));
   }
@@ -105,13 +98,13 @@ public class CommitBufferTest {
     final String tableName = name;
     client.initializeOffset(tableName, 0);
     final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
-        client, tableName, changelogTp, supplier, admin, ResponsivePartitionedStore.PLUGIN, true);
+        client, tableName, changelogTp, admin, ResponsivePartitionedStore.PLUGIN, true);
 
     // When:
     for (int i = 0; i < CommitBuffer.MAX_BATCH_SIZE * 1.5; i++) {
       buffer.put(KEY, VALUE);
     }
-    buffer.flush();
+    buffer.flush(100L);
 
     // Then:
     final byte[] value = client.get(tableName, 0, KEY);
@@ -125,13 +118,13 @@ public class CommitBufferTest {
     final String tableName = name;
     client.initializeOffset(tableName, 0);
     final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
-        client, tableName, changelogTp, supplier, admin, ResponsivePartitionedStore.PLUGIN, true);
+        client, tableName, changelogTp, admin, ResponsivePartitionedStore.PLUGIN, true);
     for (int i = 0; i < CommitBuffer.MAX_BATCH_SIZE * 1.5; i++) {
       buffer.put(KEY, VALUE);
     }
 
     // when:
-    buffer.flush();
+    buffer.flush(100L);
 
     // Then:
     verify(admin).deleteRecords(any());
@@ -143,13 +136,13 @@ public class CommitBufferTest {
     final String tableName = name;
     client.initializeOffset(tableName, 0);
     final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
-        client, tableName, changelogTp, supplier, admin, ResponsivePartitionedStore.PLUGIN, false);
+        client, tableName, changelogTp, admin, ResponsivePartitionedStore.PLUGIN, false);
     for (int i = 0; i < CommitBuffer.MAX_BATCH_SIZE * 1.5; i++) {
       buffer.put(KEY, VALUE);
     }
 
     // when:
-    buffer.flush();
+    buffer.flush(100L);
 
     // Then:
     verifyNoInteractions(admin);
@@ -162,11 +155,11 @@ public class CommitBufferTest {
     client.initializeOffset(table, 0);
     client.insertData(table, 0, KEY, VALUE);
     final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
-        client, table, changelogTp, supplier, admin, ResponsivePartitionedStore.PLUGIN, true);
+        client, table, changelogTp, admin, ResponsivePartitionedStore.PLUGIN, true);
 
     // When:
     buffer.tombstone(Bytes.wrap(new byte[]{1}));
-    buffer.flush();
+    buffer.flush(100L);
 
     // Then:
     final byte[] value = client.get(table, 0, KEY);
@@ -180,13 +173,13 @@ public class CommitBufferTest {
     client.initializeOffset(tableName, 0);
     client.execute(client.revokePermit(tableName, 0, 101));
     final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
-        client, tableName, changelogTp, supplier, admin, ResponsivePartitionedStore.PLUGIN, true);
+        client, tableName, changelogTp, admin, ResponsivePartitionedStore.PLUGIN, true);
 
     // Expect
     // When:
     assertThrows(ProcessorStateException.class, () -> {
       buffer.put(KEY, VALUE);
-      buffer.flush();
+      buffer.flush(100L);
     }, "client was fenced");
   }
 
@@ -197,13 +190,13 @@ public class CommitBufferTest {
     client.initializeOffset(tableName, 0);
     client.execute(client.acquirePermit(tableName, 0, UNSET_PERMIT, UUID.randomUUID(), 1));
     final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
-        client, tableName, changelogTp, supplier, admin, ResponsivePartitionedStore.PLUGIN, true);
+        client, tableName, changelogTp, admin, ResponsivePartitionedStore.PLUGIN, true);
 
     // Expect
     // When:
     assertThrows(ProcessorStateException.class, () -> {
       buffer.put(KEY, VALUE);
-      buffer.flush();
+      buffer.flush(100L);
     }, "client was fenced");
   }
 
@@ -214,13 +207,13 @@ public class CommitBufferTest {
     client.initializeOffset(tableName, 0);
     client.execute(client.revokePermit(tableName, 0, 100));
     final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
-        client, tableName, changelogTp, supplier, admin, ResponsivePartitionedStore.PLUGIN, true);
+        client, tableName, changelogTp, admin, ResponsivePartitionedStore.PLUGIN, true);
 
     // Expect
     // When:
     assertThrows(ProcessorStateException.class, () -> {
       buffer.put(KEY, VALUE);
-      buffer.flush();
+      buffer.flush(100L);
     }, "client was fenced");
   }
 
@@ -231,7 +224,7 @@ public class CommitBufferTest {
     client.initializeOffset(tableName, 0);
     client.execute(client.revokePermit(tableName, 0, 100));
     final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
-        client, tableName, changelogTp, supplier, admin, ResponsivePartitionedStore.PLUGIN, true);
+        client, tableName, changelogTp, admin, ResponsivePartitionedStore.PLUGIN, true);
 
     final ConsumerRecord<byte[], byte[]> ignored = new ConsumerRecord<>(
         changelogTp.topic(), changelogTp.partition(), 100, new byte[]{1}, new byte[]{1});
@@ -253,7 +246,7 @@ public class CommitBufferTest {
     client.initializeOffset(tableName, 0);
     client.execute(client.revokePermit(tableName, 0, 100));
     final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
-        client, tableName, changelogTp, supplier, admin, ResponsivePartitionedStore.PLUGIN, true);
+        client, tableName, changelogTp, admin, ResponsivePartitionedStore.PLUGIN, true);
 
     final CountDownLatch latch1 = new CountDownLatch(0);
     final CountDownLatch latch2 = new CountDownLatch(0);

--- a/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsiveGlobalStoreIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsiveGlobalStoreIntegrationTest.java
@@ -111,9 +111,9 @@ public class ResponsiveGlobalStoreIntegrationTest {
         final var streams = buildStreams(properties)
     ) {
       // When:
-      pipeInput(GLOBAL_TOPIC, producer, System::currentTimeMillis, 0, 3, 0, 1);
+      pipeInput(GLOBAL_TOPIC, 2, producer, System::currentTimeMillis, 0, 3, 0, 1);
       IntegrationTestUtils.startAppAndAwaitRunning(Duration.ofSeconds(10), streams);
-      pipeInput(INPUT_TOPIC, producer, System::currentTimeMillis, 0, 10, 0, 1);
+      pipeInput(INPUT_TOPIC, 2, producer, System::currentTimeMillis, 0, 10, 0, 1);
 
       // Then:
       final Set<KeyValue<Long, Long>> result = new HashSet<>(

--- a/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsivePartitionedStoreEosIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsivePartitionedStoreEosIntegrationTest.java
@@ -138,8 +138,8 @@ public class ResponsivePartitionedStoreEosIntegrationTest {
       IntegrationTestUtils.startAppAndAwaitRunning(Duration.ofSeconds(10), streamsA, streamsB);
 
       // committed data first, then second set of uncommitted data
-      pipeInput(INPUT_TOPIC, producer, System::currentTimeMillis, 0, 10, 0, 1);
-      pipeInput(INPUT_TOPIC, producer, System::currentTimeMillis, 10, 15, 0, 1);
+      pipeInput(INPUT_TOPIC, 2, producer, System::currentTimeMillis, 0, 10, 0, 1);
+      pipeInput(INPUT_TOPIC, 2, producer, System::currentTimeMillis, 10, 15, 0, 1);
 
       new RemoteMonitor(executor, () -> state.numCommits.get() == 2)
           .await(Duration.ofSeconds(5));
@@ -156,7 +156,7 @@ public class ResponsivePartitionedStoreEosIntegrationTest {
       // topic-partitions should be assigned to the first client, at
       // which point 5 of the writes should be aborted and reprocessed
       // by the new client
-      pipeInput(INPUT_TOPIC, producer, System::currentTimeMillis, 15, 20, 0, 1);
+      pipeInput(INPUT_TOPIC, 2, producer, System::currentTimeMillis, 15, 20, 0, 1);
 
       // the stall only happens on process, so this needs to be after the
       // previous pipeInput call

--- a/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsivePartitionedStoreRestoreIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsivePartitionedStoreRestoreIntegrationTest.java
@@ -122,27 +122,27 @@ public class ResponsivePartitionedStoreRestoreIntegrationTest {
       final TestInfo info,
       final Admin admin,
       @ResponsiveConfigParam final Map<String, Object> responsiveProps
-
-  ) {
+  ) throws InterruptedException, ExecutionException {
     name = info.getTestMethod().orElseThrow().getName();
     this.responsiveProps.putAll(responsiveProps);
 
     this.admin = admin;
-    admin.createTopics(
+    final var result = admin.createTopics(
         List.of(
-            new NewTopic(INPUT_TOPIC, Optional.of(1), Optional.empty()),
-            new NewTopic(INPUT_TBL_TOPIC, Optional.of(1), Optional.empty())
+            new NewTopic(inputTopic(), Optional.of(1), Optional.empty()),
+            new NewTopic(inputTblTopic(), Optional.of(1), Optional.empty())
                 .configs(Map.of(
                     TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT)),
-            new NewTopic(OUTPUT_TOPIC, Optional.of(1), Optional.empty()),
-            new NewTopic(OUTPUT_JOINED, Optional.of(1), Optional.empty())
+            new NewTopic(outputTopic(), Optional.of(1), Optional.empty()),
+            new NewTopic(outputJoined(), Optional.of(1), Optional.empty())
         )
     );
+    result.all().get();
   }
 
   @AfterEach
   public void after() {
-    admin.deleteTopics(List.of(INPUT_TOPIC, INPUT_TBL_TOPIC, OUTPUT_TOPIC, OUTPUT_JOINED));
+    admin.deleteTopics(List.of(inputTopic(), inputTblTopic(), outputTopic(), outputJoined()));
   }
 
   @Test
@@ -151,13 +151,13 @@ public class ResponsivePartitionedStoreRestoreIntegrationTest {
     final KafkaProducer<Long, Long> producer = new KafkaProducer<>(properties);
     final KafkaClientSupplier defaultClientSupplier = new DefaultKafkaClientSupplier();
     final CassandraClientFactory defaultFactory = new DefaultCassandraClientFactory();
-    final TopicPartition input = new TopicPartition(INPUT_TOPIC, 0);
+    final TopicPartition input = new TopicPartition(inputTopic(), 0);
 
     try (final ResponsiveKafkaStreams streams
              = buildAggregatorApp(properties, defaultClientSupplier, defaultFactory)) {
       IntegrationTestUtils.startAppAndAwaitRunning(Duration.ofSeconds(30), streams);
       // Send some data through
-      pipeInput(producer, INPUT_TOPIC, System::currentTimeMillis, 0, 10, 0);
+      pipeInput(inputTopic(), 1, producer, System::currentTimeMillis, 0, 10, 0);
       // Wait for it to be processed
       waitTillFullyConsumed(input, Duration.ofSeconds(120));
 
@@ -165,9 +165,10 @@ public class ResponsivePartitionedStoreRestoreIntegrationTest {
       final CassandraClient cassandraClient = defaultFactory.createCassandraClient(
           defaultFactory.createCqlSession(new ResponsiveDriverConfig(properties))
       );
-      final long cassandraOffset = cassandraClient.getOffset("testagg", 0).offset;
+      final long cassandraOffset = cassandraClient.getOffset(aggName(), 0).offset;
       assertThat(cassandraOffset, greaterThan(0L));
-      final TopicPartition changelog = new TopicPartition(name + "-testagg-changelog", 0);
+      final TopicPartition changelog
+          = new TopicPartition(name + "-" + aggName() + "-changelog", 0);
       final List<ConsumerRecord<Long, Long>> changelogRecords
           = slurpPartition(changelog, properties);
       final long last = changelogRecords.get(changelogRecords.size() - 1).offset();
@@ -181,16 +182,16 @@ public class ResponsivePartitionedStoreRestoreIntegrationTest {
     final KafkaProducer<Long, Long> producer = new KafkaProducer<>(properties);
     final KafkaClientSupplier defaultClientSupplier = new DefaultKafkaClientSupplier();
     final CassandraClientFactory defaultFactory = new DefaultCassandraClientFactory();
-    final TopicPartition inputTbl = new TopicPartition(INPUT_TBL_TOPIC, 0);
-    final TopicPartition input = new TopicPartition(INPUT_TOPIC, 0);
+    final TopicPartition inputTbl = new TopicPartition(inputTblTopic(), 0);
+    final TopicPartition input = new TopicPartition(inputTopic(), 0);
 
     try (final ResponsiveKafkaStreams streams
              = buildAggregatorApp(properties, defaultClientSupplier, defaultFactory)) {
       IntegrationTestUtils.startAppAndAwaitRunning(Duration.ofSeconds(10), streams);
       // Send some data through
-      pipeInput(INPUT_TBL_TOPIC, producer, System::currentTimeMillis, 0, 10, 0, 1, 2, 3);
+      pipeInput(inputTblTopic(), 1, producer, System::currentTimeMillis, 0, 10, 0, 1, 2, 3);
       waitTillFullyConsumed(inputTbl, Duration.ofSeconds(120));
-      pipeInput(INPUT_TOPIC, producer, System::currentTimeMillis, 0, 10, 0);
+      pipeInput(inputTopic(), 1, producer, System::currentTimeMillis, 0, 10, 0);
       // Wait for it to be processed
       waitTillFullyConsumed(input, Duration.ofSeconds(120));
     }
@@ -208,7 +209,7 @@ public class ResponsivePartitionedStoreRestoreIntegrationTest {
 
       // Send some more data through and wait for it to be committed
       final long endInput = endOffset(input);
-      pipeInput(INPUT_TOPIC, producer, System::currentTimeMillis, 10, 20, 0);
+      pipeInput(inputTopic(), 1, producer, System::currentTimeMillis, 10, 20, 0);
       producer.flush();
       waitTillConsumedPast(input, endInput + 1, Duration.ofSeconds(30));
     }
@@ -217,9 +218,9 @@ public class ResponsivePartitionedStoreRestoreIntegrationTest {
     final CassandraClient cassandraClient = defaultFactory.createCassandraClient(
         defaultFactory.createCqlSession(new ResponsiveDriverConfig(properties))
     );
-    final long cassandraOffset = cassandraClient.getOffset("testagg", 0).offset;
+    final long cassandraOffset = cassandraClient.getOffset(aggName(), 0).offset;
     assertThat(cassandraOffset, greaterThan(0L));
-    final TopicPartition changelog = new TopicPartition(name + "-testagg-changelog", 0);
+    final TopicPartition changelog = new TopicPartition(name + "-" + aggName() + "-changelog", 0);
     final long changelogOffset = admin.listOffsets(Map.of(changelog, OffsetSpec.latest())).all()
         .get()
         .get(changelog)
@@ -232,7 +233,7 @@ public class ResponsivePartitionedStoreRestoreIntegrationTest {
              = buildAggregatorApp(properties, recordingClientSupplier, defaultFactory)) {
       IntegrationTestUtils.startAppAndAwaitRunning(Duration.ofSeconds(30), streams);
       // Send some more data through and check output
-      pipeInput(INPUT_TOPIC, producer, System::currentTimeMillis, 20, 30, 0);
+      pipeInput(inputTopic(), 1, producer, System::currentTimeMillis, 20, 30, 0);
       producer.flush();
       waitTillFullyConsumed(input, Duration.ofSeconds(120));
     }
@@ -257,7 +258,7 @@ public class ResponsivePartitionedStoreRestoreIntegrationTest {
       final Map<String, Object> properties
   ) {
     final List<ConsumerRecord<Long, Long>> all
-        = slurpPartition(new TopicPartition(OUTPUT_TOPIC, 0), properties);
+        = slurpPartition(new TopicPartition(outputTopic(), 0), properties);
     return all.size() == 0 ? Optional.empty() : Optional.of(all.get(all.size() - 1));
   }
 
@@ -294,21 +295,21 @@ public class ResponsivePartitionedStoreRestoreIntegrationTest {
 
     final StreamsBuilder builder = new StreamsBuilder();
 
-    final KStream<Long, Long> input = builder.stream(INPUT_TOPIC);
+    final KStream<Long, Long> input = builder.stream(inputTopic());
     final KTable<Long, Long> inputTbl = builder.table(
-        INPUT_TBL_TOPIC,
-        Materialized.as(ResponsiveStores.keyValueStore("inputTbl"))
+        inputTblTopic(),
+        Materialized.as(ResponsiveStores.keyValueStore(name + "inputTbl"))
     );
     input
         .groupByKey()
         .aggregate(
             () -> 0L,
             (k, v, va) -> v + va,
-            (Materialized) Materialized.as(ResponsiveStores.keyValueStore("testagg"))
+            (Materialized) Materialized.as(ResponsiveStores.keyValueStore(aggName()))
                 .withLoggingEnabled(
                     Map.of(TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_DELETE)))
         .toStream()
-        .to(OUTPUT_TOPIC);
+        .to(outputTopic());
     input.join(inputTbl, Long::sum);
 
     final Properties builderProperties = new Properties();
@@ -319,6 +320,26 @@ public class ResponsivePartitionedStoreRestoreIntegrationTest {
         clientSupplier,
         cassandraClientFactory
     );
+  }
+
+  private String aggName() {
+    return name + "testagg";
+  }
+
+  private String inputTopic() {
+    return name + "." + INPUT_TOPIC;
+  }
+
+  private String inputTblTopic() {
+    return name + "." + INPUT_TBL_TOPIC;
+  }
+
+  private String outputTopic() {
+    return name + "." + OUTPUT_TOPIC;
+  }
+
+  private String outputJoined() {
+    return name + "." + OUTPUT_JOINED;
   }
 
   private static class Fault {
@@ -421,6 +442,8 @@ public class ResponsivePartitionedStoreRestoreIntegrationTest {
     properties.put(consumerPrefix(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG), MAX_POLL_MS);
     properties.put(consumerPrefix(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG), MAX_POLL_MS);
     properties.put(consumerPrefix(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG), MAX_POLL_MS - 1);
+
+    properties.put(ResponsiveDriverConfig.STORE_FLUSH_RECORDS_THRESHOLD, 0);
 
     return properties;
   }

--- a/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsiveStoreRegistryTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsiveStoreRegistryTest.java
@@ -13,7 +13,8 @@ class ResponsiveStoreRegistryTest {
   private static final ResponsiveStoreRegistration REGISTRATION = new ResponsiveStoreRegistration(
       "store",
       TOPIC_PARTITION,
-      123L
+      123L,
+      o -> {}
   );
 
   private final ResponsiveStoreRegistry registry = new ResponsiveStoreRegistry();

--- a/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsiveStoreTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsiveStoreTest.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.when;
 import dev.responsive.db.CassandraClient;
 import dev.responsive.db.CassandraClient.OffsetRow;
 import dev.responsive.kafka.api.InternalConfigs;
+import dev.responsive.kafka.config.ResponsiveDriverConfig;
 import dev.responsive.utils.RemoteMonitor;
 import dev.responsive.utils.TableName;
 import java.util.HashMap;
@@ -87,7 +88,8 @@ public class ResponsiveStoreTest {
         StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092",
         StreamsConfig.APPLICATION_ID_CONFIG, "test",
         StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, StringSerde.class,
-        StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, StringSerde.class
+        StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, StringSerde.class,
+        ResponsiveDriverConfig.TENANT_ID_CONFIG, "foo"
     ));
     config.putAll(
         new InternalConfigs.Builder()

--- a/kafka-client/src/test/java/dev/responsive/utils/IntegrationTestUtils.java
+++ b/kafka-client/src/test/java/dev/responsive/utils/IntegrationTestUtils.java
@@ -35,6 +35,7 @@ public final class IntegrationTestUtils {
 
   public static void pipeInput(
       final String topic,
+      final int partitions,
       final KafkaProducer<Long, Long> producer,
       final Supplier<Long> timestamp,
       final long valFrom,
@@ -45,7 +46,7 @@ public final class IntegrationTestUtils {
       for (long v = valFrom; v < valTo; v++) {
         producer.send(new ProducerRecord<>(
             topic,
-            (int) k % 2,
+            (int) k % partitions,
             timestamp.get(),
             k,
             v


### PR DESCRIPTION
This patch flushes state stores on every streams commit. The stores discover commits and the associated offsets via a notification registered with ResponsiveStoreRegistry. The notification is called by a ResponsiveProducer callback on each commit