### PR TITLE
fix: initialize restore consumer offsets once

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/db/CassandraFactSchema.java
+++ b/kafka-client/src/main/java/dev/responsive/db/CassandraFactSchema.java
@@ -23,6 +23,7 @@ import static dev.responsive.db.ColumnName.OFFSET;
 import static dev.responsive.db.ColumnName.PARTITION_KEY;
 import static dev.responsive.db.ColumnName.ROW_TYPE;
 import static dev.responsive.kafka.store.ResponsiveStoreRegistration.NO_COMMITTED_OFFSET;
+
 import com.datastax.oss.driver.api.core.cql.BoundStatement;
 import com.datastax.oss.driver.api.core.cql.PreparedStatement;
 import com.datastax.oss.driver.api.core.cql.Row;

--- a/kafka-client/src/main/java/dev/responsive/db/CassandraFactSchema.java
+++ b/kafka-client/src/main/java/dev/responsive/db/CassandraFactSchema.java
@@ -24,6 +24,7 @@ import static dev.responsive.db.ColumnName.OFFSET;
 import static dev.responsive.db.ColumnName.ROW_TYPE;
 import static dev.responsive.db.RowType.DATA_ROW;
 import static dev.responsive.db.RowType.METADATA_ROW;
+import static dev.responsive.kafka.store.ResponsiveStoreRegistration.NO_COMMITTED_OFFSET;
 
 import com.datastax.oss.driver.api.core.cql.BoundStatement;
 import com.datastax.oss.driver.api.core.cql.PreparedStatement;
@@ -123,7 +124,7 @@ public class CassandraFactSchema implements RemoteKeyValueSchema {
         QueryBuilder.insertInto(table)
             .value(ROW_TYPE.column(), QueryBuilder.literal(METADATA_ROW.val()))
             .value(DATA_KEY.column(), QueryBuilder.literal(metadataKey(kafkaPartition)))
-            .value(OFFSET.column(), OFFSET.literal(-1L))
+            .value(OFFSET.column(), OFFSET.literal(NO_COMMITTED_OFFSET))
             .ifNotExists()
             .build()
     );

--- a/kafka-client/src/main/java/dev/responsive/db/CassandraKeyValueSchema.java
+++ b/kafka-client/src/main/java/dev/responsive/db/CassandraKeyValueSchema.java
@@ -26,6 +26,7 @@ import static dev.responsive.db.ColumnName.PARTITION_KEY;
 import static dev.responsive.db.ColumnName.ROW_TYPE;
 import static dev.responsive.db.RowType.DATA_ROW;
 import static dev.responsive.db.RowType.METADATA_ROW;
+import static dev.responsive.kafka.store.ResponsiveStoreRegistration.NO_COMMITTED_OFFSET;
 
 import com.datastax.oss.driver.api.core.cql.BoundStatement;
 import com.datastax.oss.driver.api.core.cql.PreparedStatement;
