### PR TITLE
allow setting an environment prefix in operator

### DIFF
--- a/operator/src/main/helm/templates/deployment.yaml
+++ b/operator/src/main/helm/templates/deployment.yaml
@@ -39,6 +39,8 @@ spec:
                 value: {{ .Values.logging.kafka.topic }}
               - name: LOGGING_KAFKA_KEY_FILE
                 value: /etc/responsive-operator/logging_kafka/key.properties
+              - name: OPERATOR_OPTS
+                value: {{ .Values.operatorOpts }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/operator/src/main/helm/values.yaml
+++ b/operator/src/main/helm/values.yaml
@@ -44,3 +44,5 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+operatorOpts: ""

--- a/operator/src/main/java/dev/responsive/k8s/controller/ControllerProtoFactories.java
+++ b/operator/src/main/java/dev/responsive/k8s/controller/ControllerProtoFactories.java
@@ -24,27 +24,32 @@ import responsive.controller.v1.controller.proto.ControllerOuterClass.Applicatio
 
 public final class ControllerProtoFactories {
   public static ControllerOuterClass.UpsertPolicyRequest upsertPolicyRequest(
+      final String environment,
       final ResponsivePolicy policy) {
     return ControllerOuterClass.UpsertPolicyRequest.newBuilder()
         .setPolicy(ControllerProtoFactories.policyFromK8sResource(policy.getSpec()))
         // TODO(rohan): dont just use a namespaced (w/ /) name
-        .setApplicationId(getFullApplicationName(policy))
+        .setApplicationId(getFullApplicationName(environment, policy))
         .build();
   }
 
   public static ControllerOuterClass.CurrentStateRequest currentStateRequest(
+      final String environment,
       final ResponsivePolicy policy,
       final ApplicationState state
   ) {
     return ControllerOuterClass.CurrentStateRequest.newBuilder()
-        .setApplicationId(getFullApplicationName(policy))
+        .setApplicationId(getFullApplicationName(environment, policy))
         .setState(state)
         .build();
   }
 
-  public static ControllerOuterClass.EmptyRequest emptyRequest(final ResponsivePolicy policy) {
+  public static ControllerOuterClass.EmptyRequest emptyRequest(
+      final String environment,
+      final ResponsivePolicy policy
+  ) {
     return ControllerOuterClass.EmptyRequest.newBuilder()
-        .setApplicationId(getFullApplicationName(policy))
+        .setApplicationId(getFullApplicationName(environment, policy))
         .build();
   }
 
@@ -63,7 +68,13 @@ public final class ControllerProtoFactories {
     return builder.build();
   }
 
-  private static String getFullApplicationName(final ResponsivePolicy policy) {
-    return policy.getSpec().getApplicationNamespace() + "/" + policy.getSpec().getApplicationName();
+  private static String getFullApplicationName(
+      final String environment,
+      final ResponsivePolicy policy
+  ) {
+    final String prefix = environment.isEmpty() ? "" : environment + "/";
+    return prefix
+        + policy.getSpec().getApplicationNamespace()
+        + "/" + policy.getSpec().getApplicationName();
   }
 }

--- a/operator/src/main/java/dev/responsive/k8s/operator/OperatorMain.java
+++ b/operator/src/main/java/dev/responsive/k8s/operator/OperatorMain.java
@@ -57,6 +57,8 @@ public class OperatorMain {
     }
 
     final String target = cmd.getOptionValue(OperatorOptions.CONTROLLER_URL);
+    final String environment = cmd.hasOption(OperatorOptions.ENVIRONMENT)
+        ? cmd.getOptionValue(OperatorOptions.ENVIRONMENT) : "";
     final String secretFilePath = cmd.getOptionValue(OperatorOptions.SECRETS_FILE);
     final boolean tlsOff = cmd.hasOption(OperatorOptions.TLS_OFF);
     final Properties config = load(secretFilePath);
@@ -73,7 +75,7 @@ public class OperatorMain {
 
     final Operator operator = new Operator();
     Serialization.jsonMapper().registerModule(new Jdk8Module());
-    operator.register(new ResponsivePolicyReconciler(new ControllerGrpcClient(
+    operator.register(new ResponsivePolicyReconciler(environment, new ControllerGrpcClient(
         target,
         apiKey,
         secret,

--- a/operator/src/main/java/dev/responsive/k8s/operator/OperatorOptions.java
+++ b/operator/src/main/java/dev/responsive/k8s/operator/OperatorOptions.java
@@ -30,6 +30,13 @@ public final class OperatorOptions {
       .numberOfArgs(1)
       .build();
 
+  public static final Option ENVIRONMENT = Option.builder("environment")
+      .hasArg(true)
+      .required(false)
+      .desc("The environment this operator is running in")
+      .numberOfArgs(1)
+      .build();
+
   public static final Option SECRETS_FILE = Option.builder("secretsFile")
       .hasArg(true)
       .required(true)
@@ -43,5 +50,6 @@ public final class OperatorOptions {
   public static final Options OPTIONS = new Options()
       .addOption(CONTROLLER_URL)
       .addOption(SECRETS_FILE)
-      .addOption(TLS_OFF);
+      .addOption(TLS_OFF)
+      .addOption(ENVIRONMENT);
 }

--- a/operator/src/main/java/dev/responsive/k8s/operator/reconciler/DemoPolicyPlugin.java
+++ b/operator/src/main/java/dev/responsive/k8s/operator/reconciler/DemoPolicyPlugin.java
@@ -39,6 +39,12 @@ import responsive.controller.v1.controller.proto.ControllerOuterClass;
 public class DemoPolicyPlugin implements PolicyPlugin {
   private static final Logger LOG = LoggerFactory.getLogger(DemoPolicyPlugin.class);
 
+  private final String environment;
+
+  public DemoPolicyPlugin(final String environment) {
+    this.environment = environment;
+  }
+
   @Override
   public Map<String, EventSource> prepareEventSources(
       final EventSourceContext<ResponsivePolicy> ctx,
@@ -81,7 +87,9 @@ public class DemoPolicyPlugin implements PolicyPlugin {
     LOG.info("Found type {} for app {}/{}", managedApp.appType(), appNamespace, appName);
 
     responsiveCtx.getControllerClient().currentState(
-        ControllerProtoFactories.currentStateRequest(policy,
+        ControllerProtoFactories.currentStateRequest(
+            environment,
+            policy,
             currentStateFromApplication(managedApp))
     );
 

--- a/operator/src/test/java/dev/responsive/k8s/controller/ControllerProtoFactoriesTest.java
+++ b/operator/src/test/java/dev/responsive/k8s/controller/ControllerProtoFactoriesTest.java
@@ -36,6 +36,8 @@ import responsive.controller.v1.controller.proto.ControllerOuterClass.DemoPolicy
 import responsive.controller.v1.controller.proto.ControllerOuterClass.PolicyStatus;
 
 class ControllerProtoFactoriesTest {
+  private static final String TESTENV = "testenv";
+
   private final ResponsivePolicy demoPolicy = new ResponsivePolicy();
   private ApplicationState demoApplicationState;
 
@@ -62,10 +64,10 @@ class ControllerProtoFactoriesTest {
   @Test
   public void shouldCreateUpsertPolicyRequestForDemoPolicy() {
     // when:
-    final var request = ControllerProtoFactories.upsertPolicyRequest(demoPolicy);
+    final var request = ControllerProtoFactories.upsertPolicyRequest(TESTENV, demoPolicy);
 
     // then:
-    assertThat(request.getApplicationId(), is("gouda/cheddar"));
+    assertThat(request.getApplicationId(), is("testenv/gouda/cheddar"));
     assertThat(request.getPolicy().hasDemoPolicy(), is(true));
     assertThat(request.getPolicy().getStatus(), is(PolicyStatus.POLICY_STATUS_MANAGED));
     final DemoPolicy demoPolicy = request.getPolicy().getDemoPolicy();
@@ -90,7 +92,7 @@ class ControllerProtoFactoriesTest {
     demoPolicy.setSpec(specWithDiagnoser(Diagnoser.lag()));
 
     // when:
-    final var request = ControllerProtoFactories.upsertPolicyRequest(demoPolicy);
+    final var request = ControllerProtoFactories.upsertPolicyRequest(TESTENV, demoPolicy);
 
     // then:
     final DemoPolicy created = request.getPolicy().getDemoPolicy();
@@ -110,7 +112,7 @@ class ControllerProtoFactoriesTest {
     );
 
     // when:
-    final var request = ControllerProtoFactories.upsertPolicyRequest(demoPolicy);
+    final var request = ControllerProtoFactories.upsertPolicyRequest(TESTENV, demoPolicy);
 
     // then:
     final DemoPolicy created = request.getPolicy().getDemoPolicy();
@@ -133,7 +135,7 @@ class ControllerProtoFactoriesTest {
     );
 
     // when:
-    final var request = ControllerProtoFactories.upsertPolicyRequest(demoPolicy);
+    final var request = ControllerProtoFactories.upsertPolicyRequest(TESTENV, demoPolicy);
 
     // then:
     final DemoPolicy created = request.getPolicy().getDemoPolicy();
@@ -148,20 +150,46 @@ class ControllerProtoFactoriesTest {
   }
 
   @Test
+  public void shouldCreateUpsertPolicyRequestWithApplicationIdWhenEnvEmpty() {
+    // when:
+    final var request = ControllerProtoFactories.upsertPolicyRequest("", demoPolicy);
+
+    // then:
+    assertThat(request.getApplicationId(), is("gouda/cheddar"));
+  }
+
+  @Test
   public void shouldCreateCurrentStateRequestForDeployment() {
     // when:
     final var request
-        = ControllerProtoFactories.currentStateRequest(demoPolicy, demoApplicationState);
+        = ControllerProtoFactories.currentStateRequest(TESTENV, demoPolicy, demoApplicationState);
 
     // Then:
-    assertThat(request.getApplicationId(), is("gouda/cheddar"));
+    assertThat(request.getApplicationId(), is("testenv/gouda/cheddar"));
     assertThat(request.getState().hasDemoState(), is(true));
     assertThat(request.getState().getDemoState().getReplicas(), is(3));
   }
 
   @Test
+  public void shouldSetAppIdInCurrentStateRequestWhenEnvEmpty() {
+    // when:
+    final var request
+        = ControllerProtoFactories.currentStateRequest("", demoPolicy, demoApplicationState);
+
+    // Then:
+    assertThat(request.getApplicationId(), is("gouda/cheddar"));
+  }
+
+  @Test
   public void shouldCreateEmptyRequest() {
-    final var request = ControllerProtoFactories.emptyRequest(demoPolicy);
+    final var request = ControllerProtoFactories.emptyRequest(TESTENV, demoPolicy);
+
+    assertThat(request.getApplicationId(), is("testenv/gouda/cheddar"));
+  }
+
+  @Test
+  public void shouldCreateEmptyRequestWhenEnvEmpty() {
+    final var request = ControllerProtoFactories.emptyRequest("", demoPolicy);
 
     assertThat(request.getApplicationId(), is("gouda/cheddar"));
   }

--- a/operator/src/test/java/dev/responsive/k8s/operator/reconciler/DemoPolicyPluginTest.java
+++ b/operator/src/test/java/dev/responsive/k8s/operator/reconciler/DemoPolicyPluginTest.java
@@ -106,7 +106,7 @@ class DemoPolicyPluginTest {
   private ControllerClient controllerClient;
 
   private final dev.responsive.k8s.operator.reconciler.DemoPolicyPlugin
-      plugin = new dev.responsive.k8s.operator.reconciler.DemoPolicyPlugin();
+      plugin = new dev.responsive.k8s.operator.reconciler.DemoPolicyPlugin("testenv");
   private final Deployment deployment = new Deployment();
   private final StatefulSet statefulSet = new StatefulSet();
   private final ResponsivePolicy policy = new ResponsivePolicy();
@@ -267,6 +267,7 @@ class DemoPolicyPluginTest {
     MatcherAssert.assertThat(
         currentStateRequest,
         equalTo(ControllerProtoFactories.currentStateRequest(
+                "testenv",
                 policy,
                 ControllerOuterClass.ApplicationState.newBuilder()
                     .setDemoState(

--- a/operator/src/test/java/dev/responsive/k8s/operator/reconciler/ResponsivePolicyReconcilerTest.java
+++ b/operator/src/test/java/dev/responsive/k8s/operator/reconciler/ResponsivePolicyReconcilerTest.java
@@ -105,6 +105,7 @@ class ResponsivePolicyReconcilerTest {
         Optional.of(new DemoPolicy(123, 7, Optional.empty()))
     ));
     reconciler = new dev.responsive.k8s.operator.reconciler.ResponsivePolicyReconciler(
+        "testenv",
         responsiveCtx,
         ImmutableMap.of(ResponsivePolicySpec.PolicyType.DEMO, plugin)
     );
@@ -162,7 +163,8 @@ class ResponsivePolicyReconcilerTest {
     reconciler.reconcile(policy, ctx);
 
     // then:
-    verify(controllerClient).upsertPolicy(ControllerProtoFactories.upsertPolicyRequest(policy));
+    verify(controllerClient)
+        .upsertPolicy(ControllerProtoFactories.upsertPolicyRequest("testenv", policy));
   }
 
   @Test


### PR DESCRIPTION
Adds a command line option --environment to set an environment
prefix in calls to the controller. This can be used to distinguish applications
in different k8s clusters (or other grouping of the user's choice). Also
adds support to the helm chart for specifying options.