### PR TITLE
builds docker images for amd64 and aarch64/arm64

### DIFF
--- a/.github/workflows/github-main.yaml
+++ b/.github/workflows/github-main.yaml
@@ -44,12 +44,20 @@ jobs:
         with:
           arguments: publishMavenJavaPublicationToS3Repository # publish only to S3
         if: github.ref == 'refs/heads/main'
-        
+
+      # We need this to emulate other architectures for multi-platform docker builds
+      - name: Set up QEMU for Docker
+        uses: docker/setup-qemu-action@v2
+
+      # We use the build extensions to do multi-architecture docker builds
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Publish Images
         uses: gradle/gradle-build-action@v2
         with:
-          arguments: pushCRD pushDocker pushHelm -PdockerRegistry=${{ steps.login-ecr-public.outputs.registry }}/j8q9y0n6 -PhelmRegistry=${{ steps.login-ecr-public.outputs.registry }}/j8q9y0n6
-        if: github.ref == 'refs/heads/main'
+          arguments: pushCRD pushDockerMultiArch pushHelm -PdockerRegistry=${{ steps.login-ecr-public.outputs.registry }}/j8q9y0n6 -PhelmRegistry=${{ steps.login-ecr-public.outputs.registry }}/j8q9y0n6
+        #if: github.ref == 'refs/heads/main'
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2

--- a/.github/workflows/github-publish.yaml
+++ b/.github/workflows/github-publish.yaml
@@ -61,11 +61,19 @@ jobs:
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
 
+      # We need this to emulate other architectures for multi-platform docker builds
+      - name: Set up QEMU for Docker
+        uses: docker/setup-qemu-action@v2
+
+      # We use the build extensions to do multi-architecture docker builds
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
       - name: Publish Operator Images
         uses: gradle/gradle-build-action@v2
         if: ${{ inputs.module == 'operator' }}
         with:
-          arguments: operator:pushCRD operator:pushDocker operator:pushHelm -PdockerRegistry=${{ steps.login-ecr-public.outputs.registry }}/j8q9y0n6 -PhelmRegistry=${{ steps.login-ecr-public.outputs.registry }}/j8q9y0n6
+          arguments: operator:pushCRD operator:pushDockerMultiArch operator:pushHelm -PdockerRegistry=${{ steps.login-ecr-public.outputs.registry }}/j8q9y0n6 -PhelmRegistry=${{ steps.login-ecr-public.outputs.registry }}/j8q9y0n6
         env:
           ECR_REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
 
@@ -73,7 +81,7 @@ jobs:
         uses: gradle/gradle-build-action@v2
         if: ${{ inputs.module == 'kafka-client' }}
         with:
-          arguments: kafka-client-examples:simple-example:pushDocker -PdockerRegistry=${{ steps.login-ecr-public.outputs.registry }}/j8q9y0n6 -PhelmRegistry=${{ steps.login-ecr-public.outputs.registry }}/j8q9y0n6
+          arguments: kafka-client-examples:simple-example:pushDockerMultiArch -PdockerRegistry=${{ steps.login-ecr-public.outputs.registry }}/j8q9y0n6 -PhelmRegistry=${{ steps.login-ecr-public.outputs.registry }}/j8q9y0n6
         env:
           ECR_REGISTRY: ${{ steps.login-ecr-public.outputs.registry }}
 
@@ -124,7 +132,7 @@ jobs:
         working-directory: sindri
         if: ${{ inputs.module == 'kafka-client' }}
         run: |
-            ./scripts/update-client-versions -s release -p false -i public.ecr.aws/j8q9y0n6/responsiveinc/simple-example -t $KAFKA_CLIENTS_VERSION
+            ./scripts/update-client-versions -s release -p true -i public.ecr.aws/j8q9y0n6/responsiveinc/simple-example -t $KAFKA_CLIENTS_VERSION
             ./scripts/run-smoke-test -s release -w system-tests-pub-release
             git checkout -- .
             ./scripts/update-client-versions -u -s release -p true -i public.ecr.aws/j8q9y0n6/responsiveinc/simple-example -t $KAFKA_CLIENTS_VERSION

--- a/buildSrc/src/main/kotlin/responsive.docker.gradle.kts
+++ b/buildSrc/src/main/kotlin/responsive.docker.gradle.kts
@@ -71,24 +71,26 @@ class DockerPlugin : Plugin<Project> {
             )
         }
 
-        project.tasks.register("tagDocker", Exec::class) {
-            dependsOn("buildDocker")
-            commandLine(
-                    "docker",
-                    "tag",
-                    config.dockerImage.get(),
-                    dockerRepoBase + config.dockerImage.get()
-            )
-        }
-
-        project.tasks.register("pushDocker", Exec::class) {
-            dependsOn("tagDocker")
-            commandLine("docker", "push", dockerRepoBase + config.dockerImage.get())
-        }
-
         project.tasks.register("loadDockerKind", Exec::class) {
             dependsOn("buildDocker")
             commandLine("kind", "load", "docker-image", config.dockerImage.get())
+        }
+
+        project.tasks.register("pushDockerMultiArch", Exec::class) {
+            dependsOn("copyJars")
+            dependsOn("copyDockerDir")
+            workingDir(project.buildDir.getPath())
+            commandLine(
+                    "docker",
+                    "buildx",
+                    "build",
+                    "--platform",
+                    "linux/amd64,linux/arm64",
+                    "-t",
+                    dockerRepoBase + config.dockerImage.get(),
+                    "--push",
+                    "docker"
+            )
         }
     }
 }

--- a/operator/docker/Dockerfile
+++ b/operator/docker/Dockerfile
@@ -1,11 +1,15 @@
-FROM amd64/debian:11.6 
+FROM debian:11.6
+
+ARG TARGETPLATFORM
 
 RUN apt update
 RUN apt install -y gettext-base
 RUN apt install -y wget
-RUN wget https://download.oracle.com/java/20/latest/jdk-20_linux-x64_bin.deb
-RUN apt -y install ./jdk-20_linux-x64_bin.deb
-RUN update-alternatives --install /usr/bin/java java /usr/lib/jvm/jdk-20/bin/java 1
+RUN echo $TARGETPLATFORM
+RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then wget https://download.oracle.com/java/20/latest/jdk-20_linux-x64_bin.tar.gz -O jdk-20.tar.gz; fi
+RUN if [ "$TARGETPLATFORM" = "linux/arm64" ]; then wget https://download.oracle.com/java/20/latest/jdk-20_linux-aarch64_bin.tar.gz -O jdk-20.tar.gz; fi
+RUN mkdir /usr/lib/jvm && tar zxvf jdk-20.tar.gz --directory /usr/lib/jvm
+RUN update-alternatives --install /usr/bin/java java /usr/lib/jvm/jdk-20.0.2/bin/java 1
 
 COPY libs/*.jar /usr/share/java/responsive-operator/
 COPY scripts/* /


### PR DESCRIPTION
- Add a pushDockerMultiArch task that builds and pushes a multi-architecture docker image.
- Update the github workflows to support using the new task. Each workflow that pushes images now needs extra steps to fetch the qemu emulator and install the docker build extensions.