### PR TITLE
fix: delay initialization of state stores and disable restore consumer for standby tasks

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveKafkaStreams.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveKafkaStreams.java
@@ -115,6 +115,7 @@ public class ResponsiveKafkaStreams extends KafkaStreams {
             clientSupplier,
             streamsConfig,
             storeRegistry,
+            restoreListener,
             metrics
         );
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/clients/StoreCommitListener.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/clients/StoreCommitListener.java
@@ -22,8 +22,8 @@ public class StoreCommitListener {
       final Map<RecordingKey, Long> committedOffsets,
       final Map<TopicPartition, Long> writtenOffsets
   ) {
-    // TODO: this is kind of inefficient (iterates over stores a lot). Not a huge deal
-    //       as we only run this on each commit. Can fix by indexing stores in registry
+    // TODO: we're technically iterating over zombie instances of this state store, which
+    //  should be excluded as they are technically blocked from committing
     for (final var e : committedOffsets.entrySet()) {
       final TopicPartition p = e.getKey().getPartition();
       for (final ResponsiveStoreRegistration storeRegistration

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/ActiveFilteringRestoreCallback.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/ActiveFilteringRestoreCallback.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.responsive.kafka.store;
+
+import java.util.Collection;
+import java.util.function.BooleanSupplier;
+import java.util.function.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.streams.processor.internals.RecordBatchingStateRestoreCallback;
+
+public class ActiveFilteringRestoreCallback implements RecordBatchingStateRestoreCallback {
+
+  private final TopicPartition changelogPartition;
+
+  private final Consumer<Collection<ConsumerRecord<byte[], byte[]>>> batchRestorer;
+  private final BooleanSupplier isActive;
+
+  public ActiveFilteringRestoreCallback(
+      final TopicPartition changelogPartition,
+      final Consumer<Collection<ConsumerRecord<byte[], byte[]>>> batchRestorer,
+      final BooleanSupplier isActive
+  ) {
+    this.changelogPartition = changelogPartition;
+    this.batchRestorer = batchRestorer;
+    this.isActive = isActive;
+  }
+
+  @Override
+  public void restoreBatch(final Collection<ConsumerRecord<byte[], byte[]>> records) {
+    if (isActive.getAsBoolean()) {
+      batchRestorer.accept(records);
+    } else {
+      throw new IllegalStateException("Unexpected attempt to restore batch to standby changelog: "
+                                          + changelogPartition);
+    }
+  }
+}

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/CommitBuffer.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/CommitBuffer.java
@@ -53,7 +53,7 @@ import org.apache.kafka.streams.processor.internals.RecordBatchingStateRestoreCa
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.slf4j.Logger;
 
-class CommitBuffer<K, S extends RemoteSchema<K>> implements RecordBatchingStateRestoreCallback {
+class CommitBuffer<K, S extends RemoteSchema<K>> {
 
   public static final int MAX_BATCH_SIZE = 1000;
   private final Logger log;
@@ -414,7 +414,6 @@ class CommitBuffer<K, S extends RemoteSchema<K>> implements RecordBatchingStateR
     }
   }
 
-  @Override
   public void restoreBatch(final Collection<ConsumerRecord<byte[], byte[]>> records) {
     final List<ConsumerRecord<byte[], byte[]>> batch = new ArrayList<>(maxBatchSize);
     for (final ConsumerRecord<byte[], byte[]> r : records) {

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsivePartitionedStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsivePartitionedStore.java
@@ -36,22 +36,23 @@ import java.util.List;
 import java.util.concurrent.TimeoutException;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.errors.ProcessorStateException;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StateStoreContext;
 import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
+import org.apache.kafka.streams.processor.internals.Task.TaskType;
 import org.apache.kafka.streams.query.Position;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.internals.StoreQueryUtils;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class ResponsivePartitionedStore implements KeyValueStore<Bytes, byte[]> {
 
-  private static final Logger LOG = LoggerFactory.getLogger(ResponsivePartitionedStore.class);
+  private Logger log;
 
   private final TableName name;
   private final Position position;
@@ -65,13 +66,16 @@ public class ResponsivePartitionedStore implements KeyValueStore<Bytes, byte[]> 
 
   @SuppressWarnings("rawtypes")
   private InternalProcessorContext context;
-  private int partition;
+  private TopicPartition topicPartition;
   private RemoteKeyValueSchema schema;
 
   public ResponsivePartitionedStore(final ResponsiveKeyValueParams params) {
     this.params = params;
     this.name = params.name();
     this.position = Position.emptyPosition();
+    log = new LogContext(
+        String.format("store [%s]", name.kafkaName())
+    ).logger(ResponsivePartitionedStore.class);
   }
 
   @Override
@@ -94,11 +98,23 @@ public class ResponsivePartitionedStore implements KeyValueStore<Bytes, byte[]> 
   @Override
   public void init(final StateStoreContext context, final StateStore root) {
     try {
-      LOG.info("Initializing state store {}", name);
+      this.context = asInternalProcessorContext(context);
+      storeRegistry = InternalConfigs.loadStoreRegistry(context.appConfigs());
+      topicPartition =  new TopicPartition(
+          changelogFor(context, name.kafkaName(), false),
+          context.taskId().partition()
+      );
+
+      if (!isActive()) {
+        log = new LogContext(
+            String.format("standby-store [%s]", name.kafkaName())
+        ).logger(ResponsivePartitionedStore.class);
+      }
+
+      log.info("Initializing state store");
+
       StoreUtil.validateTopologyOptimizationConfig(context.appConfigs());
       final ResponsiveConfig config = new ResponsiveConfig(context.appConfigs());
-      this.context = asInternalProcessorContext(context);
-      partition = context.taskId().partition();
 
       final SharedClients sharedClients = new SharedClients(context.appConfigs());
       CassandraClient client = sharedClients.cassandraClient;
@@ -108,14 +124,10 @@ public class ResponsivePartitionedStore implements KeyValueStore<Bytes, byte[]> 
 
       final RemoteMonitor monitor = client.awaitTable(name.cassandraName(), sharedClients.executor);
       monitor.await(Duration.ofSeconds(60));
-      LOG.info("Remote table {} is available for querying.", name.cassandraName());
+      log.info("Remote table {} is available for querying.", name.cassandraName());
 
       schema.prepare(name.cassandraName());
 
-      final TopicPartition topicPartition =  new TopicPartition(
-          changelogFor(context, name.kafkaName(), false),
-          partition
-      );
       partitioner = params.schemaType() == SchemaType.FACT
           ? SubPartitioner.NO_SUBPARTITIONS
           : config.getSubPartitioner(sharedClients.admin, name, topicPartition.topic());
@@ -129,22 +141,105 @@ public class ResponsivePartitionedStore implements KeyValueStore<Bytes, byte[]> 
           partitioner,
           config
       );
-      buffer.init();
+
+      if (isActive()) {
+        buffer.init();
+        registration = new ResponsiveStoreRegistration(
+            name.kafkaName(),
+            topicPartition,
+            buffer::flush,
+            this::storedOffset
+        );
+      } else {
+        registration = new ResponsiveStoreRegistration(
+            name.kafkaName(),
+            topicPartition,
+            buffer::flush,
+            this::storedOffset,
+            this::maybeTransitionToActive
+        );
+      }
+
+      storeRegistry.registerStore(registration);
 
       open = true;
-
-      context.register(root, buffer);
-      final long offset = buffer.offset();
-      registration = new ResponsiveStoreRegistration(
-          name.kafkaName(),
-          topicPartition,
-          offset == -1 ? 0 : offset,
-          buffer::flush
+      context.register(
+          root,
+          new ActiveFilteringRestoreCallback(
+              topicPartition,
+              (batch) -> buffer.restoreBatch(batch),
+              this::isActive
+          )
       );
-      storeRegistry = InternalConfigs.loadStoreRegistry(context.appConfigs());
-      storeRegistry.registerStore(registration);
     } catch (InterruptedException | TimeoutException e) {
-      throw new ProcessorStateException("Failed to initialize store.", e);
+      throw new ProcessorStateException("Failed to initialize store " + name(), e);
+    }
+  }
+
+  private boolean isActive() {
+    return context.taskType() == TaskType.ACTIVE;
+  }
+
+  /**
+   * The current stored offset in the remote table. Guaranteed to be less than or equal to the
+   * committed offset of the corresponding changelog topic partition in Kafka
+   * <p>
+   * NOTE: this always makes a remote call, should be cached eg when used to obtain starting offset
+   *
+   * @return the latest offset stored in the remote table, or
+   *         {@link ResponsiveStoreRegistration#NO_COMMITTED_OFFSET} if no offset was yet committed
+   */
+  private long storedOffset() {
+    if (isActive()) {
+      return buffer.offset();
+    } else {
+      log.error("Tried to access the stored offset but the commit buffer is still uninitialized");
+      throw new IllegalStateException("Requested stored offset before buffer initialization");
+    }
+  }
+
+  /**
+   * Due to a "bug" in Kafka Streams before version 3.6, it's possible for temporary standby tasks
+   * to be created so they can be recycled into active tasks in an immediate followup rebalance.
+   * This is a unique "bug" arising when an active task must be revoked from another client before
+   * it can be assigned to this (for which a standby is placed to avoid closing and losing in-memory
+   * state), thus we do not need to worry about the reverse case of active tasks becoming standby
+   * to worry about tasks being.
+   * <p>
+   * Standby tasks create a problem for us because we can't initialize the commit buffer without
+   * accidentally fencing the active task. We must delay the buffer initialization until the standby
+   * task is recycled into an active. This method is invoked to complete the transition
+   * <p>
+   * A recycled task will close everything except for its state stores, which are handed over as-is
+   * to the new task without going through #close or #init again. We use the restore consumer and a
+   * restore listener to infer when a task transitions from standby to active restoration. We also
+   * block all restoration while in standby mode, and wait to set the starting offset until it's
+   * recycled to ensure we don't overcount or undercount any changelog records
+   *
+   * @return whether the store finished initialization and is ready to restore as an active task
+   */
+  // TODO extract this and below methods into common superclass to share with Window/Session stores
+  private boolean maybeTransitionToActive() {
+    if (isActive()) {
+      log.info("Transitioning from standby to active");
+
+      log = new LogContext(
+          String.format("store [%s]", name.kafkaName())
+      ).logger(ResponsivePartitionedStore.class);
+
+      buffer.init();
+      log.info("Initialized buffer");
+      return true;
+    } else {
+      log.debug("Skipping initialization for restore start in standby mode");
+      return false;
+    }
+  }
+
+  private void enforceIsActive(final String caller) {
+    if (!isActive()) {
+      log.error("Invoked {} on store while in STANDBY", caller);
+      throw new IllegalStateException("Unexpected read/write to store in standby state: " + name());
     }
   }
 
@@ -169,6 +264,7 @@ public class ResponsivePartitionedStore implements KeyValueStore<Bytes, byte[]> 
 
   @Override
   public void put(final Bytes key, final byte[] value) {
+    enforceIsActive("put");
     buffer.put(key, value, context.timestamp());
     StoreQueryUtils.updatePosition(position, context);
   }
@@ -203,6 +299,7 @@ public class ResponsivePartitionedStore implements KeyValueStore<Bytes, byte[]> 
 
   @Override
   public byte[] get(final Bytes key) {
+    enforceIsActive("get");
     // try the buffer first, it acts as a local cache
     // but this is also necessary for correctness as
     // it is possible that the data is either uncommitted
@@ -212,21 +309,24 @@ public class ResponsivePartitionedStore implements KeyValueStore<Bytes, byte[]> 
       return result.isTombstone ? null : result.value;
     }
 
+    final int subPartition = partitioner.partition(topicPartition.partition(), key);
     final long minValidTs = params
         .timeToLive()
         .map(ttl -> context.timestamp() - ttl.toMillis())
         .orElse(-1L);
 
-    return schema.get(name.cassandraName(), partitioner.partition(partition, key), key, minValidTs);
+    return schema.get(name.cassandraName(), subPartition, key, minValidTs);
   }
 
   @Override
   public KeyValueIterator<Bytes, byte[]> range(final Bytes from, final Bytes to) {
+    enforceIsActive("range");
     throw new UnsupportedOperationException("Not yet implemented.");
   }
 
   @Override
   public KeyValueIterator<Bytes, byte[]> all() {
+    enforceIsActive("all");
     throw new UnsupportedOperationException("Not yet implemented.");
   }
 
@@ -238,7 +338,7 @@ public class ResponsivePartitionedStore implements KeyValueStore<Bytes, byte[]> 
   @Override
   public long approximateNumEntries() {
     return partitioner
-        .all(partition)
+        .all(topicPartition.partition())
         .mapToLong(p -> schema.cassandraClient().count(name.cassandraName(), p))
         .sum();
   }
@@ -249,5 +349,6 @@ public class ResponsivePartitionedStore implements KeyValueStore<Bytes, byte[]> 
     if (storeRegistry != null) {
       storeRegistry.deregisterStore(registration);
     }
+    open = false;
   }
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveStore.java
@@ -90,6 +90,7 @@ public class ResponsiveStore implements KeyValueStore<Bytes, byte[]> {
     } else {
       delegate = new ResponsivePartitionedStore(params);
     }
+
     delegate.init(context, root);
   }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveStoreRegistration.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveStoreRegistration.java
@@ -16,42 +16,114 @@
 
 package dev.responsive.kafka.store;
 
-import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting;
 import java.util.Objects;
+import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
+import java.util.function.LongSupplier;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.LogContext;
 import org.slf4j.Logger;
 
 public final class ResponsiveStoreRegistration {
   public static final long NO_COMMITTED_OFFSET = -1L; // buffer is initialized but no prior offset
+  public static final long UNINITIALIZED_OFFSET = -2L; // buffer is not yet initialized
 
   private final Logger log;
   private final String storeName;
   private final TopicPartition changelogTopicPartition;
   private final Consumer<Long> onCommit;
 
-  private final long startOffset; // stored offset during init, ie where restore should start
+  private final LongSupplier storedOffset; // RPC to fetch offset committed in remote table
+  private final BooleanSupplier maybeInitialize; // returns true if/when initialization is done
+  private long startOffset; // stored offset as of initialization, ie where restore should start
 
-  @VisibleForTesting
   public ResponsiveStoreRegistration(
       final String storeName,
       final TopicPartition changelogTopicPartition,
-      final long startOffset,
-      final Consumer<Long> onCommit
+      final Consumer<Long> onCommit,
+      final LongSupplier storedOffset
+  ) {
+    this(
+        storeName,
+        changelogTopicPartition,
+        onCommit,
+        () -> {
+          throw new IllegalStateException("Already initialized stored offset for changelog "
+                                              + changelogTopicPartition);
+        },
+        () -> {
+          throw new IllegalStateException("Already initialized regular active store with changelog "
+                                              + changelogTopicPartition);
+        },
+        storedOffset.getAsLong()
+    );
+  }
+
+  public ResponsiveStoreRegistration(
+      final String storeName,
+      final TopicPartition changelogTopicPartition,
+      final Consumer<Long> onCommit,
+      final LongSupplier storedOffset,
+      final BooleanSupplier maybeInitialize
+  ) {
+    this(
+        storeName,
+        changelogTopicPartition,
+        onCommit,
+        storedOffset,
+        maybeInitialize,
+        UNINITIALIZED_OFFSET
+    );
+  }
+
+  private ResponsiveStoreRegistration(
+      final String storeName,
+      final TopicPartition changelogTopicPartition,
+      final Consumer<Long> onCommit,
+      final LongSupplier storedOffset,
+      final BooleanSupplier maybeInitialize,
+      final long startOffset
   ) {
     this.storeName = Objects.requireNonNull(storeName);
     this.changelogTopicPartition = Objects.requireNonNull(changelogTopicPartition);
-    this.startOffset = startOffset;
     this.onCommit = Objects.requireNonNull(onCommit);
+    this.storedOffset = Objects.requireNonNull(storedOffset);
+    this.maybeInitialize = Objects.requireNonNull(maybeInitialize);
+    this.startOffset = startOffset;
     this.log = new LogContext(
-        String.format("changelog [%s]", changelogTopicPartition)
+        String.format("registered changelog [%s]", changelogTopicPartition)
     ).logger(ResponsiveStoreRegistration.class);
     log.debug("Created store registration with stored offset={}", startOffset);
   }
 
+  /**
+   * Invoked prior to beginning restoration on a changelog, whether active or standby.
+   * Used by the {@link dev.responsive.kafka.clients.ResponsiveRestoreConsumer} to determine
+   * where to seek before starting the restore
+   *
+   * @return the initial committed offset from which restoration should be started
+   */
   public long startOffset() {
-    return startOffset;
+    maybeInitializeStateStoreAndOffset();
+
+    if (startOffset == NO_COMMITTED_OFFSET) {
+      log.debug("Starting at offset 0 due to no prior committed offset");
+      return 0L;
+    } else if (startOffset == UNINITIALIZED_OFFSET) {
+      log.debug("Returning dummy start offset 0 for un-initialized standby store");
+      return 0L;
+    } else {
+      return startOffset;
+    }
+  }
+
+  private void maybeInitializeStateStoreAndOffset() {
+    if (startOffset == UNINITIALIZED_OFFSET) {
+      if (maybeInitialize.getAsBoolean()) {
+        startOffset = storedOffset.getAsLong();
+        log.info("Initialized recycled state store with starting offset = {}", startOffset);
+      }
+    }
   }
 
   public TopicPartition changelogTopicPartition() {

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveStoreRegistry.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveStoreRegistry.java
@@ -16,8 +16,11 @@
 
 package dev.responsive.kafka.store;
 
+import java.util.Collection;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.stream.Collectors;
@@ -25,43 +28,55 @@ import org.apache.kafka.common.TopicPartition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Note: there is exactly one instance per Streams application, shared between all threads. This
+ * means we may track multiple versions of the same state store, for example an active/standby and
+ * one or more zombies.
+ */
+// TODO could solve the above issue by creating one store registry per StreamThread, which
+//  would of course also let us remove all the synchronization as well. Which is nice
 public class ResponsiveStoreRegistry {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(ResponsiveStoreRegistry.class);
+  private static final Logger LOG = LoggerFactory.getLogger(ResponsiveStoreRegistry.class);
 
-  private final List<ResponsiveStoreRegistration> stores = new LinkedList<>();
+  private final Map<TopicPartition, List<ResponsiveStoreRegistration>> stores = new HashMap<>();
 
-  public synchronized OptionalLong getCommittedOffset(final TopicPartition topicPartition) {
+  public synchronized OptionalLong startOffset(final TopicPartition topicPartition) {
     return getRegisteredStoresForChangelog(topicPartition).stream()
         .mapToLong(ResponsiveStoreRegistration::startOffset)
         .max();
   }
 
+  // TODO: we return potentially more than one store because there might be zombie stores that
+  //  haven't yet been closed/unregistered -- but we can just bump the zombies to maintain
+  //  and allow only a single valid registered store at a time (eg via onRestoreStart)
   public synchronized List<ResponsiveStoreRegistration> getRegisteredStoresForChangelog(
       final TopicPartition topicPartition
   ) {
-    return stores.stream()
-        .filter(s -> s.changelogTopicPartition().equals(topicPartition))
-        .collect(Collectors.toList());
+    return stores.get(topicPartition);
   }
 
   public synchronized void registerStore(final ResponsiveStoreRegistration registration) {
     validateSingleMaterialization(registration);
-    stores.add(registration);
+    stores
+        .computeIfAbsent(registration.changelogTopicPartition(), x -> new LinkedList<>())
+        .add(registration);
   }
 
   public synchronized void deregisterStore(final ResponsiveStoreRegistration registration) {
-    stores.remove(registration);
+    stores.remove(registration.changelogTopicPartition());
   }
 
   public synchronized List<ResponsiveStoreRegistration> stores() {
-    return stores;
+    return stores.values().stream().flatMap(Collection::stream).collect(Collectors.toList());
   }
 
+  // Validate that no two stores of different names attempt to materialize the same changelog topic
   private void validateSingleMaterialization(final ResponsiveStoreRegistration registration) {
     final String topic = registration.changelogTopicPartition().topic();
     final String name = registration.storeName();
-    final Optional<ResponsiveStoreRegistration> conflicting = stores.stream()
+    final Optional<ResponsiveStoreRegistration> conflicting = stores.entrySet().stream()
+        .flatMap(e -> e.getValue().stream())
         .filter(si -> si.changelogTopicPartition().topic().equals(topic)
             && !si.storeName().equals(name))
         .findFirst();
@@ -71,7 +86,7 @@ public class ResponsiveStoreRegistry {
           topic,
           name, conflicting.get().storeName()
       ));
-      LOGGER.error("found conflicting materialization", err);
+      LOG.error("Found conflicting materialization", err);
       throw err;
     }
   }

--- a/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsiveStoreRegistryTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsiveStoreRegistryTest.java
@@ -26,13 +26,13 @@ class ResponsiveStoreRegistryTest {
 
   @Test
   public void shouldGetCommittedOffsetFromRegisteredStore() {
-    assertThat(registry.getCommittedOffset(TOPIC_PARTITION), is(OptionalLong.of(123L)));
+    assertThat(registry.startOffset(TOPIC_PARTITION), is(OptionalLong.of(123L)));
   }
 
   @Test
   public void shouldReturnEmptyCommittedOffsetFromNotRegisteredStore() {
     assertThat(
-        registry.getCommittedOffset(new TopicPartition("foo", 1)),
+        registry.startOffset(new TopicPartition("foo", 1)),
         is(OptionalLong.empty())
     );
   }
@@ -43,7 +43,7 @@ class ResponsiveStoreRegistryTest {
     registry.deregisterStore(REGISTRATION);
 
     // when:
-    final OptionalLong offset = registry.getCommittedOffset(TOPIC_PARTITION);
+    final OptionalLong offset = registry.startOffset(TOPIC_PARTITION);
 
     // then:
     assertThat(offset, is(OptionalLong.empty()));


### PR DESCRIPTION
This patch is for mounting a defense against the possibility of standby tasks which may be assigned in a rebalance in order to turn them into active tasks in an immediate followup rebalance, once revoked by their current owner. In general, these standbys should always be temporary and either recycled to active or removed entirely by the next rebalance (though we don't assume this anywhere in case of change in behavior). We can, however, assume that active tasks are never going to be recycled into a standby.

The problem for us is that a standby task will end up fencing the active (and throwing us into a rebalance loop) if it goes through with initialization of the commit buffer during the StateStore's #init. So ultimately, we want to 

1. Skip the `CommitBuffer#init` call if the task is a standby
2. Enforce that the task is active for all put/get calls
3. Pause any changelog partitions belonging to standby tasks assigned to the restoreConsumer
4. After a standby is recycled but before it begins active restoration:
    i. complete the state store initialization
    ii. fetch the stored offset in the remote table
    iii. unpause the changelog

1-2 are relatively easy but unfortunately because a recycle is handled transparently with no calls to the underlying store, 3-4 are a bit tricky. 

Luckily we can leverage the existing seek/offset initialization logic in the restoreConsumer to hook into the state store when restoration starts, and solve 4.i - ii by asking the corresponding ResponsiveStoreRegistration for the stored offset to begin restoring from. The store registration calls the underlying store, which checks whether it's transitioned to ACTIVE and initializes the buffer if so.

For 3 & 4.iv we use a StateRestoreListener to detect when a task begins active restoration, since this listener is not invoked for standbys. Effectively we pause all changelogs when they are first registered, and then mark them as active to unpause them once we see a StateRestoreListener#onRestoreStart