### PR TITLE
support subpartitioning (without wiring it in yet)

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/db/CassandraClient.java
+++ b/kafka-client/src/main/java/dev/responsive/db/CassandraClient.java
@@ -48,6 +48,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
+import javax.annotation.CheckReturnValue;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.state.KeyValueIterator;
@@ -198,6 +199,7 @@ public class CassandraClient {
    *         for {@code offset} has a value smaller than the supplied
    *         {@code offset} parameter.
    */
+  @CheckReturnValue
   public BoundStatement revokePermit(
       final String table,
       final int partitionKey,
@@ -209,6 +211,7 @@ public class CassandraClient {
         .setLong(OFFSET.bind(), offset);
   }
 
+  @CheckReturnValue
   public BoundStatement acquirePermit(
       final String table,
       final int partitionKey,
@@ -224,6 +227,7 @@ public class CassandraClient {
         .setLong(OFFSET.bind(), offset);
   }
 
+  @CheckReturnValue
   public BoundStatement finalizeTxn(
       final String table,
       final int partitionKey,
@@ -505,6 +509,7 @@ public class CassandraClient {
    *         matching {@code partitionKey} and {@code key} in the
    *         {@code table}
    */
+  @CheckReturnValue
   public BoundStatement deleteData(
       final String table,
       final int partitionKey,
@@ -529,6 +534,7 @@ public class CassandraClient {
    *         matching {@code partitionKey} and {@code key} in the
    *         {@code table} with value {@code value}
    */
+  @CheckReturnValue
   public BoundStatement insertData(
       final String table,
       final int partitionKey,
@@ -555,6 +561,7 @@ public class CassandraClient {
    *         matching {@code partitionKey} and {@code key} in the
    *         {@code table} with value {@code value}
    */
+  @CheckReturnValue
   public BoundStatement insertWindowed(
       final String table,
       final int partitionKey,
@@ -866,7 +873,9 @@ public class CassandraClient {
     ).all();
 
     if (result.size() != 1) {
-      throw new IllegalArgumentException();
+      throw new IllegalStateException(String.format(
+          "Expected exactly one offset row for %s[%s] but got %d",
+          tableName, partition, result.size()));
     } else {
       return new OffsetRow(
           result.get(0).getLong(OFFSET.column()),

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/CassandraClientFactory.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/CassandraClientFactory.java
@@ -2,11 +2,10 @@ package dev.responsive.kafka.api;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import dev.responsive.db.CassandraClient;
-import dev.responsive.kafka.config.ResponsiveDriverConfig;
-import java.util.Map;
+import dev.responsive.kafka.config.ResponsiveConfig;
 
 public interface CassandraClientFactory {
-  CqlSession createCqlSession(ResponsiveDriverConfig config);
+  CqlSession createCqlSession(ResponsiveConfig config);
 
   CassandraClient createCassandraClient(CqlSession session);
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/DefaultCassandraClientFactory.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/DefaultCassandraClientFactory.java
@@ -1,22 +1,22 @@
 package dev.responsive.kafka.api;
 
-import static dev.responsive.kafka.config.ResponsiveDriverConfig.CLIENT_ID_CONFIG;
-import static dev.responsive.kafka.config.ResponsiveDriverConfig.CLIENT_SECRET_CONFIG;
-import static dev.responsive.kafka.config.ResponsiveDriverConfig.STORAGE_DATACENTER_CONFIG;
-import static dev.responsive.kafka.config.ResponsiveDriverConfig.STORAGE_HOSTNAME_CONFIG;
-import static dev.responsive.kafka.config.ResponsiveDriverConfig.STORAGE_PORT_CONFIG;
-import static dev.responsive.kafka.config.ResponsiveDriverConfig.TENANT_ID_CONFIG;
+import static dev.responsive.kafka.config.ResponsiveConfig.CLIENT_ID_CONFIG;
+import static dev.responsive.kafka.config.ResponsiveConfig.CLIENT_SECRET_CONFIG;
+import static dev.responsive.kafka.config.ResponsiveConfig.STORAGE_DATACENTER_CONFIG;
+import static dev.responsive.kafka.config.ResponsiveConfig.STORAGE_HOSTNAME_CONFIG;
+import static dev.responsive.kafka.config.ResponsiveConfig.STORAGE_PORT_CONFIG;
+import static dev.responsive.kafka.config.ResponsiveConfig.TENANT_ID_CONFIG;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import dev.responsive.db.CassandraClient;
-import dev.responsive.kafka.config.ResponsiveDriverConfig;
+import dev.responsive.kafka.config.ResponsiveConfig;
 import dev.responsive.utils.SessionUtil;
 import java.net.InetSocketAddress;
 import org.apache.kafka.common.config.types.Password;
 
 public class DefaultCassandraClientFactory implements CassandraClientFactory {
   @Override
-  public CqlSession createCqlSession(final ResponsiveDriverConfig config) {
+  public CqlSession createCqlSession(final ResponsiveConfig config) {
     final InetSocketAddress address = InetSocketAddress.createUnresolved(
         config.getString(STORAGE_HOSTNAME_CONFIG),
         config.getInt(STORAGE_PORT_CONFIG)

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveKafkaStreams.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveKafkaStreams.java
@@ -1,12 +1,12 @@
 package dev.responsive.kafka.api;
 
-import static dev.responsive.kafka.config.ResponsiveDriverConfig.NUM_STANDBYS_OVERRIDE;
-import static dev.responsive.kafka.config.ResponsiveDriverConfig.TASK_ASSIGNOR_CLASS_OVERRIDE;
+import static dev.responsive.kafka.config.ResponsiveConfig.NUM_STANDBYS_OVERRIDE;
+import static dev.responsive.kafka.config.ResponsiveConfig.TASK_ASSIGNOR_CLASS_OVERRIDE;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import dev.responsive.db.CassandraClient;
 import dev.responsive.kafka.clients.ResponsiveKafkaClientSupplier;
-import dev.responsive.kafka.config.ResponsiveDriverConfig;
+import dev.responsive.kafka.config.ResponsiveConfig;
 import dev.responsive.kafka.store.ResponsiveStoreRegistry;
 import java.time.Duration;
 import java.util.Map;
@@ -86,7 +86,7 @@ public class ResponsiveKafkaStreams extends KafkaStreams {
       final ResponsiveStoreRegistry storeRegistry,
       final CassandraClientFactory cassandraClientFactory
   ) {
-    final ResponsiveDriverConfig responsiveConfigs = new ResponsiveDriverConfig(configs);
+    final ResponsiveConfig responsiveConfigs = new ResponsiveConfig(configs);
 
     final CqlSession session = cassandraClientFactory.createCqlSession(responsiveConfigs);
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/config/ResponsiveConfig.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/config/ResponsiveConfig.java
@@ -29,7 +29,8 @@ import org.apache.kafka.streams.processor.internals.assignment.StickyTaskAssigno
 /**
  * Configurations for {@link dev.responsive.kafka.api.ResponsiveKafkaStreams}
  */
-public class ResponsiveDriverConfig extends AbstractConfig {
+@SuppressWarnings("checkstyle:linelength")
+public class ResponsiveConfig extends AbstractConfig {
 
   // ------------------ connection configurations -----------------------------
 
@@ -75,6 +76,28 @@ public class ResponsiveDriverConfig extends AbstractConfig {
   private static final String REQUEST_TIMEOUT_MS_DOC = "The timeout for making requests to the "
       + "responsive server. This applies both to metadata requests and query execution.";
   private static final long REQUEST_TIMEOUT_MS_DEFAULT = 5000L;
+
+
+  // ------------------ performance related configurations --------------------
+
+  // TODO: we should make this configurable per-store
+  public static final String STORAGE_DESIRED_NUM_PARTITION_CONFIG = "responsive.storage.desired.num.partitions";
+  private static final String STORAGE_DESIRED_NUM_PARTITIONS_DOC = "The desired number of "
+      + "partitions to create in the remote store. This is a best effort target, as the actual "
+      + "number of partitions must be a multiple of the Kafka store's number of partitions. This "
+      + "configuration does not apply to global stores.";
+  private static final int STORAGE_DESIRED_NUM_PARTITIONS_DEFAULT = 4096;
+
+  // TODO: consider if we want this as a local, global or per-store configuration
+  public static final String MAX_CONCURRENT_REMOTE_WRITES_CONFIG = "responsive.max.concurrent.writes";
+  private static final String MAX_CONCURRENT_REMOTE_WRITES_DOC = "The maximum number of writes "
+      + "that will every be concurrently issued to the remote store. Increasing this value will "
+      + "reduce the time that it takes to flush data to the remote store, but potentially increase "
+      + "the latency of each individual write and any other concurrent reads from other threads. "
+      + "This configuration is 'local': in practice, the number of concurrent writes from all "
+      + "applications to the remote store is this number * the number of stream threads running "
+      + "across all nodes.";
+  public static final int MAX_CONCURRENT_REMOTE_WRITES_DEFAULT = 32;
 
 
   // ------------------ required StreamsConfig overrides ----------------------
@@ -164,7 +187,7 @@ public class ResponsiveDriverConfig extends AbstractConfig {
     }
   }
 
-  public ResponsiveDriverConfig(final Map<?, ?> originals) {
+  public ResponsiveConfig(final Map<?, ?> originals) {
     super(CONFIG_DEF, originals);
   }
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/AtomicWriter.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/AtomicWriter.java
@@ -69,7 +69,7 @@ class AtomicWriter<K> {
     results.forEach(this::add);
   }
 
-  private void add(final Result<K> result) {
+  public void add(final Result<K> result) {
     if (result.isTombstone || plugin.retain(result.key)) {
       statements.add(result.isTombstone
           ? plugin.deleteData(client, tableName, partition, result.key)
@@ -130,5 +130,9 @@ class AtomicWriter<K> {
             permit,
             offset
         );
+  }
+
+  public int partition() {
+    return partition;
   }
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/BufferPlugin.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/BufferPlugin.java
@@ -20,6 +20,7 @@ import com.datastax.oss.driver.api.core.cql.BoundStatement;
 import dev.responsive.db.CassandraClient;
 import java.util.Comparator;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.utils.Bytes;
 
 /**
  * Used to ensure that {@link CommitBuffer} can work both with
@@ -47,4 +48,6 @@ interface BufferPlugin<K> extends Comparator<K> {
   default boolean retain(final K key) {
     return true;
   }
+
+  Bytes bytes(final K key);
 }

--- a/kafka-client/src/main/java/dev/responsive/utils/SubPartitioner.java
+++ b/kafka-client/src/main/java/dev/responsive/utils/SubPartitioner.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.utils;
+
+import java.util.function.Function;
+import java.util.stream.IntStream;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.common.utils.Utils;
+import org.apache.kafka.streams.state.internals.Murmur3;
+
+/**
+ * {@code SubPartitioner} allows sub-partitioning a partition
+ * space into additional partitions such that there is a 1:N
+ * mapping of original partitions to new partitions (namely,
+ * if two events are in the same new partition they must have
+ * been in the same original partition, but the opposite is
+ * not true).
+ *
+ * <p>The algorithm used simply maps each original partition
+ * to {@code n} new partitions, beginning with {@code original
+ * * n} and ending with {@code original * n + n} (exclusive). To
+ * compute which new partition a key falls into, it applies a hash
+ * function and mods by {@code n}, adding that value to the base
+ * mapped partition.</p>
+ */
+public class SubPartitioner {
+
+  public static final SubPartitioner NO_SUBPARTITIONS = new SubPartitioner(1, k -> 0);
+
+  // ensure that the default sub-partitioning hasher is unlikely
+  // to be the same as the hasher that was used for the original
+  // partition scheme - if the hashers are the same, and the
+  // number of sub partitions is equal to the number of original
+  // partitions, all keys would be mapped to the same sub-partition
+  // and all other sub-partitions would be empty
+  private static final int SALT = 31;
+
+  /**
+   * the number of subpartitions is: {@code original_partitions * n}
+   */
+  private final int factor;
+  private final Function<Bytes, Integer> hasher;
+
+  public SubPartitioner(final int factor) {
+    this(factor, k -> SALT * Murmur3.hash32(k.get()));
+  }
+
+  public SubPartitioner(final int factor, final Function<Bytes, Integer> hasher) {
+    this.factor = factor;
+    this.hasher = hasher;
+  }
+
+  public int partition(final int original, final Bytes key) {
+    return first(original) + Utils.toPositive(hasher.apply(key)) % factor;
+  }
+
+  /**
+   * @return the multiplication factor of this sub-partitioner
+   */
+  public int getFactor() {
+    return factor;
+  }
+
+  /**
+   * @param partition the original partition
+   * @return the sub-partition at index 0 for this partition
+   */
+  public int first(final int partition) {
+    return partition * factor;
+  }
+
+  /**
+   * @param partition the original partition
+   * @return all subpartitions that this partition could map to
+   */
+  public IntStream all(final int partition) {
+    return IntStream.range(first(partition), first(partition) + factor);
+  }
+}

--- a/kafka-client/src/test/java/dev/responsive/kafka/store/AtomicWriterTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/store/AtomicWriterTest.java
@@ -244,6 +244,11 @@ class AtomicWriterTest {
     }
 
     @Override
+    public Bytes bytes(final Bytes key) {
+      return key;
+    }
+
+    @Override
     public int compare(final Bytes o1, final Bytes o2) {
       return o1.compareTo(o2);
     }

--- a/kafka-client/src/test/java/dev/responsive/kafka/store/CommitBufferDrainTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/store/CommitBufferDrainTest.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.kafka.store;
+
+import static java.util.concurrent.CompletableFuture.supplyAsync;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.function.Supplier;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CommitBufferDrainTest {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CommitBufferDrainTest.class);
+
+  @Test
+  public void shouldDrainWithMaxConcurrencyWhenAllSucceed() {
+    // Given:
+    final var latches = Map.of(
+        0, new CountDownLatch(0),
+        1, new CountDownLatch(1),
+        2, new CountDownLatch(1)
+    );
+    final ExecutorService exec = Executors.newFixedThreadPool(4);
+
+    final ConcurrentLinkedDeque<Integer> tracker = new ConcurrentLinkedDeque<>();
+    final ConcurrentLinkedDeque<Integer> interrupted = new ConcurrentLinkedDeque<>();
+
+    final var p0 = new TestWriter(latches, 0, 1, true, exec, tracker, interrupted);
+    final var p1 = new TestWriter(latches, 1, 2, true, exec, tracker, interrupted);
+    final var p2 = new TestWriter(latches, 2, 2, true, exec, tracker, interrupted);
+
+    // When:
+    final AtomicWriteResult result = CommitBuffer.drain(
+        // p2 blocks until p1 completes, this tests to ensure that
+        // we run p1 when p0 completes instead of when the entire
+        // mini-batch of [p0, p2] completes
+        List.of(p0, p2, p1),
+        TestWriter::get,
+        TestWriter::partition,
+        100,
+        2
+    );
+
+    // Then:
+    assertThat(result.wasApplied(), is(true));
+    assertThat(result.getPartition(), is(100));
+    assertThat(tracker.toArray(Integer[]::new), is(new Integer[]{0, 1, 2}));
+    assertThat(interrupted, hasSize(0));
+
+    exec.shutdown();
+  }
+
+  @Test
+  public void shouldCancelOngoingAndNotContinueDrainOnFailure() throws InterruptedException {
+    // Given:
+    final var latches = Map.of(
+        0, new CountDownLatch(0),
+        1, new CountDownLatch(1),
+        2, new CountDownLatch(1)
+    );
+    final ExecutorService exec = Executors.newFixedThreadPool(4);
+
+    final ConcurrentLinkedDeque<Integer> tracker = new ConcurrentLinkedDeque<>();
+    final ConcurrentLinkedDeque<Integer> interrupted = new ConcurrentLinkedDeque<>();
+    final var p0 = new TestWriter(latches, 0, 1, false, exec, tracker, interrupted);
+    final var p1 = new TestWriter(latches, 1, 2, true, exec, tracker, interrupted);
+    final var p2 = new TestWriter(latches, 2, 0, true, exec, tracker, interrupted);
+
+    // When:
+    final AtomicWriteResult result = CommitBuffer.drain(
+        // 0 fails, which should cancel 1 and 2 should never have run
+        List.of(p1, p0, p2),
+        TestWriter::get,
+        TestWriter::partition,
+        100,
+        2
+    );
+
+    // Then:
+    assertThat(result.wasApplied(), is(false));
+    assertThat(result.getPartition(), is(0));
+    assertThat(tracker, hasSize(1));
+    assertThat(tracker, contains(0));
+
+    exec.shutdownNow();
+
+    // we should count down 1 when it is interrupted
+    latches.get(1).await();
+
+    // 2 should never have run, so it isn't interrupted
+    assertThat(interrupted.size(), is(1));
+    assertThat(interrupted, contains(1));
+  }
+
+  static class TestWriter implements Supplier<CompletionStage<AtomicWriteResult>> {
+
+    private final Map<Integer, CountDownLatch> latches;
+    private final int partition;
+    private final int release;
+    private final boolean success;
+    private final Executor exec;
+    private final ConcurrentLinkedDeque<Integer> orderTracker;
+    private final ConcurrentLinkedDeque<Integer> interrupted;
+
+    public TestWriter(
+        final Map<Integer, CountDownLatch> latches,
+        final int partition,
+        final int release,
+        final boolean success,
+        final Executor exec,
+        final ConcurrentLinkedDeque<Integer> successTracker,
+        final ConcurrentLinkedDeque<Integer> interrupted) {
+      this.latches = latches;
+      this.partition = partition;
+      this.release = release;
+      this.success = success;
+      this.exec = exec;
+      this.orderTracker = successTracker;
+      this.interrupted = interrupted;
+    }
+
+    @Override
+    public CompletionStage<AtomicWriteResult> get() {
+      return supplyAsync(
+          awrSupplier(latches, partition, release, success, orderTracker, interrupted), exec
+      );
+    }
+
+    public int partition() {
+      return partition;
+    }
+  }
+
+  private static Supplier<AtomicWriteResult> awrSupplier(
+      final Map<Integer, CountDownLatch> latches,
+      final int partition,
+      final int release,
+      final boolean success,
+      final ConcurrentLinkedDeque<Integer> tracker,
+      final ConcurrentLinkedDeque<Integer> interrupted
+  ) {
+    return () -> {
+      try {
+        LOG.info("Started execution of {}", partition);
+        latches.get(partition).await();
+        tracker.add(partition);
+
+        if (success) {
+          LOG.info("Finished execution of {}.. Releasing {}", partition, release);
+          latches.get(release).countDown();
+          return AtomicWriteResult.success(partition);
+        } else {
+          LOG.info("Failed execution of {}.. not releasing {}", partition, release);
+          return AtomicWriteResult.failure(partition);
+        }
+      } catch (InterruptedException e) {
+        LOG.info("Interrupted partition {}", partition);
+        interrupted.add(partition);
+        latches.get(partition).countDown(); // count yourself down
+        throw new CompletionException(e);
+      }
+    };
+  }
+
+
+}

--- a/kafka-client/src/test/java/dev/responsive/kafka/store/CommitBufferTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/store/CommitBufferTest.java
@@ -17,6 +17,7 @@
 package dev.responsive.kafka.store;
 
 import static dev.responsive.db.CassandraClient.UNSET_PERMIT;
+import static dev.responsive.kafka.store.ResponsivePartitionedStore.PLUGIN;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
@@ -27,11 +28,13 @@ import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.cql.SimpleStatementBuilder;
 import com.datastax.oss.driver.api.querybuilder.SchemaBuilder;
 import dev.responsive.db.CassandraClient;
 import dev.responsive.utils.ContainerExtension;
+import dev.responsive.utils.SubPartitioner;
+import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -62,8 +65,10 @@ import org.testcontainers.containers.CassandraContainer;
 @MockitoSettings(strictness = Strictness.LENIENT)
 public class CommitBufferTest {
 
-  private static final Bytes KEY = Bytes.wrap(new byte[]{1});
+  private static final Bytes KEY = Bytes.wrap(ByteBuffer.allocate(4).putInt(0).array());
+  private static final Bytes KEY2 = Bytes.wrap(ByteBuffer.allocate(4).putInt(1).array());
   private static final byte[] VALUE = new byte[]{1};
+  private static final int KAFKA_PARTITION = 2;
 
   private CqlSession session;
   private CassandraClient client;
@@ -71,6 +76,7 @@ public class CommitBufferTest {
 
   private String name;
   @Mock private Admin admin;
+  private SubPartitioner partitioner;
 
   @BeforeEach
   public void before(final TestInfo info, final CassandraContainer<?> cassandra) {
@@ -81,13 +87,18 @@ public class CommitBufferTest {
         .withKeyspace("responsive_clients") // NOTE: this keyspace is expected to exist
         .build();
     client = new CassandraClient(session);
-    changelogTp = new TopicPartition("log", 0);
+    changelogTp = new TopicPartition("log", KAFKA_PARTITION);
+    partitioner = SubPartitioner.NO_SUBPARTITIONS;
 
     client.createDataTable(name);
     client.prepareStatements(name);
 
     when(admin.deleteRecords(Mockito.any()))
         .thenReturn(new DeleteRecordsResult(Map.of()));
+  }
+
+  private void setPartitioner(final int factor) {
+    partitioner = new SubPartitioner(factor, k -> ByteBuffer.wrap(k.get()).getInt());
   }
 
   @AfterEach
@@ -100,9 +111,9 @@ public class CommitBufferTest {
   public void shouldFlushAndUpdateOffsetWhenLargerOffset() {
     // Given:
     final String tableName = name;
-    client.initializeOffset(tableName, 0);
     final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
-        client, tableName, changelogTp, admin, ResponsivePartitionedStore.PLUGIN, true, 0);
+        client, tableName, changelogTp, admin, PLUGIN, true, 0, partitioner);
+    buffer.init();
 
     // When:
     for (int i = 0; i < CommitBuffer.MAX_BATCH_SIZE * 1.5; i++) {
@@ -111,18 +122,66 @@ public class CommitBufferTest {
     buffer.flush(100L);
 
     // Then:
-    final byte[] value = client.get(tableName, 0, KEY);
+    final byte[] value = client.get(tableName, KAFKA_PARTITION, KEY);
     assertThat(value, is(VALUE));
-    assertThat(client.getOffset(tableName, 0).offset, is(100L));
+    assertThat(client.getOffset(tableName, KAFKA_PARTITION).offset, is(100L));
+  }
+
+  @Test
+  public void shouldExplodeFlushAndUpdateOffsetWhenLargerOffset() {
+    // Given:
+    setPartitioner(2);
+    final String tableName = name;
+    final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
+        client, tableName, changelogTp, admin, PLUGIN, true, 0, partitioner);
+    buffer.init();
+
+    // When:
+    for (int i = 0; i < CommitBuffer.MAX_BATCH_SIZE * 2.5; i++) {
+      final byte[] array = ByteBuffer.allocate(4).putInt(i).array();
+      buffer.put(new Bytes(array), VALUE);
+    }
+    buffer.flush(100L);
+
+    // Then:
+    assertThat(client.get(tableName, KAFKA_PARTITION * 2, KEY), is(VALUE));
+    assertThat(client.get(tableName, KAFKA_PARTITION * 2 + 1, KEY2), is(VALUE));
+
+    assertThat(client.getOffset(tableName, KAFKA_PARTITION * 2).offset, is(100L));
+    assertThat(client.getOffset(tableName, KAFKA_PARTITION * 2 + 1).offset, is(100L));
+  }
+
+  @Test
+  public void shouldExplodeFlushWhenThereAreEmptyPartitionSets() {
+    // Given:
+    setPartitioner(2);
+    final String tableName = name;
+    final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
+        client, tableName, changelogTp, admin, PLUGIN, true, 0, partitioner);
+    buffer.init();
+
+    // When:
+    for (int i = 0; i < CommitBuffer.MAX_BATCH_SIZE * 1.5; i++) {
+      // i << 1 ensures they all go to partition 0
+      final byte[] array = ByteBuffer.allocate(4).putInt(i << 1).array();
+      buffer.put(new Bytes(array), VALUE);
+    }
+    buffer.flush(100L);
+
+    // Then:
+    assertThat(client.get(tableName, KAFKA_PARTITION * 2, KEY), is(VALUE));
+
+    assertThat(client.getOffset(tableName, KAFKA_PARTITION * 2).offset, is(100L));
+    assertThat(client.getOffset(tableName, KAFKA_PARTITION * 2 + 1).offset, is(100L));
   }
 
   @Test
   public void shouldTruncateTopicAfterFlushIfTruncateEnabled() {
     // Given:
     final String tableName = name;
-    client.initializeOffset(tableName, 0);
     final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
-        client, tableName, changelogTp, admin, ResponsivePartitionedStore.PLUGIN, true, 0);
+        client, tableName, changelogTp, admin, PLUGIN, true, 0, partitioner);
+    buffer.init();
     for (int i = 0; i < CommitBuffer.MAX_BATCH_SIZE * 1.5; i++) {
       buffer.put(KEY, VALUE);
     }
@@ -138,9 +197,10 @@ public class CommitBufferTest {
   public void shouldNotTruncateTopicAfterFlushIfTruncateDisabled() {
     // Given:
     final String tableName = name;
-    client.initializeOffset(tableName, 0);
     final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
-        client, tableName, changelogTp, admin, ResponsivePartitionedStore.PLUGIN, false, 0);
+        client, tableName, changelogTp, admin, PLUGIN, false, 0, partitioner);
+    buffer.init();
+
     for (int i = 0; i < CommitBuffer.MAX_BATCH_SIZE * 1.5; i++) {
       buffer.put(KEY, VALUE);
     }
@@ -156,9 +216,10 @@ public class CommitBufferTest {
   public void shouldOnlyFlushWhenBufferFull() {
     // Given:
     final String tableName = name;
-    client.initializeOffset(tableName, 0);
     final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
-        client, tableName, changelogTp, admin, ResponsivePartitionedStore.PLUGIN, false, 10);
+        client, tableName, changelogTp, admin, PLUGIN, false, 10, partitioner);
+    buffer.init();
+
     for (byte i = 0; i < 9; i++) {
       buffer.put(Bytes.wrap(new byte[]{i}), VALUE);
     }
@@ -167,27 +228,27 @@ public class CommitBufferTest {
     buffer.flush(9L);
 
     // Then:
-    assertThat(client.getOffset(tableName, 0).offset, is(-1L));
+    assertThat(client.getOffset(tableName, KAFKA_PARTITION).offset, is(-1L));
     buffer.put(Bytes.wrap(new byte[]{10}), VALUE);
     buffer.flush(10L);
-    assertThat(client.getOffset(tableName, 0).offset, is(10L));
+    assertThat(client.getOffset(tableName, KAFKA_PARTITION).offset, is(10L));
   }
 
   @Test
   public void shouldDeleteRowInCassandraWithTombstone() {
     // Given:
     final String table = name;
-    client.initializeOffset(table, 0);
-    client.insertData(table, 0, KEY, VALUE);
+    client.execute(client.insertData(table, KAFKA_PARTITION, KEY, VALUE));
     final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
-        client, table, changelogTp, admin, ResponsivePartitionedStore.PLUGIN, true, 0);
+        client, table, changelogTp, admin, PLUGIN, true, 0, partitioner);
+    buffer.init();
 
     // When:
-    buffer.tombstone(Bytes.wrap(new byte[]{1}));
+    buffer.tombstone(KEY);
     buffer.flush(100L);
 
     // Then:
-    final byte[] value = client.get(table, 0, KEY);
+    final byte[] value = client.get(table, KAFKA_PARTITION, KEY);
     assertThat(value, nullValue());
   }
 
@@ -195,10 +256,10 @@ public class CommitBufferTest {
   public void shouldThrowErrorOnFlushWhenSmallerOffset() {
     // Given:
     final String tableName = name;
-    client.initializeOffset(tableName, 0);
-    client.execute(client.revokePermit(tableName, 0, 101));
     final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
-        client, tableName, changelogTp, admin, ResponsivePartitionedStore.PLUGIN, true, 0);
+        client, tableName, changelogTp, admin, PLUGIN, true, 0, partitioner);
+    buffer.init();
+    client.execute(client.revokePermit(tableName, KAFKA_PARTITION, 101));
 
     // Expect
     // When:
@@ -212,10 +273,11 @@ public class CommitBufferTest {
   public void shouldThrowErrorOnFlushWhenDifferentTxnIdIsSet() {
     // Given:
     final String tableName = name;
-    client.initializeOffset(tableName, 0);
-    client.execute(client.acquirePermit(tableName, 0, UNSET_PERMIT, UUID.randomUUID(), 1));
     final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
-        client, tableName, changelogTp, admin, ResponsivePartitionedStore.PLUGIN, true, 0);
+        client, tableName, changelogTp, admin, PLUGIN, true, 0, partitioner);
+    buffer.init();
+    client.execute(
+        client.acquirePermit(tableName, KAFKA_PARTITION, UNSET_PERMIT, UUID.randomUUID(), 1));
 
     // Expect
     // When:
@@ -229,10 +291,10 @@ public class CommitBufferTest {
   public void shouldThrowErrorOnFlushWhenEqualOffset() {
     // Given:
     final String tableName = name;
-    client.initializeOffset(tableName, 0);
-    client.execute(client.revokePermit(tableName, 0, 100));
     final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
-        client, tableName, changelogTp, admin, ResponsivePartitionedStore.PLUGIN, true, 0);
+        client, tableName, changelogTp, admin, PLUGIN, true, 0, partitioner);
+    buffer.init();
+    client.execute(client.revokePermit(tableName, KAFKA_PARTITION, 100));
 
     // Expect
     // When:
@@ -246,10 +308,10 @@ public class CommitBufferTest {
   public void shouldRestoreRecordsGreaterThanCassandraOffset() {
     // Given:
     final String tableName = name;
-    client.initializeOffset(tableName, 0);
-    client.execute(client.revokePermit(tableName, 0, 100));
     final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
-        client, tableName, changelogTp, admin, ResponsivePartitionedStore.PLUGIN, true, 0);
+        client, tableName, changelogTp, admin, PLUGIN, true, 0, partitioner);
+    buffer.init();
+    client.execute(client.revokePermit(tableName, KAFKA_PARTITION, 100));
 
     final ConsumerRecord<byte[], byte[]> ignored = new ConsumerRecord<>(
         changelogTp.topic(), changelogTp.partition(), 100, new byte[]{1}, new byte[]{1});
@@ -260,17 +322,18 @@ public class CommitBufferTest {
     buffer.restoreBatch(List.of(ignored, restored));
 
     // Then:
-    assertThat(client.getOffset(tableName, 0).offset, is(101L));
+    assertThat(client.getOffset(tableName, KAFKA_PARTITION).offset, is(101L));
   }
 
   @Test
   public void shouldRestoreStreamsBatchLargerThanCassandraBatch() {
     // Given:
     final String tableName = name;
-    client.initializeOffset(tableName, 0);
-    client.execute(client.revokePermit(tableName, 0, 100));
     final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
-        client, tableName, changelogTp, admin, ResponsivePartitionedStore.PLUGIN, true, 0, 3);
+        client, tableName, changelogTp, admin, PLUGIN, true, 0, 3, partitioner);
+    buffer.init();
+    client.execute(client.revokePermit(tableName, 0, 100));
+
     final List<ConsumerRecord<byte[], byte[]>> records = IntStream.range(0, 5)
         .mapToObj(i -> new ConsumerRecord<>(
             changelogTp.topic(),
@@ -288,7 +351,7 @@ public class CommitBufferTest {
       assertThat(
           client.get(
               tableName,
-              0,
+              KAFKA_PARTITION,
               Bytes.wrap(Integer.toString(i).getBytes(Charset.defaultCharset()))),
           is(Integer.toString(i).getBytes(Charset.defaultCharset())));
     }
@@ -299,10 +362,10 @@ public class CommitBufferTest {
   public void shouldIgnoreFlushFailuresOnRestore() {
     // Given:
     final String tableName = name;
-    client.initializeOffset(tableName, 0);
-    client.execute(client.revokePermit(tableName, 0, 100));
     final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
-        client, tableName, changelogTp, admin, ResponsivePartitionedStore.PLUGIN, true, 0);
+        client, tableName, changelogTp, admin, PLUGIN, true, 0, partitioner);
+    buffer.init();
+    client.execute(client.revokePermit(tableName, KAFKA_PARTITION, 100));
 
     final CountDownLatch latch1 = new CountDownLatch(0);
     final CountDownLatch latch2 = new CountDownLatch(0);
@@ -321,7 +384,7 @@ public class CommitBufferTest {
     try {
       executor.submit(() -> {
         latch2.await();
-        client.execute(client.revokePermit(tableName, 0, 102));
+        client.execute(client.revokePermit(tableName, KAFKA_PARTITION, 102));
         latch1.countDown();
         return null;
       });
@@ -332,6 +395,34 @@ public class CommitBufferTest {
 
     // Then:
     assertThat(buffer.size(), is(0)); // nothing should have been added
+  }
+
+  @Test
+  public void shouldRevokeCorruptedPermitsOnInit() {
+    // Given:
+    final String tableName = name;
+    final CommitBuffer<Bytes> buffer = new CommitBuffer<>(
+        client, tableName, changelogTp, admin, PLUGIN, true, 0, partitioner);
+    // first initialize the offsets
+    client.initializeOffset(tableName, 0);
+
+    // simulate that offset 100 was already written
+    client.execute(client.revokePermit(tableName, 0, 100L));
+    client.execute(client.acquirePermit(tableName, 0, UNSET_PERMIT, UUID.randomUUID(), 100L));
+
+    // When:
+    buffer.init();
+
+    // Then:
+    final var result = client.execute(
+        new SimpleStatementBuilder(
+            "SELECT offset, permit FROM " + tableName + " WHERE partitionKey = 0"
+        ).build()
+    ).all();
+
+    assertThat(result.size(), is(1));
+    assertThat(result.get(0).get("offset", Long.class), is(100L));
+    assertThat(result.get(0).get("permit", UUID.class), is(UNSET_PERMIT));
   }
 
 }

--- a/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsivePartitionedStoreRestoreIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsivePartitionedStoreRestoreIntegrationTest.java
@@ -54,7 +54,7 @@ import dev.responsive.kafka.api.CassandraClientFactory;
 import dev.responsive.kafka.api.DefaultCassandraClientFactory;
 import dev.responsive.kafka.api.ResponsiveKafkaStreams;
 import dev.responsive.kafka.api.ResponsiveStores;
-import dev.responsive.kafka.config.ResponsiveDriverConfig;
+import dev.responsive.kafka.config.ResponsiveConfig;
 import dev.responsive.utils.ContainerExtension;
 import dev.responsive.utils.IntegrationTestUtils;
 import dev.responsive.utils.ResponsiveConfigParam;
@@ -163,7 +163,7 @@ public class ResponsivePartitionedStoreRestoreIntegrationTest {
 
       // Make sure changelog is even w/ cassandra
       final CassandraClient cassandraClient = defaultFactory.createCassandraClient(
-          defaultFactory.createCqlSession(new ResponsiveDriverConfig(properties))
+          defaultFactory.createCqlSession(new ResponsiveConfig(properties))
       );
       final long cassandraOffset = cassandraClient.getOffset(aggName(), 0).offset;
       assertThat(cassandraOffset, greaterThan(0L));
@@ -216,7 +216,7 @@ public class ResponsivePartitionedStoreRestoreIntegrationTest {
 
     // Make sure changelog is ahead of cassandra
     final CassandraClient cassandraClient = defaultFactory.createCassandraClient(
-        defaultFactory.createCqlSession(new ResponsiveDriverConfig(properties))
+        defaultFactory.createCqlSession(new ResponsiveConfig(properties))
     );
     final long cassandraOffset = cassandraClient.getOffset(aggName(), 0).offset;
     assertThat(cassandraOffset, greaterThan(0L));
@@ -359,7 +359,7 @@ public class ResponsivePartitionedStoreRestoreIntegrationTest {
     private final AtomicReference<Fault> fault = new AtomicReference<>(null);
 
     @Override
-    public CqlSession createCqlSession(ResponsiveDriverConfig config) {
+    public CqlSession createCqlSession(ResponsiveConfig config) {
       final CqlSession wrapped = wrappedFactory.createCqlSession(config);
       final var spy = spy(wrapped);
       doAnswer(a -> {
@@ -443,7 +443,7 @@ public class ResponsivePartitionedStoreRestoreIntegrationTest {
     properties.put(consumerPrefix(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG), MAX_POLL_MS);
     properties.put(consumerPrefix(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG), MAX_POLL_MS - 1);
 
-    properties.put(ResponsiveDriverConfig.STORE_FLUSH_RECORDS_THRESHOLD, 0);
+    properties.put(ResponsiveConfig.STORE_FLUSH_RECORDS_THRESHOLD, 0);
 
     return properties;
   }

--- a/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsiveStoreTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsiveStoreTest.java
@@ -27,7 +27,7 @@ import static org.mockito.Mockito.when;
 import dev.responsive.db.CassandraClient;
 import dev.responsive.db.CassandraClient.OffsetRow;
 import dev.responsive.kafka.api.InternalConfigs;
-import dev.responsive.kafka.config.ResponsiveDriverConfig;
+import dev.responsive.kafka.config.ResponsiveConfig;
 import dev.responsive.utils.RemoteMonitor;
 import dev.responsive.utils.TableName;
 import java.util.HashMap;
@@ -89,7 +89,7 @@ public class ResponsiveStoreTest {
         StreamsConfig.APPLICATION_ID_CONFIG, "test",
         StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, StringSerde.class,
         StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, StringSerde.class,
-        ResponsiveDriverConfig.TENANT_ID_CONFIG, "foo"
+        ResponsiveConfig.TENANT_ID_CONFIG, "foo"
     ));
     config.putAll(
         new InternalConfigs.Builder()

--- a/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsiveWindowIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsiveWindowIntegrationTest.java
@@ -16,10 +16,10 @@
 
 package dev.responsive.kafka.store;
 
-import static dev.responsive.kafka.config.ResponsiveDriverConfig.STORAGE_DATACENTER_CONFIG;
-import static dev.responsive.kafka.config.ResponsiveDriverConfig.STORAGE_HOSTNAME_CONFIG;
-import static dev.responsive.kafka.config.ResponsiveDriverConfig.STORAGE_PORT_CONFIG;
-import static dev.responsive.kafka.config.ResponsiveDriverConfig.TENANT_ID_CONFIG;
+import static dev.responsive.kafka.config.ResponsiveConfig.STORAGE_DATACENTER_CONFIG;
+import static dev.responsive.kafka.config.ResponsiveConfig.STORAGE_HOSTNAME_CONFIG;
+import static dev.responsive.kafka.config.ResponsiveConfig.STORAGE_PORT_CONFIG;
+import static dev.responsive.kafka.config.ResponsiveConfig.TENANT_ID_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.MAX_POLL_RECORDS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG;
@@ -41,7 +41,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import dev.responsive.kafka.api.ResponsiveKafkaStreams;
 import dev.responsive.kafka.api.ResponsiveStores;
 import dev.responsive.kafka.api.ResponsiveWindowedStoreSupplier;
-import dev.responsive.kafka.config.ResponsiveDriverConfig;
+import dev.responsive.kafka.config.ResponsiveConfig;
 import dev.responsive.utils.ContainerExtension;
 import java.time.Duration;
 import java.util.HashMap;
@@ -371,7 +371,7 @@ public class ResponsiveWindowIntegrationTest {
 
     properties.put(consumerPrefix(MAX_POLL_RECORDS_CONFIG), 1);
 
-    properties.put(ResponsiveDriverConfig.STORE_FLUSH_RECORDS_THRESHOLD, 1);
+    properties.put(ResponsiveConfig.STORE_FLUSH_RECORDS_THRESHOLD, 1);
 
     return properties;
   }

--- a/kafka-client/src/test/java/dev/responsive/utils/ContainerExtension.java
+++ b/kafka-client/src/test/java/dev/responsive/utils/ContainerExtension.java
@@ -16,18 +16,17 @@
 
 package dev.responsive.utils;
 
-import static dev.responsive.kafka.config.ResponsiveDriverConfig.STORAGE_DATACENTER_CONFIG;
-import static dev.responsive.kafka.config.ResponsiveDriverConfig.STORAGE_HOSTNAME_CONFIG;
-import static dev.responsive.kafka.config.ResponsiveDriverConfig.STORAGE_PORT_CONFIG;
-import static dev.responsive.kafka.config.ResponsiveDriverConfig.TASK_ASSIGNOR_CLASS_OVERRIDE;
-import static dev.responsive.kafka.config.ResponsiveDriverConfig.TENANT_ID_CONFIG;
+import static dev.responsive.kafka.config.ResponsiveConfig.STORAGE_DATACENTER_CONFIG;
+import static dev.responsive.kafka.config.ResponsiveConfig.STORAGE_HOSTNAME_CONFIG;
+import static dev.responsive.kafka.config.ResponsiveConfig.STORAGE_PORT_CONFIG;
+import static dev.responsive.kafka.config.ResponsiveConfig.TASK_ASSIGNOR_CLASS_OVERRIDE;
+import static dev.responsive.kafka.config.ResponsiveConfig.TENANT_ID_CONFIG;
 import static org.apache.kafka.clients.CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG;
 import static org.apache.kafka.streams.StreamsConfig.InternalConfig.INTERNAL_TASK_ASSIGNOR_CLASS;
 
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.kafka.clients.admin.Admin;
-import org.apache.kafka.streams.StreamsConfig.InternalConfig;
 import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;

--- a/kafka-client/src/test/java/dev/responsive/utils/SubPartitionerTest.java
+++ b/kafka-client/src/test/java/dev/responsive/utils/SubPartitionerTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.utils;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.kafka.common.utils.Bytes;
+import org.junit.jupiter.api.Test;
+
+class SubPartitionerTest {
+
+  @Test
+  public void shouldMapPartitionsToLargerSpace() {
+    // Given:
+    final var partitioner = new SubPartitioner(2, k -> (int) k.get()[0]);
+
+    // When:
+    final int zero = partitioner.partition(0, Bytes.wrap(new byte[]{0}));
+    final int one = partitioner.partition(0, Bytes.wrap(new byte[]{1}));
+    final int two = partitioner.partition(1, Bytes.wrap(new byte[]{2}));
+    final int three = partitioner.partition(1, Bytes.wrap(new byte[]{3}));
+
+    // Then:
+    assertThat(zero, is(0));
+    assertThat(one, is(1));
+    assertThat(two, is(2));
+    assertThat(three, is(3));
+  }
+
+  @Test
+  public void shouldIterateAllSubPartitions() {
+    // Given:
+    final var partitioner = new SubPartitioner(2, k -> (int) k.get()[0]);
+
+    // When:
+    final List<Integer> result = partitioner.all(2).boxed().collect(Collectors.toList());
+
+    // Then:
+    assertThat(result, contains(4, 5));
+  }
+
+}

--- a/kafka-client/src/test/resources/junit-platform.properties
+++ b/kafka-client/src/test/resources/junit-platform.properties
@@ -1,0 +1,17 @@
+#
+# Copyright 2023 Responsive Computing, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+junit.jupiter.execution.timeout.default=5m


### PR DESCRIPTION
Review guide:

1. Rename `ResponsiveDriverConfig` to `ResponsiveConfig` since we no longer have a `ResponsiveDriver` class
2. Introduce `SubPartitioner` that has the sub-partitioning algorithm
3. Make changes to `CommitBuffer` to support subpartitions
4. Tests for the above

This PR doesn't make any functional changes since it is hardcodes everything to `SubPartitioner.NO_SUBPARTITIONS`. The next PR will wire through and add more E2E testing.