@@ -128,7 +129,7 @@ public class CassandraKeyValueSchema implements RemoteKeyValueSchema {
               .value(PARTITION_KEY.column(), PARTITION_KEY.literal(sub))
               .value(ROW_TYPE.column(), METADATA_ROW.literal())
               .value(DATA_KEY.column(), DATA_KEY.literal(METADATA_KEY))
-              .value(OFFSET.column(), OFFSET.literal(-1L))
+              .value(OFFSET.column(), OFFSET.literal(NO_COMMITTED_OFFSET))
               .value(EPOCH.column(), EPOCH.literal(0L))
               .ifNotExists()
               .build()

--- a/kafka-client/src/main/java/dev/responsive/db/CassandraWindowedSchema.java
+++ b/kafka-client/src/main/java/dev/responsive/db/CassandraWindowedSchema.java
@@ -27,6 +27,7 @@ import static dev.responsive.db.ColumnName.ROW_TYPE;
 import static dev.responsive.db.ColumnName.WINDOW_START;
 import static dev.responsive.db.RowType.DATA_ROW;
 import static dev.responsive.db.RowType.METADATA_ROW;
+import static dev.responsive.kafka.store.ResponsiveStoreRegistration.NO_COMMITTED_OFFSET;
 
 import com.datastax.oss.driver.api.core.cql.BoundStatement;
 import com.datastax.oss.driver.api.core.cql.PreparedStatement;
@@ -138,7 +139,7 @@ public class CassandraWindowedSchema implements RemoteWindowedSchema {
               .value(ROW_TYPE.column(), METADATA_ROW.literal())
               .value(DATA_KEY.column(), DATA_KEY.literal(ColumnName.METADATA_KEY))
               .value(WINDOW_START.column(), WINDOW_START.literal(0L))
-              .value(OFFSET.column(), OFFSET.literal(-1L))
+              .value(OFFSET.column(), OFFSET.literal(NO_COMMITTED_OFFSET))
               .value(EPOCH.column(), EPOCH.literal(0L))
               .ifNotExists()
               .build()

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveStores.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveStores.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package dev.responsive.kafka.api;
 
 import dev.responsive.kafka.store.ResponsiveMaterialized;

--- a/kafka-client/src/main/java/dev/responsive/kafka/clients/DelegatingConsumer.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/clients/DelegatingConsumer.java
@@ -37,7 +37,7 @@ import org.apache.kafka.common.TopicPartition;
 
 public abstract class DelegatingConsumer<K, V> implements Consumer<K, V> {
 
-  protected final Consumer<K, V> delegate;
+  private final Consumer<K, V> delegate;
 
   public DelegatingConsumer(final Consumer<K, V> delegate) {
     this.delegate = delegate;

--- a/kafka-client/src/main/java/dev/responsive/kafka/clients/ResponsiveGlobalConsumer.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/clients/ResponsiveGlobalConsumer.java
@@ -97,7 +97,7 @@ public class ResponsiveGlobalConsumer extends DelegatingConsumer<byte[], byte[]>
 
   @Override
   public ConsumerRecords<byte[], byte[]> poll(final Duration timeout) {
-    final ConsumerRecords<byte[], byte[]> poll = delegate.poll(timeout);
+    final ConsumerRecords<byte[], byte[]> poll = super.poll(timeout);
     return SingletonConsumerRecords.of(poll);
   }
 
@@ -125,7 +125,7 @@ public class ResponsiveGlobalConsumer extends DelegatingConsumer<byte[], byte[]>
   @Override
   public long position(final TopicPartition partition, final Duration duration) {
     if (assignment().contains(partition)) {
-      return delegate.position(partition, duration);
+      return super.position(partition, duration);
     }
 
     // we may not be assigned this partition, in which case someone else

--- a/kafka-client/src/main/java/dev/responsive/kafka/clients/ResponsiveKafkaClientSupplier.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/clients/ResponsiveKafkaClientSupplier.java
@@ -118,7 +118,8 @@ public final class ResponsiveKafkaClientSupplier implements KafkaClientSupplier 
 
   @Override
   public Consumer<byte[], byte[]> getConsumer(final Map<String, Object> config) {
-    LOG.info("Creating responsive main consumer");
+    final String clientId = (String) config.get(CommonClientConfigs.CLIENT_ID_CONFIG);
+    LOG.info("Creating responsive main consumer: {}", clientId);
     final String tid = threadIdFromConsumerConfig(config);
     final ListenersForThread tc = sharedListeners.getAndMaybeInitListenersForThread(
         eos,
@@ -130,7 +131,7 @@ public final class ResponsiveKafkaClientSupplier implements KafkaClientSupplier 
     );
     // TODO: the end offsets poller call is kind of heavy for a synchronized block
     return factories.createResponsiveConsumer(
-        (String) config.get(CommonClientConfigs.CLIENT_ID_CONFIG),
+        clientId,
         wrapped.getConsumer(config),
         List.of(
             tc.committedOffsetMetricListener,
@@ -143,8 +144,10 @@ public final class ResponsiveKafkaClientSupplier implements KafkaClientSupplier 
 
   @Override
   public Consumer<byte[], byte[]> getRestoreConsumer(final Map<String, Object> config) {
-    LOG.info("Creating responsive restore consumer");
+    final String clientId = (String) config.get(CommonClientConfigs.CLIENT_ID_CONFIG);
+    LOG.info("Creating responsive restore consumer: {}", clientId);
     return new ResponsiveRestoreConsumer<>(
+        clientId,
         wrapped.getRestoreConsumer(config),
         storeRegistry::getCommittedOffset
     );

--- a/kafka-client/src/main/java/dev/responsive/kafka/clients/ResponsiveRestoreConsumer.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/clients/ResponsiveRestoreConsumer.java
@@ -1,61 +1,113 @@
 package dev.responsive.kafka.clients;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.HashSet;
 import java.util.Objects;
 import java.util.OptionalLong;
+import java.util.Set;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.utils.LogContext;
+import org.slf4j.Logger;
 
 /**
  * Consumer implementation to use for restoring Responsive stores. This Restore Consumer emulates
- * consumping a topic that has been truncated up to some offset on a subset of topic partitions.
+ * consuming a topic that has been truncated up to some offset on a subset of topic partitions.
  * The specific offsets are provided by a function mapping the topic partition to the start
  * offset. This consumer is used in conjunction with Responsive Stores, which provide a safe
  * starting offset that has been committed to a remote storage system. This is useful for
  * minimizing the length of restores when using a Responsive Store over a compacted changelog
  * topic (which cannot be truncated).
+ * <p>
+ * This consumer is used by Kafka Streams for both active and standby task restoration, though
+ * only one or the other at a given time. This may be subject to change, but the general process
+ * follows this pattern:
+ * 1. initialize changelogs for newly assigned tasks:
+ *     i. restoreConsumer.assign(current assignment + new changelogs)
+ *     ii. if STANDBY_MODE: restoreConsumer.pause(standby changelogs)
+ *     iii. restoreConsumer.seekToBeginning(new changelogs)
+ *     iv. startOffset = restoreConsumer.position(changelog)
+ *     iv. for each ACTIVE changelog: call StateRestoreListener#onRestoreStart
+ * 2. restore active/standby state stores:
+ *     i. poll for new record batch
+ *     ii. restore batch through StateRestoreCallback
+ *     iii. for each ACTIVE changelog in batch: call StateRestoreListener#onBatchRestored
+ *     iv. update current offset based on highest offset in batch
  *
  * @param <K> Type of the record keys
  * @param <V> Type of the record values
  */
 public class ResponsiveRestoreConsumer<K, V> extends DelegatingConsumer<K, V> {
-  final Function<TopicPartition, OptionalLong> startOffsets;
+  private final Logger log;
+
+  private final Function<TopicPartition, OptionalLong> startOffsets;
+  private final Set<TopicPartition> uninitializedOffsets = new HashSet<>();
 
   public ResponsiveRestoreConsumer(
+      final String clientId,
       final Consumer<K, V> delegate,
       final Function<TopicPartition, OptionalLong> startOffsets
   ) {
     super(delegate);
     this.startOffsets = Objects.requireNonNull(startOffsets);
+    this.log = new LogContext(
+        String.format("responsive-restore-consumer [%s]", Objects.requireNonNull(clientId))
+    ).logger(ResponsiveConsumer.class);
   }
 
-  private List<TopicPartition> seekInitial(final Collection<TopicPartition> partitions) {
-    final List<TopicPartition> notFound = new LinkedList<>();
+  private Set<TopicPartition> initializeOffsets(final Collection<TopicPartition> partitions) {
+    final Set<TopicPartition> notFound = new HashSet<>();
     for (final TopicPartition p : partitions) {
       final OptionalLong start = startOffsets.apply(p);
       if (start.isPresent()) {
-        delegate.seek(p, start.getAsLong());
+        super.seek(p, start.getAsLong());
       } else {
         notFound.add(p);
       }
     }
-    return Collections.unmodifiableList(notFound);
+    uninitializedOffsets.removeAll(partitions);
+    return Collections.unmodifiableSet(notFound);
   }
 
   @Override
   public void assign(Collection<TopicPartition> partitions) {
+    // track any newly-assigned changelogs
+    uninitializedOffsets.addAll(
+        partitions.stream()
+            .filter(p -> !super.assignment().contains(p))
+            .collect(Collectors.toSet()));
+
+    // clear any now-unassigned changelogs
+    uninitializedOffsets.retainAll(partitions);
+
     super.assign(partitions);
-    seekInitial(partitions);
+  }
+
+  @Override
+  public void unsubscribe() {
+    uninitializedOffsets.clear();
+    super.unsubscribe();
+  }
+
+  @Override
+  public ConsumerRecords<K, V> poll(final Duration timeout) {
+    if (!uninitializedOffsets.isEmpty()) {
+      log.error("Found uninitialized changelog partitions during poll: {}", uninitializedOffsets);
+      throw new IllegalStateException("Restore consumer invoked poll without initializing offsets");
+    }
+    return super.poll(timeout);
   }
 
   @Override
   public void seek(final TopicPartition partition, final long offset) {
     super.seek(partition, Math.max(offset, startOffsets.apply(partition).orElse(offset)));
+    uninitializedOffsets.remove(partition);
   }
 
   @Override
@@ -71,16 +123,18 @@ public class ResponsiveRestoreConsumer<K, V> extends DelegatingConsumer<K, V> {
             offsetAndMetadata.metadata()
         )
     );
+    uninitializedOffsets.remove(partition);
   }
 
   @Override
   public void seekToBeginning(final Collection<TopicPartition> partitions) {
-    final Collection<TopicPartition> withUncachedPosition = seekInitial(partitions);
+    final Set<TopicPartition> withUncachedPosition = initializeOffsets(partitions);
     if (withUncachedPosition.size() > 0) {
       // Make sure to only do this if the list of partitions without cached start positions
       // is not empty. If it's empty, KafkaConsumer will seek to the actual beginning of _all_
       // partitions.
       super.seekToBeginning(withUncachedPosition);
+      uninitializedOffsets.removeAll(withUncachedPosition);
     }
   }
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/clients/StoreCommitListener.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/clients/StoreCommitListener.java
@@ -28,14 +28,14 @@ public class StoreCommitListener {
       final TopicPartition p = e.getKey().getPartition();
       for (final ResponsiveStoreRegistration storeRegistration
           : storeRegistry.getRegisteredStoresForChangelog(p)) {
-        storeRegistration.getOnCommit().accept(e.getValue());
+        storeRegistration.onCommit().accept(e.getValue());
       }
     }
     for (final var e : writtenOffsets.entrySet()) {
       final TopicPartition p = e.getKey();
       for (final ResponsiveStoreRegistration storeRegistration
           : storeRegistry.getRegisteredStoresForChangelog(p)) {
-        storeRegistration.getOnCommit().accept(e.getValue());
+        storeRegistration.onCommit().accept(e.getValue());
       }
     }
   }

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveGlobalStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveGlobalStore.java
@@ -55,8 +55,6 @@ public class ResponsiveGlobalStore implements KeyValueStore<Bytes, byte[]> {
   private StateStoreContext context;
   private RemoteKeyValueSchema schema;
 
-  // TODO: instead of splitting this out into a separate store implementation, we should just
-  //  check whether a store is global at runtime (during init) and branch the logic from there
   public ResponsiveGlobalStore(final TableName name) {
     this.name = name;
     this.position = Position.emptyPosition();

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveStore.java
@@ -16,6 +16,8 @@
 
 package dev.responsive.kafka.store;
 
+import static org.apache.kafka.streams.processor.internals.ProcessorContextUtils.asInternalProcessorContext;
+
 import dev.responsive.kafka.api.ResponsiveKeyValueParams;
 import java.util.List;
 import org.apache.kafka.common.annotation.InterfaceStability.Evolving;
@@ -25,7 +27,7 @@ import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.processor.ProcessorContext;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StateStoreContext;
-import org.apache.kafka.streams.processor.internals.GlobalProcessorContextImpl;
+import org.apache.kafka.streams.processor.internals.Task.TaskType;
 import org.apache.kafka.streams.query.Position;
 import org.apache.kafka.streams.query.PositionBound;
 import org.apache.kafka.streams.query.Query;
@@ -83,7 +85,7 @@ public class ResponsiveStore implements KeyValueStore<Bytes, byte[]> {
 
   @Override
   public void init(final StateStoreContext context, final StateStore root) {
-    if (context instanceof GlobalProcessorContextImpl) {
+    if (asInternalProcessorContext(context).taskType() == TaskType.GLOBAL) {
       delegate = new ResponsiveGlobalStore(params.name());
     } else {
       delegate = new ResponsivePartitionedStore(params);

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveStoreRegistry.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveStoreRegistry.java
@@ -33,7 +33,7 @@ public class ResponsiveStoreRegistry {
 
   public synchronized OptionalLong getCommittedOffset(final TopicPartition topicPartition) {
     return getRegisteredStoresForChangelog(topicPartition).stream()
-        .mapToLong(ResponsiveStoreRegistration::getCommittedOffset)
+        .mapToLong(ResponsiveStoreRegistration::startOffset)
         .max();
   }
 
@@ -41,7 +41,7 @@ public class ResponsiveStoreRegistry {
       final TopicPartition topicPartition
   ) {
     return stores.stream()
-        .filter(s -> s.getChangelogTopicPartition().equals(topicPartition))
+        .filter(s -> s.changelogTopicPartition().equals(topicPartition))
         .collect(Collectors.toList());
   }
 
@@ -59,17 +59,17 @@ public class ResponsiveStoreRegistry {
   }
 
   private void validateSingleMaterialization(final ResponsiveStoreRegistration registration) {
-    final String topic = registration.getChangelogTopicPartition().topic();
-    final String name = registration.getName();
+    final String topic = registration.changelogTopicPartition().topic();
+    final String name = registration.storeName();
     final Optional<ResponsiveStoreRegistration> conflicting = stores.stream()
-        .filter(si -> si.getChangelogTopicPartition().topic().equals(topic)
-            && !si.getName().equals(name))
+        .filter(si -> si.changelogTopicPartition().topic().equals(topic)
+            && !si.storeName().equals(name))
         .findFirst();
     if (conflicting.isPresent()) {
       final var err = new IllegalStateException(String.format(
           "Found two stores that materialize the same changelog topic (%s): %s, %s",
           topic,
-          name, conflicting.get().getName()
+          name, conflicting.get().storeName()
       ));
       LOGGER.error("found conflicting materialization", err);
       throw err;

--- a/kafka-client/src/test/java/dev/responsive/kafka/clients/ResponsiveConsumerTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/clients/ResponsiveConsumerTest.java
@@ -75,17 +75,11 @@ class ResponsiveConsumerTest {
   }
 
   @Test
-  public void shouldNotifyWhenNoListenerProvided() {
-    // given:
-    consumer.subscribe(List.of("baguette", "pita"));
-    final var rebalanceListener = verifyAndGetCapturedRebalanceListener();
-
-    // when:
-    rebalanceListener.onPartitionsAssigned(List.of(PARTITION));
-
-    // then:
-    verify(listener1).onPartitionsAssigned(List.of(PARTITION));
-    verify(listener2).onPartitionsAssigned(List.of(PARTITION));
+  public void shouldThrowWhenNoListenerProvided() {
+    assertThrows(
+        IllegalStateException.class,
+        () -> consumer.subscribe(List.of("baguette", "pita"))
+    );
   }
 
   @Test

--- a/kafka-client/src/test/java/dev/responsive/kafka/clients/ResponsiveRestoreConsumerTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/clients/ResponsiveRestoreConsumerTest.java
@@ -1,14 +1,20 @@
 package dev.responsive.kafka.clients;
 
 import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
 
+import java.time.Duration;
+import java.util.Collections;
 import java.util.List;
 import java.util.OptionalLong;
+import java.util.Set;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -29,6 +35,7 @@ public class ResponsiveRestoreConsumerTest {
   @BeforeEach
   public void setup() {
     restoreConsumer = new ResponsiveRestoreConsumer<>(
+        "restore-consumer",
         wrapped,
         tp -> {
           if (tp.equals(TOPIC_PARTITION1)) {
@@ -42,13 +49,14 @@ public class ResponsiveRestoreConsumerTest {
   }
 
   @Test
-  public void shouldSetPositionOnAssign() {
+  public void shouldNotResetPositionOnAssignWithCachedPosition() {
     // when:
     restoreConsumer.assign(List.of(TOPIC_PARTITION1, TOPIC_PARTITION2));
 
     // then:
-    verify(wrapped).seek(TOPIC_PARTITION1, 123L);
-    verify(wrapped).seek(TOPIC_PARTITION2, 456L);
+    verify(wrapped, times(2)).assignment();
+    verify(wrapped).assign(List.of(TOPIC_PARTITION1, TOPIC_PARTITION2));
+    verifyNoMoreInteractions(wrapped);
   }
 
   @Test
@@ -57,6 +65,7 @@ public class ResponsiveRestoreConsumerTest {
     restoreConsumer.assign(List.of(TOPIC_PARTITION_NOT_CACHED));
 
     // then:
+    verify(wrapped).assignment();
     verify(wrapped).assign(List.of(TOPIC_PARTITION_NOT_CACHED));
     verifyNoMoreInteractions(wrapped);
   }
@@ -114,11 +123,73 @@ public class ResponsiveRestoreConsumerTest {
     // when:
     restoreConsumer.assign(List.of(TOPIC_PARTITION_NOT_CACHED));
     clearConsumerInvocations();
-    restoreConsumer.seekToBeginning(List.of(TOPIC_PARTITION_NOT_CACHED));
+    restoreConsumer.seekToBeginning(Set.of(TOPIC_PARTITION_NOT_CACHED));
 
     // then:
-    verify(wrapped).seekToBeginning(List.of(TOPIC_PARTITION_NOT_CACHED));
+    verify(wrapped).seekToBeginning(Set.of(TOPIC_PARTITION_NOT_CACHED));
     verifyNoMoreInteractions(wrapped);
+  }
+
+  @Test
+  public void shouldThrowIfCallToPollWithoutSeek() {
+    // when:
+    restoreConsumer.assign(List.of(TOPIC_PARTITION1, TOPIC_PARTITION2));
+
+    restoreConsumer.seekToBeginning(Collections.singleton(TOPIC_PARTITION1));
+
+    // then:
+    Assertions.assertThrows(
+        IllegalStateException.class,
+        () -> restoreConsumer.poll(Duration.ofMillis(100))
+    );
+  }
+
+  @Test
+  public void shouldThrowIfCallToPollWithoutSeekAfterReassignment() {
+    // when:
+    when(wrapped.assignment())
+        .thenReturn(Set.of(TOPIC_PARTITION1, TOPIC_PARTITION2))
+        .thenReturn(Set.of(TOPIC_PARTITION2));
+
+    restoreConsumer.assign(List.of(TOPIC_PARTITION1, TOPIC_PARTITION2));
+    restoreConsumer.seekToBeginning(List.of(TOPIC_PARTITION1, TOPIC_PARTITION2));
+
+    // remove tp1 to clear its seek
+    restoreConsumer.assign(List.of(TOPIC_PARTITION2));
+
+    // reassign tp1 requires a new seek before poll
+    restoreConsumer.assign(List.of(TOPIC_PARTITION1, TOPIC_PARTITION2));
+
+    // then:
+    Assertions.assertThrows(
+        IllegalStateException.class,
+        () -> restoreConsumer.poll(Duration.ofMillis(100))
+    );
+  }
+
+  @Test
+  public void shouldClearUninitializedPartitionsWhenUnassigned() {
+    // when:
+    restoreConsumer.assign(List.of(TOPIC_PARTITION1, TOPIC_PARTITION2));
+    when(wrapped.assignment()).thenReturn(Set.of(TOPIC_PARTITION1, TOPIC_PARTITION2));
+
+    restoreConsumer.seekToBeginning(Collections.singleton(TOPIC_PARTITION1));
+
+    restoreConsumer.assign(List.of(TOPIC_PARTITION1));
+
+    // then:
+    restoreConsumer.poll(Duration.ofMillis(100));
+  }
+
+  @Test
+  public void shouldClearUninitializedPartitionsWhenUnsubscribed() {
+    // when:
+    restoreConsumer.assign(List.of(TOPIC_PARTITION1, TOPIC_PARTITION2));
+
+    restoreConsumer.unsubscribe();
+
+    // then:
+    restoreConsumer.poll(Duration.ofMillis(100));
   }
 
   @SuppressWarnings("unchecked")

--- a/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsiveStoreTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsiveStoreTest.java
@@ -22,8 +22,8 @@ import static org.hamcrest.Matchers.instanceOf;
 import dev.responsive.kafka.api.ResponsiveKeyValueParams;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StateStoreContext;
-import org.apache.kafka.streams.processor.internals.GlobalProcessorContextImpl;
-import org.apache.kafka.streams.processor.internals.ProcessorContextImpl;
+import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
+import org.apache.kafka.streams.processor.internals.Task.TaskType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -37,19 +37,22 @@ import org.mockito.quality.Strictness;
 public class ResponsiveStoreTest {
 
   private static final String NAME = "foo";
+  private final ResponsiveStore store =
+      new ResponsiveStore(ResponsiveKeyValueParams.keyValue(NAME));
 
   @Mock
   private StateStore root;
+  @Mock
+  private InternalProcessorContext<?, ?> context;
 
   @Test
-  public void shouldCreateGlobalStoreWhenPassedGlobalStoreContext() {
+  public void shouldCreateGlobalStore() {
     // Given:
-    final StateStoreContext context = Mockito.mock(GlobalProcessorContextImpl.class);
-    final var store = new ResponsiveStore(ResponsiveKeyValueParams.keyValue(NAME));
+    Mockito.when(context.taskType()).thenReturn(TaskType.GLOBAL);
 
     // When:
     try {
-      store.init(context, root);
+      store.init((StateStoreContext) context, root);
     } catch (final Exception ignored) {
       // delegate initialization will fail with mocks, but still be properly set
     }
@@ -61,12 +64,11 @@ public class ResponsiveStoreTest {
   @Test
   public void shouldCreatePartitionedStoreWhenPassedStoreContext() {
     // Given:
-    final StateStoreContext context = Mockito.mock(ProcessorContextImpl.class);
-    final var store = new ResponsiveStore(ResponsiveKeyValueParams.keyValue(NAME));
+    Mockito.when(context.taskType()).thenReturn(TaskType.ACTIVE);
 
     // When:
     try {
-      store.init(context, root);
+      store.init((StateStoreContext) context, root);
     } catch (final Exception ignored) {
       // delegate initialization will fail with mocks, but still be properly set
     }

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/store/CassandraClientStub.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/store/CassandraClientStub.java
@@ -63,7 +63,7 @@ public class CassandraClientStub extends CassandraClient {
   }
 
   private void flush() {
-    storeRegistry.stores().forEach(s -> s.getOnCommit().accept(0L));
+    storeRegistry.stores().forEach(s -> s.onCommit().accept(0L));
   }
 
   @Override


### PR DESCRIPTION
Main change here is a fix in the ResponsiveRestoreConsumer, to avoid accidentally resetting any actively restoring changelogs back to their starting offset when new restoring tasks are added.

Cleaned up a few miscellaneous things I happened to notice in the various kafka clients on the side.

Also includes a few related (but minor) refactors from https://github.com/responsivedev/responsive-pub/pull/97/ to help break that up