### PR TITLE
support data keys that are equal to the metadata key literal

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/db/CassandraClient.java
+++ b/kafka-client/src/main/java/dev/responsive/db/CassandraClient.java
@@ -16,7 +16,7 @@
 
 package dev.responsive.db;
 
-import static dev.responsive.db.ColumnNames.PARTITION_KEY;
+import static dev.responsive.db.ColumnName.PARTITION_KEY;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.cql.AsyncResultSet;

--- a/kafka-client/src/main/java/dev/responsive/db/CassandraFactSchema.java
+++ b/kafka-client/src/main/java/dev/responsive/db/CassandraFactSchema.java
@@ -116,7 +116,6 @@ public class CassandraFactSchema implements RemoteKeyValueSchema {
   public MetadataRow metadata(final String table, final int partition) {
     final BoundStatement bound = getMeta.get(table)
         .bind()
-        .setByte(ROW_TYPE.column(), METADATA_ROW.val())
         .setByteBuffer(DATA_KEY.bind(), metadataKey(partition));
     final List<Row> result = client.execute(bound).all();
 
@@ -141,7 +140,6 @@ public class CassandraFactSchema implements RemoteKeyValueSchema {
     LOG.info("Setting offset for {}[{}] to {}", table, partition, offset);
     return setOffset.get(table)
         .bind()
-        .setByte(ROW_TYPE.column(), METADATA_ROW.val())
         .setByteBuffer(DATA_KEY.bind(), metadataKey(partition))
         .setLong(OFFSET.bind(), offset);
   }

--- a/kafka-client/src/main/java/dev/responsive/db/ColumnName.java
+++ b/kafka-client/src/main/java/dev/responsive/db/ColumnName.java
@@ -26,12 +26,13 @@ import java.time.Instant;
 import java.util.function.Function;
 import org.apache.kafka.common.utils.Bytes;
 
-public enum ColumnNames {
+public enum ColumnName {
 
   // shared partition key column
   PARTITION_KEY("partitionKey", "partitionkey"),
 
   // columns for the data tables
+  ROW_TYPE("type", "type"),
   DATA_KEY("key", "datakey", b -> bytes((Bytes) b)),
   DATA_VALUE("value", "value", b -> bytes((byte[]) b)),
   OFFSET("offset", "offset"),
@@ -56,11 +57,11 @@ public enum ColumnNames {
     return QueryBuilder.literal(Instant.ofEpochMilli(ts));
   }
 
-  ColumnNames(final String column, final String bind) {
+  ColumnName(final String column, final String bind) {
     this(column, bind, QueryBuilder::literal);
   }
 
-  ColumnNames(final String column, final String bind, final Function<Object, Literal> getLiteral) {
+  ColumnName(final String column, final String bind, final Function<Object, Literal> getLiteral) {
     this.column = column;
     this.bind = bind;
     this.getLiteral = getLiteral;

--- a/kafka-client/src/main/java/dev/responsive/db/LwtFencingToken.java
+++ b/kafka-client/src/main/java/dev/responsive/db/LwtFencingToken.java
@@ -17,11 +17,13 @@
 package dev.responsive.db;
 
 import static com.datastax.oss.driver.api.querybuilder.QueryBuilder.bindMarker;
-import static dev.responsive.db.ColumnNames.DATA_KEY;
-import static dev.responsive.db.ColumnNames.EPOCH;
-import static dev.responsive.db.ColumnNames.METADATA_KEY;
-import static dev.responsive.db.ColumnNames.PARTITION_KEY;
-import static dev.responsive.db.ColumnNames.WINDOW_START;
+import static dev.responsive.db.ColumnName.DATA_KEY;
+import static dev.responsive.db.ColumnName.EPOCH;
+import static dev.responsive.db.ColumnName.METADATA_KEY;
+import static dev.responsive.db.ColumnName.PARTITION_KEY;
+import static dev.responsive.db.ColumnName.ROW_TYPE;
+import static dev.responsive.db.ColumnName.WINDOW_START;
+import static dev.responsive.db.RowType.METADATA_ROW;
 
 import com.datastax.oss.driver.api.core.cql.BatchStatementBuilder;
 import com.datastax.oss.driver.api.core.cql.PreparedStatement;
@@ -144,6 +146,7 @@ public class LwtFencingToken implements FencingToken {
     return table.getClient().execute(
         QueryBuilder.update(name)
             .setColumn(EPOCH.column(), EPOCH.literal(epoch))
+            .where(ROW_TYPE.relation().isEqualTo(METADATA_ROW.literal()))
             .where(DATA_KEY.relation().isEqualTo(DATA_KEY.literal(METADATA_KEY)))
             .where(PARTITION_KEY.relation().isEqualTo(PARTITION_KEY.literal(partition)))
             .ifColumn(EPOCH.column()).isLessThan(EPOCH.literal(epoch))
@@ -161,6 +164,7 @@ public class LwtFencingToken implements FencingToken {
         QueryBuilder.update(name)
             .setColumn(EPOCH.column(), EPOCH.literal(epoch))
             .where(PARTITION_KEY.relation().isEqualTo(PARTITION_KEY.literal(partition)))
+            .where(ROW_TYPE.relation().isEqualTo(METADATA_ROW.literal()))
             .where(DATA_KEY.relation().isEqualTo(DATA_KEY.literal(METADATA_KEY)))
             .where(WINDOW_START.relation().isEqualTo(WINDOW_START.literal(0L)))
             .ifColumn(EPOCH.column()).isLessThan(EPOCH.literal(epoch))
@@ -177,6 +181,7 @@ public class LwtFencingToken implements FencingToken {
         QueryBuilder.update(name)
             .setColumn(EPOCH.column(), EPOCH.literal(epoch))
             .where(PARTITION_KEY.relation().isEqualTo(bindMarker(PARTITION_KEY.bind())))
+            .where(ROW_TYPE.relation().isEqualTo(METADATA_ROW.literal()))
             .where(DATA_KEY.relation().isEqualTo(DATA_KEY.literal(METADATA_KEY)))
             .ifColumn(EPOCH.column()).isEqualTo(EPOCH.literal(epoch))
             .build()
@@ -192,6 +197,7 @@ public class LwtFencingToken implements FencingToken {
         QueryBuilder.update(name)
             .setColumn(EPOCH.column(), EPOCH.literal(epoch))
             .where(PARTITION_KEY.relation().isEqualTo(bindMarker(PARTITION_KEY.bind())))
+            .where(ROW_TYPE.relation().isEqualTo(METADATA_ROW.literal()))
             .where(DATA_KEY.relation().isEqualTo(DATA_KEY.literal(METADATA_KEY)))
             .where(WINDOW_START.relation().isEqualTo(WINDOW_START.literal(0L)))
             .ifColumn(EPOCH.column()).isEqualTo(EPOCH.literal(epoch))

--- a/kafka-client/src/main/java/dev/responsive/db/RowType.java
+++ b/kafka-client/src/main/java/dev/responsive/db/RowType.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.db;
+
+import com.datastax.oss.driver.api.querybuilder.QueryBuilder;
+import com.datastax.oss.driver.api.querybuilder.term.Term;
+
+public enum RowType {
+
+  METADATA_ROW((byte) 0x0),
+  DATA_ROW((byte) 0x1);
+
+  private final byte val;
+
+  RowType(final byte val) {
+    this.val = val;
+  }
+
+  public byte val() {
+    return val;
+  }
+
+  public Term literal() {
+    return QueryBuilder.literal(val);
+  }
+}

--- a/kafka-client/src/main/java/dev/responsive/db/RowType.java
+++ b/kafka-client/src/main/java/dev/responsive/db/RowType.java
@@ -21,8 +21,9 @@ import com.datastax.oss.driver.api.querybuilder.term.Term;
 
 public enum RowType {
 
-  METADATA_ROW((byte) 0x0),
-  DATA_ROW((byte) 0x1);
+  UNKNOWN((byte) 0x0),
+  METADATA_ROW((byte) 0x1),
+  DATA_ROW((byte) 0x2);
 
   private final byte val;
 


### PR DESCRIPTION
depends on #91 - adds a row type byte to each data key so that we can differentiate between a metadata key and a data key with the same byte contents