### PR TITLE
only write offset to base subpartition

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/db/CassandraClient.java
+++ b/kafka-client/src/main/java/dev/responsive/db/CassandraClient.java
@@ -417,6 +417,7 @@ public class CassandraClient {
     getMetadata.computeIfAbsent(tableName, k -> session.prepare(
         QueryBuilder
             .selectFrom(tableName)
+            .column(OFFSET.column())
             .column(EPOCH.column())
             .where(PARTITION_KEY.relation().isEqualTo(bindMarker(PARTITION_KEY.bind())))
             .where(DATA_KEY.relation().isEqualTo(DATA_KEY.literal(METADATA_KEY)))

--- a/kafka-client/src/main/java/dev/responsive/db/CassandraClient.java
+++ b/kafka-client/src/main/java/dev/responsive/db/CassandraClient.java
@@ -863,12 +863,9 @@ public class CassandraClient {
    */
   public MetadataRow metadata(final String tableName, final int partition) {
     final List<Row> result = session.execute(
-        QueryBuilder.selectFrom(tableName)
-            .column(OFFSET.column())
-            .column(EPOCH.column())
-            .where(PARTITION_KEY.relation().isEqualTo(PARTITION_KEY.literal(partition)))
-            .where(DATA_KEY.relation().isEqualTo(DATA_KEY.literal(METADATA_KEY)))
-            .build()
+        getMetadata.get(tableName)
+            .bind()
+            .setInt(PARTITION_KEY.bind(), partition)
     ).all();
 
     if (result.size() != 1) {

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/AtomicWriter.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/AtomicWriter.java
@@ -19,6 +19,7 @@ package dev.responsive.kafka.store;
 import com.datastax.oss.driver.api.core.cql.BatchStatementBuilder;
 import com.datastax.oss.driver.api.core.cql.BatchType;
 import com.datastax.oss.driver.api.core.cql.BatchableStatement;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.datastax.oss.driver.api.core.cql.Statement;
 import dev.responsive.db.CassandraClient;
 import dev.responsive.model.Result;
@@ -106,7 +107,10 @@ class AtomicWriter<K> {
     return partition;
   }
 
-  public CompletionStage<AtomicWriteResult> setOffset(final long offset) {
-    return executeAsync(client.setOffset(tableName, partition, offset, epoch));
+  public AtomicWriteResult setOffset(final long offset) {
+    final var result = client.execute(client.setOffset(tableName, partition, offset, epoch));
+    return result.wasApplied()
+        ? AtomicWriteResult.success(partition)
+        : AtomicWriteResult.failure(partition);
   }
 }

--- a/kafka-client/src/test/java/dev/responsive/kafka/store/CommitBufferTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/store/CommitBufferTest.java
@@ -109,7 +109,7 @@ public class CommitBufferTest {
   }
 
   @Test
-  public void shouldFlushWithCorrectEpochAndOffsetForAllSubpartitions() {
+  public void shouldFlushWithCorrectEpochForAllSubpartitionsAndOffsetForBaseSubpartition() {
     // Given:
     setPartitioner(3);
     final String tableName = name;
@@ -132,8 +132,8 @@ public class CommitBufferTest {
     assertThat(client.get(tableName, 6, k0), is(VALUE));
     assertThat(client.get(tableName, 7, k1), is(VALUE));
     assertThat(client.metadata(tableName, 6), is(new MetadataRow(100L, 1L)));
-    assertThat(client.metadata(tableName, 7), is(new MetadataRow(100L, 1L)));
-    assertThat(client.metadata(tableName, 8), is(new MetadataRow(100L, 1L)));
+    assertThat(client.metadata(tableName, 7), is(new MetadataRow(-1L, 1L)));
+    assertThat(client.metadata(tableName, 8), is(new MetadataRow(-1L, 1L)));
   }
 
   @Test

--- a/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsivePartitionedStoreRestoreIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsivePartitionedStoreRestoreIntegrationTest.java
@@ -165,6 +165,7 @@ public class ResponsivePartitionedStoreRestoreIntegrationTest {
       final CassandraClient cassandraClient = defaultFactory.createCassandraClient(
           defaultFactory.createCqlSession(new ResponsiveConfig(properties))
       );
+      cassandraClient.prepareStatements(aggName());
       final long cassandraOffset = cassandraClient.metadata(aggName(), 0).offset;
       assertThat(cassandraOffset, greaterThan(0L));
       final TopicPartition changelog
@@ -218,6 +219,7 @@ public class ResponsivePartitionedStoreRestoreIntegrationTest {
     final CassandraClient cassandraClient = defaultFactory.createCassandraClient(
         defaultFactory.createCqlSession(new ResponsiveConfig(properties))
     );
+    cassandraClient.prepareStatements(aggName());
     final long cassandraOffset = cassandraClient.metadata(aggName(), 0).offset;
     assertThat(cassandraOffset, greaterThan(0L));
     final TopicPartition changelog = new TopicPartition(name + "-" + aggName() + "-changelog", 0);


### PR DESCRIPTION
follow up from #70 

<img width="489" alt="image" src="https://github.com/responsivedev/responsive-pub/assets/3172405/b0774258-be67-4a99-a83d-24bad8277820">

Doesn't seem to affect the max process rate (expected) but the max commit time ms definitely has a stat-sig drop, which I think will reduce load on C*:

<img width="276" alt="image" src="https://github.com/responsivedev/responsive-pub/assets/3172405/28f1b899-dc8d-4678-bfb5-89221b1be46b">
