### PR TITLE
fix: delay initialization to prevent standby tasks from fencing actives

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/clients/SharedClients.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/clients/SharedClients.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package dev.responsive.kafka.clients;
 
 import dev.responsive.db.CassandraClient;
@@ -5,13 +21,11 @@ import dev.responsive.kafka.api.InternalConfigs;
 import java.util.Map;
 import java.util.concurrent.ScheduledExecutorService;
 import org.apache.kafka.clients.admin.Admin;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Basic container class for session clients and other shared resources
  */
-public class SharedClients {
+public final class SharedClients {
   public final CassandraClient cassandraClient;
   public final Admin admin;
   public final ScheduledExecutorService executor;

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/CommitBuffer.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/CommitBuffer.java
@@ -57,7 +57,7 @@ import org.apache.kafka.streams.processor.internals.RecordBatchingStateRestoreCa
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.slf4j.Logger;
 
-class CommitBuffer<K, S extends RemoteSchema<K>> implements RecordBatchingStateRestoreCallback {
+class CommitBuffer<K, S extends RemoteSchema<K>> {
 
   public static final int MAX_BATCH_SIZE = 1000;
   private final Logger log;
@@ -464,7 +464,6 @@ class CommitBuffer<K, S extends RemoteSchema<K>> implements RecordBatchingStateR
     }
   }
 
-  @Override
   public void restoreBatch(final Collection<ConsumerRecord<byte[], byte[]>> records) {
     final List<ConsumerRecord<byte[], byte[]>> batch = new ArrayList<>(maxBatchSize);
     for (final ConsumerRecord<byte[], byte[]> r : records) {

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveGlobalStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveGlobalStore.java
@@ -54,8 +54,6 @@ public class ResponsiveGlobalStore implements KeyValueStore<Bytes, byte[]> {
   private StateStoreContext context;
   private RemoteKeyValueSchema schema;
 
-  // TODO: instead of splitting this out into a separate store implementation, we should just
-  //  check whether a store is global at runtime (during init) and branch the logic from there
   public ResponsiveGlobalStore(final TableName name) {
     this.name = name;
     this.position = Position.emptyPosition();

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveMaterialized.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveMaterialized.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package dev.responsive.kafka.store;
 
 import static dev.responsive.utils.StoreUtil.validateLogConfigs;

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveRestoreCallback.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveRestoreCallback.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package dev.responsive.kafka.store;
 
 import java.util.Collection;
@@ -9,19 +24,19 @@ import org.apache.kafka.streams.processor.internals.RecordBatchingStateRestoreCa
 public class ResponsiveRestoreCallback implements RecordBatchingStateRestoreCallback {
 
   private final Consumer<Collection<ConsumerRecord<byte[], byte[]>>> batchRestorer;
-  private final Supplier<Boolean> allowRestore;
+  private final Supplier<Boolean> isActive;
 
   public ResponsiveRestoreCallback(
       final Consumer<Collection<ConsumerRecord<byte[], byte[]>>> batchRestorer,
-      final Supplier<Boolean> allowRestore
+      final Supplier<Boolean> isActive
   ) {
     this.batchRestorer = batchRestorer;
-    this.allowRestore = allowRestore;
+    this.isActive = isActive;
   }
 
   @Override
   public void restoreBatch(final Collection<ConsumerRecord<byte[], byte[]>> records) {
-    if (allowRestore.get()) {
+    if (isActive.get()) {
       batchRestorer.accept(records);
     }
   }

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveRestoreCallback.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveRestoreCallback.java
@@ -1,0 +1,28 @@
+package dev.responsive.kafka.store;
+
+import java.util.Collection;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.streams.processor.internals.RecordBatchingStateRestoreCallback;
+
+public class ResponsiveRestoreCallback implements RecordBatchingStateRestoreCallback {
+
+  private final Consumer<Collection<ConsumerRecord<byte[], byte[]>>> batchRestorer;
+  private final Supplier<Boolean> allowRestore;
+
+  public ResponsiveRestoreCallback(
+      final Consumer<Collection<ConsumerRecord<byte[], byte[]>>> batchRestorer,
+      final Supplier<Boolean> allowRestore
+  ) {
+    this.batchRestorer = batchRestorer;
+    this.allowRestore = allowRestore;
+  }
+
+  @Override
+  public void restoreBatch(final Collection<ConsumerRecord<byte[], byte[]>> records) {
+    if (allowRestore.get()) {
+      batchRestorer.accept(records);
+    }
+  }
+}

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveStore.java
@@ -16,6 +16,8 @@
 
 package dev.responsive.kafka.store;
 
+import static org.apache.kafka.streams.processor.internals.ProcessorContextUtils.asInternalProcessorContext;
+
 import dev.responsive.utils.TableName;
 import java.util.List;
 import org.apache.kafka.common.annotation.InterfaceStability.Evolving;
@@ -25,7 +27,7 @@ import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StateStoreContext;
-import org.apache.kafka.streams.processor.internals.GlobalProcessorContextImpl;
+import org.apache.kafka.streams.processor.internals.Task.TaskType;
 import org.apache.kafka.streams.query.Position;
 import org.apache.kafka.streams.query.PositionBound;
 import org.apache.kafka.streams.query.Query;
@@ -85,11 +87,12 @@ public class ResponsiveStore implements KeyValueStore<Bytes, byte[]> {
 
   @Override
   public void init(final StateStoreContext context, final StateStore root) {
-    if (context instanceof GlobalProcessorContextImpl) {
+    if (asInternalProcessorContext(context).taskType() == TaskType.GLOBAL) {
       delegate = new ResponsiveGlobalStore(name);
     } else {
       delegate = new ResponsivePartitionedStore(name);
     }
+
     delegate.init(context, root);
   }
 


### PR DESCRIPTION
The main change here is to delay the CommitBuffer#init until later if we detect that the store is a standby during the regular #init

We also block the restoration path until a task is in the active state, so that no `put` or any other calls will be invoked before initialization occurs. Then at the start of each put/get type call on the store, we check whether it had transitioned to active and proceed with the initialization if so.

Also sets a logPrefix with the store name and active/standby status, so it's easier to follow individual stores