### PR TITLE
add local flush triggers

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/config/ResponsiveConfig.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/config/ResponsiveConfig.java
@@ -91,20 +91,17 @@ public class ResponsiveConfig extends AbstractConfig {
   //       the total amount of buffered data. That config can be used to keep a bound on
   //       memory usage and restore times.
 
-  public static final String STORE_FLUSH_RECORDS_TRIGGER
-      = "responsive.store.flush.trigger.local.records";
+  public static final String STORE_FLUSH_RECORDS_TRIGGER_CONFIG = "responsive.store.flush.trigger.local.records";
   public static final String STORE_FLUSH_RECORDS_TRIGGER_DOC = "The number of records to"
       + " accumulate in each store before flushing to remote";
   public static final int STORE_FLUSH_RECORDS_TRIGGER_DEFAULT = Integer.MAX_VALUE;
 
-  public static final String STORE_FLUSH_BYTES_TRIGGER
-      = "responsive.store.flush.trigger.local.bytes";
+  public static final String STORE_FLUSH_BYTES_TRIGGER_CONFIG = "responsive.store.flush.trigger.local.bytes";
   public static final String STORE_FLUSH_BYTES_TRIGGER_DOC = "The size in bytes of buffered"
       + "records to accumulate in each store before flushing to remote";
   public static final Long STORE_FLUSH_BYTES_TRIGGER_DEFAULT = Long.MAX_VALUE;
 
-  public static final String STORE_FLUSH_INTERVAL_TRIGGER
-      = "responsive.store.flush.trigger.local.interval.ms";
+  public static final String STORE_FLUSH_INTERVAL_TRIGGER_MS_CONFIG = "responsive.store.flush.trigger.local.interval.ms";
   public static final String STORE_FLUSH_INTERVAL_TRIGGER_DOC = "The maximum time to wait "
       + "between consecutive flushes of a given store. Note that this is only evaluated at "
       + "commit time.";
@@ -182,7 +179,7 @@ public class ResponsiveConfig extends AbstractConfig {
           Importance.MEDIUM,
           REQUEST_TIMEOUT_MS_DOC
       ).define(
-          STORE_FLUSH_RECORDS_TRIGGER,
+          STORE_FLUSH_RECORDS_TRIGGER_CONFIG,
           Type.INT,
           STORE_FLUSH_RECORDS_TRIGGER_DEFAULT,
           Importance.MEDIUM,
@@ -200,13 +197,13 @@ public class ResponsiveConfig extends AbstractConfig {
           Importance.MEDIUM,
           MAX_CONCURRENT_REMOTE_WRITES_DOC
       ).define(
-          STORE_FLUSH_BYTES_TRIGGER,
+          STORE_FLUSH_BYTES_TRIGGER_CONFIG,
           Type.LONG,
           STORE_FLUSH_BYTES_TRIGGER_DEFAULT,
           Importance.MEDIUM,
           STORE_FLUSH_BYTES_TRIGGER_DOC
       ).define(
-          STORE_FLUSH_INTERVAL_TRIGGER,
+          STORE_FLUSH_INTERVAL_TRIGGER_MS_CONFIG,
           Type.LONG,
           STORE_FLUSH_INTERVAL_TRIGGER_DEFAULT,
           Importance.MEDIUM,

--- a/kafka-client/src/main/java/dev/responsive/kafka/config/ResponsiveConfig.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/config/ResponsiveConfig.java
@@ -19,6 +19,7 @@ package dev.responsive.kafka.config;
 import dev.responsive.db.CassandraClient;
 import dev.responsive.utils.SubPartitioner;
 import dev.responsive.utils.TableName;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.OptionalInt;
@@ -65,18 +66,6 @@ public class ResponsiveConfig extends AbstractConfig {
   public static final String CLIENT_SECRET_CONFIG = "responsive.client.secret";
   private static final String CLIENT_SECRET_DOC = "The client secret for authenticated access";
 
-  // ------------------ store tuning parameters -------------------------------
-
-  // TODO: we should have another config that's applied globally, that sets a size bound on
-  //       the total amount of buffered data. That config can be used to keep a bound on
-  //       memory usage and restore times. This config sets a store-level threshold for optimal
-  //       transaction sizes.
-  public static final String STORE_FLUSH_RECORDS_THRESHOLD
-      = "responsive.store.flush.records.interval";
-  public static final String STORE_FLUSH_RECORDS_THRESHOLD_DOC = "The number of records to"
-      + " accumulate in each store before flushing to remote";
-  public static final int STORE_FLUSH_RECORDS_THRESHOLD_DEFAULT = 10000;
-
   // ------------------ request configurations --------------------------------
 
   public static final String REQUEST_TIMEOUT_MS_CONFIG = "responsive.request.timeout.ms";
@@ -97,6 +86,30 @@ public class ResponsiveConfig extends AbstractConfig {
       + "partitions as well.";
   public static final int STORAGE_DESIRED_NUM_PARTITIONS_DEFAULT = 4096;
   public static final int NO_SUBPARTITIONS = -1;
+
+  // TODO: we should have another config that's applied globally, that sets a size bound on
+  //       the total amount of buffered data. That config can be used to keep a bound on
+  //       memory usage and restore times.
+
+  public static final String STORE_FLUSH_RECORDS_TRIGGER
+      = "responsive.store.flush.trigger.local.records";
+  public static final String STORE_FLUSH_RECORDS_TRIGGER_DOC = "The number of records to"
+      + " accumulate in each store before flushing to remote";
+  public static final int STORE_FLUSH_RECORDS_TRIGGER_DEFAULT = Integer.MAX_VALUE;
+
+  public static final String STORE_FLUSH_BYTES_TRIGGER
+      = "responsive.store.flush.trigger.local.bytes";
+  public static final String STORE_FLUSH_BYTES_TRIGGER_DOC = "The size in bytes of buffered"
+      + "records to accumulate in each store before flushing to remote";
+  public static final Long STORE_FLUSH_BYTES_TRIGGER_DEFAULT = Long.MAX_VALUE;
+
+  public static final String STORE_FLUSH_INTERVAL_TRIGGER
+      = "responsive.store.flush.trigger.local.interval.ms";
+  public static final String STORE_FLUSH_INTERVAL_TRIGGER_DOC = "The maximum time to wait "
+      + "between consecutive flushes of a given store. Note that this is only evaluated at "
+      + "commit time.";
+  public static final long STORE_FLUSH_INTERVAL_TRIGGER_DEFAULT
+      = Duration.ofSeconds(30).toMillis();
 
   // TODO: consider if we want this as a local, global or per-store configuration
   public static final String MAX_CONCURRENT_REMOTE_WRITES_CONFIG = "responsive.max.concurrent.writes";
@@ -169,11 +182,11 @@ public class ResponsiveConfig extends AbstractConfig {
           Importance.MEDIUM,
           REQUEST_TIMEOUT_MS_DOC
       ).define(
-          STORE_FLUSH_RECORDS_THRESHOLD,
+          STORE_FLUSH_RECORDS_TRIGGER,
           Type.INT,
-          STORE_FLUSH_RECORDS_THRESHOLD_DEFAULT,
+          STORE_FLUSH_RECORDS_TRIGGER_DEFAULT,
           Importance.MEDIUM,
-          STORE_FLUSH_RECORDS_THRESHOLD_DOC
+          STORE_FLUSH_RECORDS_TRIGGER_DOC
       ).define(
           STORAGE_DESIRED_NUM_PARTITION_CONFIG,
           Type.INT,
@@ -186,6 +199,18 @@ public class ResponsiveConfig extends AbstractConfig {
           MAX_CONCURRENT_REMOTE_WRITES_DEFAULT,
           Importance.MEDIUM,
           MAX_CONCURRENT_REMOTE_WRITES_DOC
+      ).define(
+          STORE_FLUSH_BYTES_TRIGGER,
+          Type.LONG,
+          STORE_FLUSH_BYTES_TRIGGER_DEFAULT,
+          Importance.MEDIUM,
+          STORE_FLUSH_BYTES_TRIGGER_DOC
+      ).define(
+          STORE_FLUSH_INTERVAL_TRIGGER,
+          Type.LONG,
+          STORE_FLUSH_INTERVAL_TRIGGER_DEFAULT,
+          Importance.MEDIUM,
+          STORE_FLUSH_INTERVAL_TRIGGER_DOC
       );
 
   private static class NonEmptyPassword implements Validator {

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/CommitBuffer.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/CommitBuffer.java
@@ -242,41 +242,51 @@ class CommitBuffer<K> implements RecordBatchingStateRestoreCallback {
     boolean bytesTrigger = false;
     boolean timeTrigger = false;
     if (buffer.getReader().size() >= flushTriggers.getRecords()) {
-      LOG.info("will flush due to records buffered {} over trigger {}",
+      LOG.info("{}[{}] will flush due to records buffered {} over trigger {}",
+          tableName,
+          partition,
           buffer.getReader().size(),
           flushTriggers.getRecords()
       );
       recordsTrigger = true;
     } else {
-      LOG.debug("records buffered {} not over trigger {}",
+      LOG.debug("{}[{}] records buffered {} not over trigger {}",
+          tableName,
+          partition,
           buffer.getReader().size(),
           flushTriggers.getRecords()
       );
     }
-    // This is a little inefficient (as opposed to maintaining the size as we go along).
-    // On the other hand, it's much less error-prone.
     final long totalBytesBuffered = totalBytesBuffered();
     if (totalBytesBuffered >= flushTriggers.getBytes()) {
-      LOG.info("will flush due to bytes buffered {} over bytes trigger {}",
+      LOG.info("{}[{}] will flush due to bytes buffered {} over bytes trigger {}",
+          tableName,
+          partition,
           totalBytesBuffered,
           flushTriggers.getBytes()
       );
       bytesTrigger = true;
     } else {
-      LOG.debug("bytes buffered {} not over trigger {}",
+      LOG.debug("{}[{}] bytes buffered {} not over trigger {}",
+          tableName,
+          partition,
           totalBytesBuffered,
           flushTriggers.getBytes()
       );
     }
     final var now = clock.get();
     if (lastFlush.plus(flushTriggers.getInterval()).isBefore(now)) {
-      LOG.info("will flush due to time since last flush {} over interval trigger {}",
+      LOG.info("{}[{}] will flush due to time since last flush {} over interval trigger {}",
+          tableName,
+          partition,
           Duration.between(lastFlush, now),
           now
       );
       timeTrigger = true;
     } else {
-      LOG.debug("time since last flush {} not over trigger {}",
+      LOG.debug("{}[{}] time since last flush {} not over trigger {}",
+          tableName,
+          partition,
           Duration.between(lastFlush, now),
           now
       );

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/FlushTriggers.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/FlushTriggers.java
@@ -12,9 +12,9 @@ public class FlushTriggers {
 
   public static FlushTriggers fromConfig(final ResponsiveConfig config) {
     return new FlushTriggers(
-        config.getInt(ResponsiveConfig.STORE_FLUSH_RECORDS_TRIGGER),
-        config.getLong(ResponsiveConfig.STORE_FLUSH_BYTES_TRIGGER),
-        Duration.ofMillis(config.getLong(ResponsiveConfig.STORE_FLUSH_INTERVAL_TRIGGER))
+        config.getInt(ResponsiveConfig.STORE_FLUSH_RECORDS_TRIGGER_CONFIG),
+        config.getLong(ResponsiveConfig.STORE_FLUSH_BYTES_TRIGGER_CONFIG),
+        Duration.ofMillis(config.getLong(ResponsiveConfig.STORE_FLUSH_INTERVAL_TRIGGER_MS_CONFIG))
     );
   }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/FlushTriggers.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/FlushTriggers.java
@@ -1,0 +1,50 @@
+package dev.responsive.kafka.store;
+
+import dev.responsive.kafka.config.ResponsiveConfig;
+import java.time.Duration;
+
+public class FlushTriggers {
+  public static FlushTriggers ALWAYS = new FlushTriggers(0, 0, Duration.ZERO);
+
+  private final int records;
+  private final long bytes;
+  private final Duration interval;
+
+  public static FlushTriggers fromConfig(final ResponsiveConfig config) {
+    return new FlushTriggers(
+        config.getInt(ResponsiveConfig.STORE_FLUSH_RECORDS_TRIGGER),
+        config.getLong(ResponsiveConfig.STORE_FLUSH_BYTES_TRIGGER),
+        Duration.ofMillis(config.getLong(ResponsiveConfig.STORE_FLUSH_INTERVAL_TRIGGER))
+    );
+  }
+
+  static FlushTriggers ofRecords(final int records) {
+    return new FlushTriggers(records, Long.MAX_VALUE, Duration.ofMillis(Long.MAX_VALUE));
+  }
+
+  static FlushTriggers ofBytes(final long bytes) {
+    return new FlushTriggers(Integer.MAX_VALUE, bytes, Duration.ofMillis(Long.MAX_VALUE));
+  }
+
+  static FlushTriggers ofInterval(final Duration interval) {
+    return new FlushTriggers(Integer.MAX_VALUE, Long.MAX_VALUE, interval);
+  }
+
+  private FlushTriggers(final int records, final long bytes, final Duration interval) {
+    this.records = records;
+    this.bytes = bytes;
+    this.interval = interval;
+  }
+
+  public int getRecords() {
+    return records;
+  }
+
+  public long getBytes() {
+    return bytes;
+  }
+
+  public Duration getInterval() {
+    return interval;
+  }
+}

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsivePartitionedStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsivePartitionedStore.java
@@ -131,7 +131,7 @@ public class ResponsivePartitionedStore implements KeyValueStore<Bytes, byte[]> 
               sharedClients.admin,
               context.appConfigs()
           ),
-          config.getInt(ResponsiveConfig.STORE_FLUSH_RECORDS_THRESHOLD),
+          FlushTriggers.fromConfig(driverConfig),
           partitioner
       );
       buffer.init();

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsivePartitionedStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsivePartitionedStore.java
@@ -131,7 +131,7 @@ public class ResponsivePartitionedStore implements KeyValueStore<Bytes, byte[]> 
               sharedClients.admin,
               context.appConfigs()
           ),
-          FlushTriggers.fromConfig(driverConfig),
+          FlushTriggers.fromConfig(config),
           partitioner
       );
       buffer.init();

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveWindowStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveWindowStore.java
@@ -168,7 +168,7 @@ public class ResponsiveWindowStore implements WindowStore<Bytes, byte[]> {
               sharedClients.admin,
               context.appConfigs()
           ),
-          config.getInt(ResponsiveConfig.STORE_FLUSH_RECORDS_THRESHOLD),
+          FlushTriggers.fromConfig(driverConfig),
           partitioner
       );
       buffer.init();

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveWindowStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveWindowStore.java
@@ -168,7 +168,7 @@ public class ResponsiveWindowStore implements WindowStore<Bytes, byte[]> {
               sharedClients.admin,
               context.appConfigs()
           ),
-          FlushTriggers.fromConfig(driverConfig),
+          FlushTriggers.fromConfig(config),
           partitioner
       );
       buffer.init();

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/SizeTrackingBuffer.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/SizeTrackingBuffer.java
@@ -23,7 +23,10 @@ public class SizeTrackingBuffer<K> {
   }
 
   public void put(final K key, final Result<K> value) {
-    bytes += plugin.bytes(key).get().length + (value.isTombstone ? 0 : value.value.length);
+    if (buffer.containsKey(key)) {
+      bytes -= sizeOf(key, buffer.get(key));
+    }
+    bytes += sizeOf(key, value);
     buffer.put(key, value);
   }
 
@@ -32,7 +35,11 @@ public class SizeTrackingBuffer<K> {
     buffer.clear();
   }
 
-  public NavigableMap<K, Result<K>> reader() {
+  public NavigableMap<K, Result<K>> getReader() {
     return reader;
+  }
+
+  private long sizeOf(final K key, final Result<K> value) {
+    return plugin.bytes(key).get().length + (value.isTombstone ? 0 : value.value.length);
   }
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/SizeTrackingBuffer.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/SizeTrackingBuffer.java
@@ -23,11 +23,11 @@ public class SizeTrackingBuffer<K> {
   }
 
   public void put(final K key, final Result<K> value) {
-    if (buffer.containsKey(key)) {
-      bytes -= sizeOf(key, buffer.get(key));
-    }
     bytes += sizeOf(key, value);
-    buffer.put(key, value);
+    final Result<K> old = buffer.put(key, value);
+    if (old != null) {
+      bytes -= sizeOf(key, old);
+    }
   }
 
   public void clear() {

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/SizeTrackingBuffer.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/SizeTrackingBuffer.java
@@ -1,0 +1,38 @@
+package dev.responsive.kafka.store;
+
+import dev.responsive.model.Result;
+import java.util.Collections;
+import java.util.NavigableMap;
+import java.util.Objects;
+import java.util.TreeMap;
+
+public class SizeTrackingBuffer<K> {
+  private final NavigableMap<K, Result<K>> buffer;
+  private final NavigableMap<K, Result<K>> reader;
+  private final BufferPlugin<K> plugin;
+  private long bytes = 0;
+
+  public SizeTrackingBuffer(final BufferPlugin<K> plugin) {
+    this.plugin = Objects.requireNonNull(plugin);
+    buffer = new TreeMap<>(plugin);
+    reader = Collections.unmodifiableNavigableMap(buffer);
+  }
+
+  public long getBytes() {
+    return bytes;
+  }
+
+  public void put(final K key, final Result<K> value) {
+    bytes += plugin.bytes(key).get().length + (value.isTombstone ? 0 : value.value.length);
+    buffer.put(key, value);
+  }
+
+  public void clear() {
+    bytes = 0;
+    buffer.clear();
+  }
+
+  public NavigableMap<K, Result<K>> reader() {
+    return reader;
+  }
+}

--- a/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsivePartitionedStoreRestoreIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsivePartitionedStoreRestoreIntegrationTest.java
@@ -443,7 +443,7 @@ public class ResponsivePartitionedStoreRestoreIntegrationTest {
     properties.put(consumerPrefix(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG), MAX_POLL_MS);
     properties.put(consumerPrefix(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG), MAX_POLL_MS - 1);
 
-    properties.put(ResponsiveConfig.STORE_FLUSH_RECORDS_THRESHOLD, 0);
+    properties.put(ResponsiveConfig.STORE_FLUSH_RECORDS_TRIGGER, 0);
 
     return properties;
   }

--- a/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsivePartitionedStoreRestoreIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsivePartitionedStoreRestoreIntegrationTest.java
@@ -443,7 +443,7 @@ public class ResponsivePartitionedStoreRestoreIntegrationTest {
     properties.put(consumerPrefix(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG), MAX_POLL_MS);
     properties.put(consumerPrefix(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG), MAX_POLL_MS - 1);
 
-    properties.put(ResponsiveConfig.STORE_FLUSH_RECORDS_TRIGGER, 0);
+    properties.put(ResponsiveConfig.STORE_FLUSH_RECORDS_TRIGGER_CONFIG, 0);
 
     return properties;
   }

--- a/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsiveWindowIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsiveWindowIntegrationTest.java
@@ -371,7 +371,7 @@ public class ResponsiveWindowIntegrationTest {
 
     properties.put(consumerPrefix(MAX_POLL_RECORDS_CONFIG), 1);
 
-    properties.put(ResponsiveConfig.STORE_FLUSH_RECORDS_TRIGGER, 1);
+    properties.put(ResponsiveConfig.STORE_FLUSH_RECORDS_TRIGGER_CONFIG, 1);
 
     return properties;
   }

--- a/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsiveWindowIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsiveWindowIntegrationTest.java
@@ -371,7 +371,7 @@ public class ResponsiveWindowIntegrationTest {
 
     properties.put(consumerPrefix(MAX_POLL_RECORDS_CONFIG), 1);
 
-    properties.put(ResponsiveConfig.STORE_FLUSH_RECORDS_THRESHOLD, 1);
+    properties.put(ResponsiveConfig.STORE_FLUSH_RECORDS_TRIGGER, 1);
 
     return properties;
   }

--- a/kafka-client/src/test/java/dev/responsive/kafka/store/SizeTrackingBufferTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/store/SizeTrackingBufferTest.java
@@ -1,0 +1,134 @@
+package dev.responsive.kafka.store;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import dev.responsive.model.Result;
+import java.util.List;
+import org.apache.kafka.common.utils.Bytes;
+import org.junit.jupiter.api.Test;
+
+class SizeTrackingBufferTest {
+  private final SizeTrackingBuffer<Bytes> buffer
+      = new SizeTrackingBuffer<>(ResponsivePartitionedStore.PLUGIN);
+
+  @Test
+  public void shouldReturnSizeZeroOnEmptyBuffer() {
+    assertThat(buffer.getBytes(), is(0L));
+  }
+
+  @Test
+  public void shouldTrackSizeOnInserts() {
+    // given:
+    final List<SizeCase> ops = List.of(
+        new SizeCase((byte) 1, 10, 20, 30),
+        new SizeCase((byte) 2, 8, 9, 47),
+        new SizeCase((byte) 3, 3, 7, 57)
+    );
+
+    // when/then:
+    for (int i = 0; i < ops.size(); i++) {
+      final var op = ops.get(i);
+      final Bytes k = Bytes.wrap(bytes(op.key, op.keySize));
+      final byte[] v = bytes((byte) i, op.recordSize);
+      buffer.put(k, Result.value(k, v));
+      assertThat(buffer.getBytes(), is(op.expectedTotal));
+    }
+  }
+
+  @Test
+  public void shouldTrackSizeOnInsertsWithUpdates() {
+    // given:
+    final List<SizeCase> ops = List.of(
+        new SizeCase((byte) 1, 10, 20, 30),
+        new SizeCase((byte) 2, 8, 9, 47),
+        new SizeCase((byte) 2, 3, 9, 42)
+    );
+
+    // when/then:
+    for (int i = 0; i < ops.size(); i++) {
+      final var op = ops.get(i);
+      final Bytes k = Bytes.wrap(bytes(op.key, op.keySize));
+      final byte[] v = bytes((byte) i, op.recordSize);
+      buffer.put(k, Result.value(k, v));
+      assertThat(buffer.getBytes(), is(op.expectedTotal));
+    }
+  }
+
+  @Test
+  public void shouldTrackSizeOnTombstone() {
+    // given:
+    final Bytes k1 = Bytes.wrap(bytes((byte) 1, 10));
+
+    // when:
+    buffer.put(k1, Result.tombstone(k1));
+
+    // then:
+    assertThat(buffer.getBytes(), is(10L));
+  }
+
+  @Test
+  public void shouldTrackSizeOnUpdateTombstone() {
+    // given:
+    final Bytes k1 = Bytes.wrap(bytes((byte) 1, 10));
+    buffer.put(k1, Result.tombstone(k1));
+
+    when:
+    buffer.put(k1, Result.value(k1, bytes((byte) 2, 15)));
+
+    // then:
+    assertThat(buffer.getBytes(), is(25L));
+  }
+
+  @Test
+  public void shouldTrackSizeOnUpdateFromTombstone() {
+    // given:
+    final Bytes k1 = Bytes.wrap(bytes((byte) 1, 10));
+    buffer.put(k1, Result.value(k1, bytes((byte) 2, 15)));
+
+    when:
+    buffer.put(k1, Result.tombstone(k1));
+
+    // then:
+    assertThat(buffer.getBytes(), is(10L));
+  }
+
+
+  @Test
+  public void shouldTrackSizeOnClear() {
+    // given:
+    final Bytes k1 = Bytes.wrap(bytes((byte) 1, 10));
+    buffer.put(k1, Result.value(k1, bytes((byte) 1, 15)));
+    final Bytes k2 = Bytes.wrap(bytes((byte) 2, 10));
+    buffer.put(k2, Result.value(k2, bytes((byte) 2, 15)));
+    assertThat(buffer.getBytes(), is(50L));
+
+    // when:
+    buffer.clear();
+
+    // then:
+    assertThat(buffer.getBytes(), is(0L));
+  }
+
+  private byte[] bytes(final byte val, int length) {
+    final byte[] ret = new byte[length];
+    for (int i = 0; i < length; i++) {
+      ret[i] = val;
+    }
+    return ret;
+  }
+
+  private static class SizeCase {
+    byte key;
+    int recordSize;
+    int keySize;
+    long expectedTotal;
+
+    public SizeCase(byte key, int recordSize, int keySize, int expectedTotal) {
+      this.key = key;
+      this.recordSize = recordSize;
+      this.keySize = keySize;
+      this.expectedTotal = expectedTotal;
+    }
+  }
+}


### PR DESCRIPTION
Adds some more local (per-state-store) flush triggers:
- size-based: triggers flushes when the accumulated state is over some size in bytes
- time-based: triggers flushes when some number of milliseconds has elapsed since the last flush

Renames the existing config so the config names are consistent

Changes the default to flush every 30 seconds