### PR TITLE
extend policy spec to support rate-based diagnosers

### DIFF
--- a/controller-api/src/main/proto/responsive/controller/internal/v1/controller.proto
+++ b/controller-api/src/main/proto/responsive/controller/internal/v1/controller.proto
@@ -31,7 +31,9 @@ message PolicyState {
 }
 
 message Action {
-  ChangeApplicationState change_application_state = 1;
+  oneof action {
+    ChangeApplicationState change_application_state = 1;
+  }
 }
 
 message ChangeApplicationState {

--- a/controller-api/src/main/proto/responsive/controller/v1/controller.proto
+++ b/controller-api/src/main/proto/responsive/controller/v1/controller.proto
@@ -81,21 +81,20 @@ message ApplicationPolicy {
 }
 
 message DemoPolicy {
-  enum DiagnoserType {
-    DIAGNOSER_TYPE_PROCESSING_RATE_SCALE_UP = 0;
-    DIAGNOSER_TYPE_PROCESSING_RATE_SCALE_DOWN = 1;
-    DIAGNOSER_TYPE_LAG = 2;
-  }
-
   message ProcessingRateDiagnoser {
     int32 rate = 1;
     optional int32 window_ms = 2;
   }
 
+  message LagDiagnoser {
+  }
+
   message Diagnoser {
-    DiagnoserType type = 1;
-    ProcessingRateDiagnoser processing_rate_scale_up = 2;
-    ProcessingRateDiagnoser processing_rate_scale_down = 3;
+    oneof diagnoser {
+      ProcessingRateDiagnoser processing_rate_scale_up = 1;
+      ProcessingRateDiagnoser processing_rate_scale_down = 2;
+      LagDiagnoser lag_scale_up = 3;
+    }
   }
 
   // TODO: change to snake case

--- a/controller-api/src/main/proto/responsive/controller/v1/controller.proto
+++ b/controller-api/src/main/proto/responsive/controller/v1/controller.proto
@@ -20,6 +20,7 @@ message PostMetricsRequest {
 }
 
 // TODO(rohan): we need to encode some ordering info (generation/version for policy, timestmap for current state)
+// todo: consider setting message fields to optional so server can validate they are set
 message UpsertPolicyRequest {
   string application_id = 1;
   int64 timestamp_ms = 2;
@@ -37,18 +38,21 @@ message EmptyRequest {
 }
 
 message SimpleResponse {
+  // todo: clean me up
   string error = 1;
 }
 
 message GetTargetStateResponse {
+  // todo: clean me up
   string error = 1;
   ApplicationState state = 2;
 }
 
-// TODO(rohan): how to support different types of applications?
 // TODO(rohan): move these to a common proto file. this file is just the grpc api
 message ApplicationState {
-  DemoApplicationState demo_state = 1;
+  oneof state {
+    DemoApplicationState demo_state = 1;
+  }
 }
 
 message DemoApplicationState {
@@ -71,9 +75,31 @@ enum PolicyStatus {
 //              also, see if we can combine with the CRD somehow
 message ApplicationPolicy {
   PolicyStatus status = 1;
-  DemoPolicy demo_policy = 2;
+  oneof policy {
+    DemoPolicy demo_policy = 2;
+  }
 }
 
 message DemoPolicy {
+  enum DiagnoserType {
+    DIAGNOSER_TYPE_PROCESSING_RATE_SCALE_UP = 0;
+    DIAGNOSER_TYPE_PROCESSING_RATE_SCALE_DOWN = 1;
+    DIAGNOSER_TYPE_LAG = 2;
+  }
+
+  message ProcessingRateDiagnoser {
+    int32 rate = 1;
+    optional int32 window_ms = 2;
+  }
+
+  message Diagnoser {
+    DiagnoserType type = 1;
+    ProcessingRateDiagnoser processing_rate_scale_up = 2;
+    ProcessingRateDiagnoser processing_rate_scale_down = 3;
+  }
+
+  // TODO: change to snake case
   int32 maxReplicas = 1;
+  int32 min_replicas = 2;
+  repeated Diagnoser diagnoser = 3;
 }

--- a/operator/src/main/java/dev/responsive/k8s/controller/ControllerProtoFactories.java
+++ b/operator/src/main/java/dev/responsive/k8s/controller/ControllerProtoFactories.java
@@ -16,19 +16,11 @@
 
 package dev.responsive.k8s.controller;
 
-import dev.responsive.k8s.crd.DemoPolicy;
 import dev.responsive.k8s.crd.ResponsivePolicy;
 import dev.responsive.k8s.crd.ResponsivePolicySpec;
-import java.util.Collections;
-import java.util.List;
-import java.util.Optional;
-import java.util.stream.Collectors;
 import responsive.controller.v1.controller.proto.ControllerOuterClass;
 import responsive.controller.v1.controller.proto.ControllerOuterClass.ApplicationPolicy;
 import responsive.controller.v1.controller.proto.ControllerOuterClass.ApplicationState;
-import responsive.controller.v1.controller.proto.ControllerOuterClass.DemoPolicy.Diagnoser;
-import responsive.controller.v1.controller.proto.ControllerOuterClass.DemoPolicy.DiagnoserType;
-import responsive.controller.v1.controller.proto.ControllerOuterClass.DemoPolicy.ProcessingRateDiagnoser;
 
 public final class ControllerProtoFactories {
   public static ControllerOuterClass.UpsertPolicyRequest upsertPolicyRequest(
@@ -56,67 +48,13 @@ public final class ControllerProtoFactories {
         .build();
   }
 
-  private static ProcessingRateDiagnoser processingRateDiagnoserFromK8sResource(
-      final DemoPolicy.ProcessingRateDiagnoser diagnoser
-  ) {
-    final var builder = ProcessingRateDiagnoser.newBuilder()
-        .setRate(diagnoser.getRate());
-    if (diagnoser.getWindowMs().isPresent()) {
-      builder.setWindowMs(diagnoser.getWindowMs().getAsInt());
-    }
-    return builder.build();
-  }
-
-  private static Diagnoser diagnoserFromK8sResource(final DemoPolicy.Diagnoser diagnoser) {
-    switch (diagnoser.getType()) {
-      case LAG_SCALE_UP:
-        return Diagnoser.newBuilder()
-            .setType(DiagnoserType.DIAGNOSER_TYPE_LAG)
-            .build();
-      case PROCESSING_RATE_SCALE_UP: {
-        return Diagnoser.newBuilder()
-            .setType(DiagnoserType.DIAGNOSER_TYPE_PROCESSING_RATE_SCALE_UP)
-            .setProcessingRateScaleUp(
-                processingRateDiagnoserFromK8sResource(
-                    diagnoser.getProcessingRateScaleUp().get()))
-            .build();
-      }
-      case PROCESSING_RATE_SCALE_DOWN: {
-        return Diagnoser.newBuilder()
-            .setType(DiagnoserType.DIAGNOSER_TYPE_PROCESSING_RATE_SCALE_DOWN)
-            .setProcessingRateScaleDown(
-                processingRateDiagnoserFromK8sResource(
-                    diagnoser.getProcessingRateScaleDown().get()))
-            .build();
-      }
-      default:
-        throw new IllegalStateException();
-    }
-  }
-
-  private static List<Diagnoser> diagnosersFromK8sResource(
-      final Optional<List<DemoPolicy.Diagnoser>> diagnosers
-  ) {
-    if (diagnosers.isEmpty()) {
-      return Collections.emptyList();
-    }
-    return diagnosers.get().stream()
-        .map(ControllerProtoFactories::diagnoserFromK8sResource)
-        .collect(Collectors.toList());
-  }
-
   private static ApplicationPolicy policyFromK8sResource(final ResponsivePolicySpec policySpec) {
     final var builder = ApplicationPolicy.newBuilder();
     switch (policySpec.getPolicyType()) {
       case DEMO:
         assert policySpec.getDemoPolicy().isPresent();
-        final var demoPolicy = policySpec.getDemoPolicy().get();
-        builder.setDemoPolicy(ControllerOuterClass.DemoPolicy.newBuilder()
-            .setMaxReplicas(demoPolicy.getMaxReplicas())
-            .setMinReplicas(demoPolicy.getMinReplicas())
-            .addAllDiagnoser(diagnosersFromK8sResource(demoPolicy.getDiagnosers()))
-            .build()
-        );
+        builder.setDemoPolicy(DemoPolicyProtoFactories.demoPolicyFromK8sResource(
+            policySpec.getDemoPolicy().get()));
         break;
       default:
         throw new IllegalStateException("Unexpected type: " + policySpec.getPolicyType());

--- a/operator/src/main/java/dev/responsive/k8s/controller/DemoPolicyProtoFactories.java
+++ b/operator/src/main/java/dev/responsive/k8s/controller/DemoPolicyProtoFactories.java
@@ -1,0 +1,72 @@
+package dev.responsive.k8s.controller;
+
+import dev.responsive.k8s.crd.DemoPolicy;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import responsive.controller.v1.controller.proto.ControllerOuterClass;
+import responsive.controller.v1.controller.proto.ControllerOuterClass.DemoPolicy.Diagnoser;
+import responsive.controller.v1.controller.proto.ControllerOuterClass.DemoPolicy.LagDiagnoser;
+import responsive.controller.v1.controller.proto.ControllerOuterClass.DemoPolicy.ProcessingRateDiagnoser;
+
+final class DemoPolicyProtoFactories {
+
+  private DemoPolicyProtoFactories() {
+  }
+
+  private static ProcessingRateDiagnoser processingRateDiagnoserFromK8sResource(
+      final DemoPolicy.ProcessingRateDiagnoser diagnoser
+  ) {
+    final var builder = ProcessingRateDiagnoser.newBuilder()
+        .setRate(diagnoser.getRate());
+    if (diagnoser.getWindowMs().isPresent()) {
+      builder.setWindowMs(diagnoser.getWindowMs().get());
+    }
+    return builder.build();
+  }
+
+  static Diagnoser diagnoserFromK8sResource(final DemoPolicy.Diagnoser diagnoser) {
+    switch (diagnoser.getType()) {
+      case LAG_SCALE_UP:
+        return Diagnoser.newBuilder()
+            .setLagScaleUp(LagDiagnoser.newBuilder().build())
+            .build();
+      case PROCESSING_RATE_SCALE_UP: {
+        return Diagnoser.newBuilder()
+            .setProcessingRateScaleUp(
+                processingRateDiagnoserFromK8sResource(
+                    diagnoser.getProcessingRateScaleUp().get()))
+            .build();
+      }
+      case PROCESSING_RATE_SCALE_DOWN: {
+        return Diagnoser.newBuilder()
+            .setProcessingRateScaleDown(
+                processingRateDiagnoserFromK8sResource(
+                    diagnoser.getProcessingRateScaleDown().get()))
+            .build();
+      }
+      default:
+        throw new IllegalStateException();
+    }
+  }
+
+  private static List<Diagnoser> diagnosersFromK8sResource(
+      final Optional<List<DemoPolicy.Diagnoser>> diagnosers
+  ) {
+    if (diagnosers.isEmpty()) {
+      return Collections.emptyList();
+    }
+    return diagnosers.get().stream()
+        .map(DemoPolicyProtoFactories::diagnoserFromK8sResource)
+        .collect(Collectors.toList());
+  }
+
+  static ControllerOuterClass.DemoPolicy demoPolicyFromK8sResource(final DemoPolicy demoPolicy) {
+    return ControllerOuterClass.DemoPolicy.newBuilder()
+        .setMaxReplicas(demoPolicy.getMaxReplicas())
+        .setMinReplicas(demoPolicy.getMinReplicas())
+        .addAllDiagnoser(DemoPolicyProtoFactories.diagnosersFromK8sResource(demoPolicy.getDiagnosers()))
+        .build();
+  }
+}

--- a/operator/src/main/java/dev/responsive/k8s/controller/DemoPolicyProtoFactories.java
+++ b/operator/src/main/java/dev/responsive/k8s/controller/DemoPolicyProtoFactories.java
@@ -66,7 +66,8 @@ final class DemoPolicyProtoFactories {
     return ControllerOuterClass.DemoPolicy.newBuilder()
         .setMaxReplicas(demoPolicy.getMaxReplicas())
         .setMinReplicas(demoPolicy.getMinReplicas())
-        .addAllDiagnoser(DemoPolicyProtoFactories.diagnosersFromK8sResource(demoPolicy.getDiagnosers()))
+        .addAllDiagnoser(
+            DemoPolicyProtoFactories.diagnosersFromK8sResource(demoPolicy.getDiagnosers()))
         .build();
   }
 }

--- a/operator/src/main/java/dev/responsive/k8s/crd/CrdUtils.java
+++ b/operator/src/main/java/dev/responsive/k8s/crd/CrdUtils.java
@@ -1,0 +1,13 @@
+package dev.responsive.k8s.crd;
+
+import java.util.Optional;
+
+final class CrdUtils {
+  private CrdUtils() {
+  }
+
+  static <T> T validatePresent(final Optional<T> o, final String name) {
+    return o.orElseThrow(
+        () -> new RuntimeException(String.format("value %s not present", name)));
+  }
+}

--- a/operator/src/main/java/dev/responsive/k8s/crd/DemoPolicy.java
+++ b/operator/src/main/java/dev/responsive/k8s/crd/DemoPolicy.java
@@ -1,0 +1,133 @@
+package dev.responsive.k8s.crd;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+public class DemoPolicy {
+  public static class ProcessingRateDiagnoser {
+    private final int rate;
+    private final OptionalInt windowMs;
+
+    public int getRate() {
+      return rate;
+    }
+
+    public OptionalInt getWindowMs() {
+      return windowMs;
+    }
+
+    public ProcessingRateDiagnoser(
+        @JsonProperty("rate") final int rate,
+        @JsonProperty("windowMs") final OptionalInt windowMs
+    ) {
+      this.rate = rate;
+      this.windowMs = Objects.requireNonNull(windowMs);
+    }
+  }
+
+  public static class Diagnoser {
+    public enum Type {
+      PROCESSING_RATE_SCALE_UP,
+      PROCESSING_RATE_SCALE_DOWN,
+      LAG_SCALE_UP
+    }
+
+    private final Type type;
+    private final Optional<ProcessingRateDiagnoser> processingRateScaleUp;
+    private final Optional<ProcessingRateDiagnoser> processingRateScaleDown;
+
+    @JsonCreator
+    public Diagnoser(
+        @JsonProperty("type") final Type strategy,
+        @JsonProperty("processingRateScaleUp")
+        final Optional<ProcessingRateDiagnoser> processingRateScaleUp,
+        @JsonProperty("processingRateScaleDown")
+        final Optional<ProcessingRateDiagnoser> processingRateScaleDown
+    ) {
+      this.type = strategy;
+      this.processingRateScaleDown = Objects.requireNonNull(processingRateScaleDown);
+      this.processingRateScaleUp = Objects.requireNonNull(processingRateScaleUp);
+    }
+
+    public static Diagnoser lag() {
+      return new Diagnoser(Type.LAG_SCALE_UP, Optional.empty(), Optional.empty());
+    }
+
+    public static Diagnoser processingRateScaleUp(final ProcessingRateDiagnoser diagnoser) {
+      return new Diagnoser(
+          Type.PROCESSING_RATE_SCALE_UP,
+          Optional.of(diagnoser),
+          Optional.empty()
+      );
+    }
+
+    public static Diagnoser processingRateScaleDown(final ProcessingRateDiagnoser diagnoser) {
+      return new Diagnoser(
+          Type.PROCESSING_RATE_SCALE_DOWN,
+          Optional.empty(),
+          Optional.of(diagnoser)
+      );
+    }
+
+    public Type getType() {
+      return type;
+    }
+
+    public Optional<ProcessingRateDiagnoser> getProcessingRateScaleUp() {
+      return processingRateScaleUp;
+    }
+
+    public Optional<ProcessingRateDiagnoser> getProcessingRateScaleDown() {
+      return processingRateScaleDown;
+    }
+
+    private void validate() {
+      Objects.requireNonNull(type);
+      switch (type) {
+        case PROCESSING_RATE_SCALE_UP:
+          CrdUtils.validatePresent(processingRateScaleUp, "processingRateScaleUp");
+          break;
+        case PROCESSING_RATE_SCALE_DOWN:
+          CrdUtils.validatePresent(processingRateScaleDown, "processingRateScaleDown");
+          break;
+        default:
+          break;
+      }
+    }
+  }
+
+  private final int maxReplicas;
+  private final int minReplicas;
+  private final Optional<List<Diagnoser>> diagnosers;
+
+  @JsonCreator
+  public DemoPolicy(
+      @JsonProperty("maxReplicas") final int maxReplicas,
+      @JsonProperty("minReplicas") final int minReplicas,
+      @JsonProperty("diagnosers") final Optional<List<Diagnoser>> diagnosers
+  ) {
+    this.maxReplicas = maxReplicas;
+    this.minReplicas = minReplicas;
+    this.diagnosers = Objects.requireNonNull(diagnosers);
+  }
+
+  void validate() {
+    diagnosers.ifPresent(ds -> ds.forEach(Diagnoser::validate));
+  }
+
+  public int getMaxReplicas() {
+    return maxReplicas;
+  }
+
+  public int getMinReplicas() {
+    return minReplicas;
+  }
+
+  public Optional<List<Diagnoser>> getDiagnosers() {
+    return diagnosers;
+  }
+}

--- a/operator/src/main/java/dev/responsive/k8s/crd/DemoPolicy.java
+++ b/operator/src/main/java/dev/responsive/k8s/crd/DemoPolicy.java
@@ -10,19 +10,20 @@ import java.util.OptionalInt;
 public class DemoPolicy {
   public static class ProcessingRateDiagnoser {
     private final int rate;
-    private final OptionalInt windowMs;
+    // don't use OptionalInt here. The CRD schema generator only handles Optional transparently
+    private final Optional<Integer> windowMs;
 
     public int getRate() {
       return rate;
     }
 
-    public OptionalInt getWindowMs() {
+    public Optional<Integer> getWindowMs() {
       return windowMs;
     }
 
     public ProcessingRateDiagnoser(
         @JsonProperty("rate") final int rate,
-        @JsonProperty("windowMs") final OptionalInt windowMs
+        @JsonProperty("windowMs") final Optional<Integer> windowMs
     ) {
       this.rate = rate;
       this.windowMs = Objects.requireNonNull(windowMs);

--- a/operator/src/main/java/dev/responsive/k8s/crd/ResponsivePolicySpec.java
+++ b/operator/src/main/java/dev/responsive/k8s/crd/ResponsivePolicySpec.java
@@ -25,6 +25,7 @@ import responsive.controller.v1.controller.proto.ControllerOuterClass.PolicyStat
 public class ResponsivePolicySpec {
   private final String applicationNamespace;
   private final String applicationName;
+  // TODO: dont use the protobuf enum type in the k8s crd definition
   private final PolicyStatus status;
   private final ResponsivePolicySpec.PolicyType policyType;
   private final Optional<DemoPolicy> demoPolicy;
@@ -41,11 +42,25 @@ public class ResponsivePolicySpec {
       @JsonProperty("policyType") final PolicyType policyType,
       @JsonProperty("demoPolicy") final Optional<DemoPolicy> demoPolicy
   ) {
-    this.applicationNamespace = Objects.requireNonNull(applicationNamespace);
-    this.applicationName = Objects.requireNonNull(applicationName);
-    this.status = Objects.requireNonNull(status);
+    this.applicationNamespace = applicationNamespace;
+    this.applicationName = applicationName;
+    this.status = status;
     this.policyType = policyType;
     this.demoPolicy = Objects.requireNonNull(demoPolicy);
+  }
+
+  public void validate() {
+    Objects.requireNonNull(applicationName, "applicationName");
+    Objects.requireNonNull(applicationNamespace, "applicationNamespace");
+    Objects.requireNonNull(status, "status");
+    Objects.requireNonNull(policyType, "policyType");
+    switch (policyType) {
+      case DEMO:
+        CrdUtils.validatePresent(demoPolicy, "demoPolicy").validate();
+        break;
+      default:
+        break;
+    }
   }
 
   public String getApplicationNamespace() {
@@ -68,19 +83,4 @@ public class ResponsivePolicySpec {
     return demoPolicy;
   }
 
-  public static class DemoPolicy {
-
-    private final int maxReplicas;
-
-    @JsonCreator
-    public DemoPolicy(
-        @JsonProperty("maxReplicas") final int maxReplicas
-    ) {
-      this.maxReplicas = maxReplicas;
-    }
-
-    public int getMaxReplicas() {
-      return maxReplicas;
-    }
-  }
 }

--- a/operator/src/main/java/dev/responsive/k8s/crd/ResponsivePolicyStatus.java
+++ b/operator/src/main/java/dev/responsive/k8s/crd/ResponsivePolicyStatus.java
@@ -16,5 +16,16 @@
 
 package dev.responsive.k8s.crd;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class ResponsivePolicyStatus {
+  private final String message;
+
+  public ResponsivePolicyStatus(@JsonProperty("message") final String message) {
+    this.message = message;
+  }
+
+  public String getMessage() {
+    return message;
+  }
 }

--- a/operator/src/test/java/dev/responsive/k8s/controller/ControllerProtoFactoriesTest.java
+++ b/operator/src/test/java/dev/responsive/k8s/controller/ControllerProtoFactoriesTest.java
@@ -21,20 +21,18 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.is;
 
 import dev.responsive.k8s.crd.DemoPolicy.Diagnoser;
-import dev.responsive.k8s.crd.DemoPolicy.Diagnoser.Type;
 import dev.responsive.k8s.crd.DemoPolicy.ProcessingRateDiagnoser;
 import dev.responsive.k8s.crd.ResponsivePolicy;
 import dev.responsive.k8s.crd.ResponsivePolicySpec;
 import io.fabric8.kubernetes.api.model.ObjectMeta;
 import java.util.List;
 import java.util.Optional;
-import java.util.OptionalInt;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import responsive.controller.v1.controller.proto.ControllerOuterClass;
 import responsive.controller.v1.controller.proto.ControllerOuterClass.ApplicationState;
 import responsive.controller.v1.controller.proto.ControllerOuterClass.DemoPolicy;
-import responsive.controller.v1.controller.proto.ControllerOuterClass.DemoPolicy.DiagnoserType;
+import responsive.controller.v1.controller.proto.ControllerOuterClass.DemoPolicy.LagDiagnoser;
 import responsive.controller.v1.controller.proto.ControllerOuterClass.PolicyStatus;
 
 class ControllerProtoFactoriesTest {
@@ -98,7 +96,7 @@ class ControllerProtoFactoriesTest {
     final DemoPolicy created = request.getPolicy().getDemoPolicy();
     assertThat(created.getDiagnoserList(), contains(
         DemoPolicy.Diagnoser.newBuilder()
-            .setType(DiagnoserType.DIAGNOSER_TYPE_LAG)
+            .setLagScaleUp(LagDiagnoser.newBuilder().build())
             .build()
     ));
   }
@@ -108,7 +106,7 @@ class ControllerProtoFactoriesTest {
     // given:
     demoPolicy.setSpec(
         specWithDiagnoser(Diagnoser.processingRateScaleUp(
-            new ProcessingRateDiagnoser(10, OptionalInt.of(123))))
+            new ProcessingRateDiagnoser(10, Optional.of(123))))
     );
 
     // when:
@@ -118,7 +116,6 @@ class ControllerProtoFactoriesTest {
     final DemoPolicy created = request.getPolicy().getDemoPolicy();
     assertThat(created.getDiagnoserList(), contains(
         DemoPolicy.Diagnoser.newBuilder()
-            .setType(DiagnoserType.DIAGNOSER_TYPE_PROCESSING_RATE_SCALE_UP)
             .setProcessingRateScaleUp(DemoPolicy.ProcessingRateDiagnoser.newBuilder()
                 .setRate(10)
                 .setWindowMs(123)
@@ -132,7 +129,7 @@ class ControllerProtoFactoriesTest {
     // given:
     demoPolicy.setSpec(
         specWithDiagnoser(Diagnoser.processingRateScaleDown(
-            new ProcessingRateDiagnoser(10, OptionalInt.of(123))))
+            new ProcessingRateDiagnoser(10, Optional.of(123))))
     );
 
     // when:
@@ -142,7 +139,6 @@ class ControllerProtoFactoriesTest {
     final DemoPolicy created = request.getPolicy().getDemoPolicy();
     assertThat(created.getDiagnoserList(), contains(
         DemoPolicy.Diagnoser.newBuilder()
-            .setType(DiagnoserType.DIAGNOSER_TYPE_PROCESSING_RATE_SCALE_DOWN)
             .setProcessingRateScaleDown(DemoPolicy.ProcessingRateDiagnoser.newBuilder()
                 .setRate(10)
                 .setWindowMs(123)

--- a/operator/src/test/java/dev/responsive/k8s/crd/ResponsivePolicySpecTest.java
+++ b/operator/src/test/java/dev/responsive/k8s/crd/ResponsivePolicySpecTest.java
@@ -1,0 +1,111 @@
+package dev.responsive.k8s.crd;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import dev.responsive.k8s.crd.DemoPolicy.Diagnoser;
+import dev.responsive.k8s.crd.ResponsivePolicySpec.PolicyType;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import responsive.controller.v1.controller.proto.ControllerOuterClass.PolicyStatus;
+
+class ResponsivePolicySpecTest {
+
+  @Test
+  public void shouldThrowOnNullName() {
+    // given:
+    final var spec = new ResponsivePolicySpec(
+        "foo",
+        null,
+        PolicyStatus.POLICY_STATUS_MANAGED,
+        PolicyType.DEMO,
+        Optional.of(new DemoPolicy(10, 0, Optional.empty()))
+    );
+
+    // when/then:
+    assertThrows(NullPointerException.class, spec::validate);
+  }
+
+  @Test
+  public void shouldThrowOnNullNamespace() {
+    // given:
+    final var spec = new ResponsivePolicySpec(
+        null,
+        "foo",
+        PolicyStatus.POLICY_STATUS_MANAGED,
+        PolicyType.DEMO,
+        Optional.of(new DemoPolicy(10, 0, Optional.empty()))
+    );
+
+    // when/then:
+    assertThrows(NullPointerException.class, spec::validate);
+  }
+
+  @Test
+  public void shouldThrowOnNullStatus() {
+    // given:
+    final var spec = new ResponsivePolicySpec(
+        "baz",
+        "foo",
+        null,
+        PolicyType.DEMO,
+        Optional.of(new DemoPolicy(10, 0, Optional.empty()))
+    );
+
+    // when/then:
+    assertThrows(NullPointerException.class, spec::validate);
+  }
+
+  @Test
+  public void shouldThrowOnNullType() {
+    // given:
+    final var spec = new ResponsivePolicySpec(
+        "baz",
+        "foo",
+        PolicyStatus.POLICY_STATUS_MANAGED,
+        null,
+        Optional.of(new DemoPolicy(10, 0, Optional.empty()))
+    );
+
+    // when/then:
+    assertThrows(NullPointerException.class, spec::validate);
+  }
+
+  @Test
+  public void shouldThrowOnNullDiagnoserType() {
+    // given:
+    final var spec = new ResponsivePolicySpec(
+        "baz",
+        "foo",
+        PolicyStatus.POLICY_STATUS_MANAGED,
+        PolicyType.DEMO,
+        Optional.of(new DemoPolicy(
+            10,
+            0,
+            Optional.of(List.of(
+                new Diagnoser(null, Optional.empty(), Optional.empty())
+            ))))
+    );
+
+    // when/then:
+    assertThrows(NullPointerException.class, spec::validate);
+  }
+
+  @Test
+  public void shouldNotThrowOnValid() {
+    // given:
+    final var spec = new ResponsivePolicySpec(
+        "baz",
+        "foo",
+        PolicyStatus.POLICY_STATUS_MANAGED,
+        PolicyType.DEMO,
+        Optional.of(new DemoPolicy(
+            10,
+            0,
+            Optional.of(List.of(Diagnoser.lag()))))
+    );
+
+    // when/then:
+    spec.validate();
+  }
+}

--- a/operator/src/test/java/dev/responsive/k8s/operator/reconciler/DemoPolicyPluginTest.java
+++ b/operator/src/test/java/dev/responsive/k8s/operator/reconciler/DemoPolicyPluginTest.java
@@ -30,6 +30,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import dev.responsive.controller.client.ControllerClient;
 import dev.responsive.k8s.controller.ControllerProtoFactories;
+import dev.responsive.k8s.crd.DemoPolicy;
 import dev.responsive.k8s.crd.ResponsivePolicy;
 import dev.responsive.k8s.crd.ResponsivePolicySpec;
 import io.fabric8.kubernetes.api.model.HasMetadata;
@@ -152,7 +153,7 @@ class DemoPolicyPluginTest {
             "baz",
             PolicyStatus.POLICY_STATUS_MANAGED,
             ResponsivePolicySpec.PolicyType.DEMO,
-            Optional.of(new ResponsivePolicySpec.DemoPolicy(123))
+            Optional.of(new DemoPolicy(123, 7, Optional.empty()))
         )
     );
 


### PR DESCRIPTION
- Extend the policy CRD to support a configurable list of diagnosers, and add specs for rate-based diagnosers that can scale up or down based on processing rate per node.
- Clean up the validation logic in the CRDs. No validation happens in the consturctor, as exceptions there cause operator to crash. Instead the reconciler validates and marks the policy as failed if the speci s bad