### PR TITLE
setup the build and workflows to use snapshot versioning.

### DIFF
--- a/.github/workflows/github-main.yaml
+++ b/.github/workflows/github-main.yaml
@@ -38,11 +38,6 @@ jobs:
         with:
           arguments: build
 
-      - name: Release
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: release
-
       - name: Publish
         uses: gradle/gradle-build-action@v2
         with:

--- a/.github/workflows/github-publish.yaml
+++ b/.github/workflows/github-publish.yaml
@@ -46,20 +46,6 @@ jobs:
         with:
           arguments: :${{ inputs.module }}:build
 
-      - name: Create Next Version Commit
-        run: |
-          git config --global user.name 'Responsive Tools'
-          git config --global user.email 'tools@responsive.dev'
-          ./gradlew :${{ inputs.module }}:markNextVersion \
-            -Prelease.incrementer=${{ inputs.increment }} \
-            -Prelease.dryRun | grep "Creating" | git commit --allow-empty -F -
-          git push
-
-      - name: Increment Version
-        uses: gradle/gradle-build-action@v2
-        with:
-          arguments: :${{ inputs.module }}:markNextVersion -Prelease.incrementer=${{ inputs.increment }}
-
       - name: Release
         uses: gradle/gradle-build-action@v2
         with:
@@ -75,10 +61,24 @@ jobs:
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
 
-      - name: Publish Images 
+      - name: Publish Images
         uses: gradle/gradle-build-action@v2
         if: ${{ inputs.module == 'operator' }}
         with:
           arguments: pushCRD pushDocker pushHelm -PdockerRegistry=${{ steps.login-ecr-public.outputs.registry }}/j8q9y0n6 -PhelmRegistry=${{ steps.login-ecr-public.outputs.registry }}/j8q9y0n6
         env:
           ECR_REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
+
+      - name: Create Next Version Commit
+        run: |
+          git config --global user.name 'Responsive Tools'
+          git config --global user.email 'tools@responsive.dev'
+          ./gradlew :${{ inputs.module }}:markNextVersion \
+            -Prelease.incrementer=${{ inputs.increment }} \
+            -Prelease.dryRun | grep "Creating" | git commit --allow-empty -F -
+          git push
+
+      - name: Increment Version
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: :${{ inputs.module }}:markNextVersion -Prelease.incrementer=${{ inputs.increment }}

--- a/buildSrc/src/main/kotlin/responsive.java-common-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/responsive.java-common-conventions.gradle.kts
@@ -62,13 +62,10 @@ allprojects {
         tag {
             prefix.set(project.name)
             versionSeparator.set("-")
-            initialVersion({_, _ -> "0.1.0-1"})
+            initialVersion({_, _ -> "0.1.0"})
         }
 
-        // use rc versions for public artifacts
-        versionIncrementer(
-            "incrementPrerelease",
-            mapOf("initialPreReleaseIfNotOnPrerelease" to "1"))
+        versionIncrementer("incrementMinor")
 
         snapshotCreator({ _, _ -> "-SNAPSHOT" })
         ignoreUncommittedChanges.set(false)


### PR DESCRIPTION
With this patch, suppose the last released version of kafka-clients is 0.4.0. Then, all master builds will build kafka-clients with 0.5.0-SNAPSHOT. The next publish job will release 0.5.0, and then master will build 0.6.0-SNAPSHOT.

After this patch, I will manually run the following to get everything on the "right" snapshot version.:
```
./gradlew markNextVersion -Prelease.dryRun | grep Creating | commit --allow-empty -F -
 git push
./gradlew markNextVersion
```