### PR TITLE
Finish Responsive TTD with stubbed clients and store schemas

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -280,7 +280,7 @@
     </module>
     <module name="AbbreviationAsWordInName">
       <property name="ignoreFinal" value="false"/>
-      <property name="allowedAbbreviationLength" value="0"/>
+      <property name="allowedAbbreviationLength" value="4"/>
       <property name="tokens"
         value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, ANNOTATION_FIELD_DEF,
                     PARAMETER_DEF, VARIABLE_DEF, METHOD_DEF, PATTERN_VARIABLE_DEF, RECORD_DEF,

--- a/kafka-client/src/main/java/dev/responsive/db/CassandraFactSchema.java
+++ b/kafka-client/src/main/java/dev/responsive/db/CassandraFactSchema.java
@@ -209,7 +209,7 @@ public class CassandraFactSchema implements RemoteKeyValueSchema {
   }
 
   @Override
-  public CassandraClient getClient() {
+  public CassandraClient cassandraClient() {
     return client;
   }
 

--- a/kafka-client/src/main/java/dev/responsive/db/CassandraKeyValueSchema.java
+++ b/kafka-client/src/main/java/dev/responsive/db/CassandraKeyValueSchema.java
@@ -232,7 +232,7 @@ public class CassandraKeyValueSchema implements RemoteKeyValueSchema {
   }
 
   @Override
-  public CassandraClient getClient() {
+  public CassandraClient cassandraClient() {
     return client;
   }
 

--- a/kafka-client/src/main/java/dev/responsive/db/CassandraWindowedSchema.java
+++ b/kafka-client/src/main/java/dev/responsive/db/CassandraWindowedSchema.java
@@ -285,7 +285,7 @@ public class CassandraWindowedSchema implements RemoteWindowedSchema {
   }
 
   @Override
-  public CassandraClient getClient() {
+  public CassandraClient cassandraClient() {
     return client;
   }
 

--- a/kafka-client/src/main/java/dev/responsive/db/LwtWriterFactory.java
+++ b/kafka-client/src/main/java/dev/responsive/db/LwtWriterFactory.java
@@ -161,7 +161,7 @@ public class LwtWriterFactory<K> implements WriterFactory<K> {
       final int partition,
       final long epoch
   ) {
-    return table.getClient().execute(
+    return table.cassandraClient().execute(
         QueryBuilder.update(name)
             .setColumn(EPOCH.column(), EPOCH.literal(epoch))
             .where(ROW_TYPE.relation().isEqualTo(METADATA_ROW.literal()))
@@ -178,7 +178,7 @@ public class LwtWriterFactory<K> implements WriterFactory<K> {
       final int partition,
       final long epoch
   ) {
-    return table.getClient().execute(
+    return table.cassandraClient().execute(
         QueryBuilder.update(name)
             .setColumn(EPOCH.column(), EPOCH.literal(epoch))
             .where(PARTITION_KEY.relation().isEqualTo(PARTITION_KEY.literal(partition)))
@@ -195,7 +195,7 @@ public class LwtWriterFactory<K> implements WriterFactory<K> {
       final String name,
       final long epoch
   ) {
-    return table.getClient().prepare(
+    return table.cassandraClient().prepare(
         QueryBuilder.update(name)
             .setColumn(EPOCH.column(), EPOCH.literal(epoch))
             .where(PARTITION_KEY.relation().isEqualTo(bindMarker(PARTITION_KEY.bind())))
@@ -211,7 +211,7 @@ public class LwtWriterFactory<K> implements WriterFactory<K> {
       final String name,
       final long epoch
   ) {
-    return table.getClient().prepare(
+    return table.cassandraClient().prepare(
         QueryBuilder.update(name)
             .setColumn(EPOCH.column(), EPOCH.literal(epoch))
             .where(PARTITION_KEY.relation().isEqualTo(bindMarker(PARTITION_KEY.bind())))

--- a/kafka-client/src/main/java/dev/responsive/db/RemoteSchema.java
+++ b/kafka-client/src/main/java/dev/responsive/db/RemoteSchema.java
@@ -97,6 +97,6 @@ public interface RemoteSchema<K> {
       final long offset
   );
 
-  CassandraClient getClient();
+  CassandraClient cassandraClient();
 
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsivePartitionedStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsivePartitionedStore.java
@@ -234,17 +234,15 @@ public class ResponsivePartitionedStore implements KeyValueStore<Bytes, byte[]> 
   public long approximateNumEntries() {
     return partitioner
         .all(partition)
-        .mapToLong(p -> schema.getClient().count(name.cassandraName(), p))
+        .mapToLong(p -> schema.cassandraClient().count(name.cassandraName(), p))
         .sum();
   }
 
   @Override
   public void close() {
+    // no need to flush the buffer here, will happen through the kafka client commit as usual
     if (storeRegistry != null) {
       storeRegistry.deregisterStore(registration);
     }
-    // the client is shared across state stores, so only the
-    // buffer needs to be flushed
-    flush();
   }
 }

--- a/responsive-test-utils/build.gradle.kts
+++ b/responsive-test-utils/build.gradle.kts
@@ -20,6 +20,7 @@ plugins {
 
 dependencies {
     implementation(project(":kafka-client"))
+    implementation(libs.bundles.scylla)
     implementation(libs.kafka.streams.test.utils)
     implementation(libs.kafka.clients) {
         artifact {

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/api/CassandraClientStub.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/api/CassandraClientStub.java
@@ -32,6 +32,7 @@ import java.util.Properties;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ScheduledExecutorService;
 
+// TODO: use mock return values instead of null here and in the TTD schemas
 public class CassandraClientStub extends CassandraClient {
 
   private final TTDKeyValueSchema kvSchema;

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/api/CassandraClientStub.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/api/CassandraClientStub.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.kafka.api;
+
+import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
+import com.datastax.oss.driver.api.core.cql.PreparedStatement;
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import com.datastax.oss.driver.api.core.cql.SimpleStatement;
+import com.datastax.oss.driver.api.core.cql.Statement;
+import dev.responsive.db.CassandraClient;
+import dev.responsive.db.RemoteKeyValueSchema;
+import dev.responsive.db.RemoteWindowedSchema;
+import dev.responsive.kafka.config.ResponsiveConfig;
+import dev.responsive.kafka.store.SchemaType;
+import dev.responsive.utils.RemoteMonitor;
+import java.util.OptionalInt;
+import java.util.Properties;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ScheduledExecutorService;
+
+public class CassandraClientStub extends CassandraClient {
+
+  private final TTDKeyValueSchema kvSchema;
+  private final TTDWindowedSchema windowedSchema;
+
+  public CassandraClientStub(final Properties props) {
+    super(new ResponsiveConfig(props));
+    kvSchema = new TTDKeyValueSchema(this);
+    windowedSchema = new TTDWindowedSchema(this);
+  }
+
+  @Override
+  public ResultSet execute(final Statement<?> statement) {
+    return null;
+  }
+
+  @Override
+  public ResultSet execute(final String cql) {
+    return null;
+  }
+
+  @Override
+  public CompletionStage<AsyncResultSet> executeAsync(final Statement<?> statement) {
+    throw new UnsupportedOperationException("Unexpected method call on TTD stub client");
+  }
+
+  @Override
+  public PreparedStatement prepare(final SimpleStatement statement) {
+    throw new UnsupportedOperationException("Unexpected method call on TTD stub client");
+  }
+
+  @Override
+  public RemoteMonitor awaitTable(
+      final String tableName,
+      final ScheduledExecutorService executorService
+  ) {
+    return new RemoteMonitor(
+        executorService,
+        () -> true
+    );
+  }
+
+  @Override
+  public long count(final String tableName, final int partition) {
+    return kvSchema.count(tableName) + windowedSchema.count(tableName);
+  }
+
+  @Override
+  public OptionalInt numPartitions(final String tableName) {
+    return OptionalInt.of(1);
+  }
+
+  @Override
+  public RemoteKeyValueSchema kvSchema(final SchemaType schemaType) {
+    return kvSchema;
+  }
+
+  @Override
+  public RemoteWindowedSchema windowedSchema() {
+    return windowedSchema;
+  }
+
+}

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/api/KVStoreStub.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/api/KVStoreStub.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.kafka.api;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.state.KeyValueIterator;
+
+public class KVStoreStub {
+
+  private final Map<Bytes, byte[]> records = new HashMap<>();
+  private Duration ttl;
+
+  public KVStoreStub(final Duration ttl) {
+    this.ttl = ttl;
+    if (ttl != null) {
+      throw new UnsupportedOperationException("ttl not yet implemented for TTD");
+    }
+  }
+
+  public long count() {
+    return records.size();
+  }
+
+  public void put(final Bytes key, final byte[] value) {
+    records.put(key, value);
+  }
+
+  public void delete(final Bytes key) {
+    records.remove(key);
+  }
+
+  public byte[] get(final Bytes key) {
+    return records.get(key);
+  }
+
+  public KeyValueIterator<Bytes, byte[]> range(final Bytes from, final Bytes to) {
+    throw new UnsupportedOperationException("Not yet implemented.");
+  }
+
+  public KeyValueIterator<Bytes, byte[]> all() {
+    throw new UnsupportedOperationException("Not yet implemented.");
+  }
+}

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/api/ResponsiveTopologyTestDriver.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/api/ResponsiveTopologyTestDriver.java
@@ -1,13 +1,33 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package dev.responsive.kafka.api;
 
-import dev.responsive.db.CassandraClient;
 import dev.responsive.kafka.config.ResponsiveConfig;
 import dev.responsive.kafka.store.ResponsiveStoreRegistry;
 import java.time.Instant;
-import java.util.HashMap;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Properties;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
+import org.apache.kafka.clients.admin.DescribeTopicsResult;
 import org.apache.kafka.clients.admin.MockAdminClient;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.TopicPartitionInfo;
+import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.Topology;
 import org.apache.kafka.streams.TopologyDescription;
 import org.apache.kafka.streams.TopologyTestDriver;
@@ -70,9 +90,11 @@ public class ResponsiveTopologyTestDriver extends TopologyTestDriver {
   ) {
     final Properties props = new Properties();
     props.putAll(baseProps);
+    props.put(ResponsiveConfig.TENANT_ID_CONFIG, "topology-test-driver");
+
     props.putAll(new InternalConfigs.Builder()
-        .withCassandraClient(new CassandraClientStub())
-        .withKafkaAdmin(new MockAdminClient())
+        .withCassandraClient(new CassandraClientStub(props))
+        .withKafkaAdmin(new TTDMockAdmin())
         .withExecutorService(new ScheduledThreadPoolExecutor(1))
         .withStoreRegistry(new ResponsiveStoreRegistry())
         .withTopologyDescription(topologyDescription)
@@ -81,12 +103,26 @@ public class ResponsiveTopologyTestDriver extends TopologyTestDriver {
     return props;
   }
 
-  private static class CassandraClientStub extends CassandraClient {
-    CassandraClientStub() {
-      super(new ResponsiveConfig(new HashMap<>()));
+  private static class TTDMockAdmin extends MockAdminClient {
+    private static final Node BROKER = new Node(0, "dummyHost-1", 1234);
+    public TTDMockAdmin() {
+      super(Collections.singletonList(BROKER), BROKER);
     }
 
-    // TODO: override CassandraClient methods to stash data in a local in-memory stub
+    @Override
+    public DescribeTopicsResult describeTopics(Collection<String> topicNames) {
+      for (final String topic : topicNames) {
+        addTopic(
+            true,
+            topic,
+            Collections.singletonList(
+                new TopicPartitionInfo(0, BROKER, Collections.emptyList(), Collections.emptyList())),
+            Collections.emptyMap()
+        );
+      }
+      return super.describeTopics(topicNames);
+    }
   }
+
 
 }

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/api/ResponsiveTopologyTestDriver.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/api/ResponsiveTopologyTestDriver.java
@@ -105,6 +105,7 @@ public class ResponsiveTopologyTestDriver extends TopologyTestDriver {
 
   private static class TTDMockAdmin extends MockAdminClient {
     private static final Node BROKER = new Node(0, "dummyHost-1", 1234);
+
     public TTDMockAdmin() {
       super(Collections.singletonList(BROKER), BROKER);
     }
@@ -115,8 +116,9 @@ public class ResponsiveTopologyTestDriver extends TopologyTestDriver {
         addTopic(
             true,
             topic,
-            Collections.singletonList(
-                new TopicPartitionInfo(0, BROKER, Collections.emptyList(), Collections.emptyList())),
+            Collections.singletonList(new TopicPartitionInfo(
+                0, BROKER, Collections.emptyList(), Collections.emptyList())
+            ),
             Collections.emptyMap()
         );
       }

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/api/TTDKeyValueSchema.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/api/TTDKeyValueSchema.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.kafka.api;
+
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
+import com.datastax.oss.driver.api.core.cql.SimpleStatement;
+import dev.responsive.db.RemoteKeyValueSchema;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.state.KeyValueIterator;
+
+public class TTDKeyValueSchema extends TTDSchema<Bytes> implements RemoteKeyValueSchema {
+
+  private final Map<String, KVStoreStub> tableNameToStore = new HashMap<>();
+
+  public TTDKeyValueSchema(final CassandraClientStub client) {
+    super(client);
+  }
+
+  @Override
+  public SimpleStatement create(final String tableName, final Optional<Duration> ttl) {
+    tableNameToStore.put(tableName, new KVStoreStub(ttl.orElse(null)));
+    return null;
+  }
+
+  @Override
+  public long count(final String tableName) {
+    return tableNameToStore.containsKey(tableName) ? tableNameToStore.get(tableName).count() : 0L;
+  }
+
+  @Override
+  public BoundStatement insert(
+      final String tableName,
+      final int partitionKey,
+      final Bytes key,
+      final byte[] value
+  ) {
+    tableNameToStore.get(tableName).put(key, value);
+    return null;
+  }
+
+  @Override
+  public BoundStatement delete(final String tableName, final int partitionKey, final Bytes key) {
+    tableNameToStore.get(tableName).delete(key);
+    return null;
+  }
+
+  @Override
+  public byte[] get(final String tableName, final int partition, final Bytes key) {
+    return tableNameToStore.get(tableName).get(key);
+  }
+
+  @Override
+  public KeyValueIterator<Bytes, byte[]> range(
+      final String tableName,
+      final int partition,
+      Bytes from,
+      final Bytes to
+  ) {
+    return tableNameToStore.get(tableName).range(from, to);
+  }
+
+  @Override
+  public KeyValueIterator<Bytes, byte[]> all(final String tableName, final int partition) {
+    return tableNameToStore.get(tableName).all();
+  }
+}

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/api/TTDSchema.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/api/TTDSchema.java
@@ -101,7 +101,7 @@ public abstract class TTDSchema<K> implements RemoteSchema<K> {
     @SuppressWarnings("ResultOfMethodCallIgnored")
     @Override
     public RemoteWriteResult setOffset(final long offset) {
-      schema.setOffset(tableName, partition,offset);
+      schema.setOffset(tableName, partition, offset);
       return RemoteWriteResult.success(partition);
     }
 

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/api/TTDSchema.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/api/TTDSchema.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.kafka.api;
+
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
+import dev.responsive.db.CassandraClient;
+import dev.responsive.db.MetadataRow;
+import dev.responsive.db.RemoteSchema;
+import dev.responsive.db.RemoteWriter;
+import dev.responsive.db.WriterFactory;
+import dev.responsive.db.partitioning.SubPartitioner;
+import dev.responsive.kafka.store.RemoteWriteResult;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+public abstract class TTDSchema<K> implements RemoteSchema<K> {
+
+  private final CassandraClientStub client;
+
+  public TTDSchema(final CassandraClientStub client) {
+    this.client = client;
+  }
+
+  /**
+   * @return the number of elements in this table
+   *         or 0 if the schema has no such table
+   */
+  public abstract long count(final String tableName);
+
+  @Override
+  public void prepare(final String tableName) {
+
+  }
+
+  @Override
+  public WriterFactory<K> init(
+      final String tableName,
+      final SubPartitioner partitioner,
+      final int kafkaPartition
+  ) {
+    return (client, name, partition, batchSize) -> new TTDWriter<K>(this, tableName, partition);
+  }
+
+  @Override
+  public MetadataRow metadata(final String table, final int partition) {
+    return new MetadataRow(0, 0);
+  }
+
+  @Override
+  public BoundStatement setOffset(final String table, final int partition, final long offset) {
+    return null;
+  }
+
+  @Override
+  public CassandraClient cassandraClient() {
+    return client;
+  }
+
+  private static class TTDWriter<K> implements RemoteWriter<K> {
+    private final TTDSchema<K> schema;
+    private final String tableName;
+    private final int partition;
+
+    public TTDWriter(final TTDSchema<K> schema, final String tableName, final int partition) {
+      this.schema = schema;
+      this.tableName = tableName;
+      this.partition = partition;
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    @Override
+    public void insert(final K key, final byte[] value) {
+      schema.insert(tableName, partition, key, value);
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    @Override
+    public void delete(final K key) {
+      schema.delete(tableName, partition, key);
+    }
+
+    @Override
+    public CompletionStage<RemoteWriteResult> flush() {
+      return CompletableFuture.completedStage(RemoteWriteResult.success(partition));
+    }
+
+    @SuppressWarnings("ResultOfMethodCallIgnored")
+    @Override
+    public RemoteWriteResult setOffset(final long offset) {
+      schema.setOffset(tableName, partition,offset);
+      return RemoteWriteResult.success(partition);
+    }
+
+    @Override
+    public int partition() {
+      return partition;
+    }
+  }
+
+}

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/api/TTDWindowedSchema.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/api/TTDWindowedSchema.java
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.kafka.api;
+
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
+import com.datastax.oss.driver.api.core.cql.SimpleStatement;
+import dev.responsive.db.RemoteWindowedSchema;
+import dev.responsive.model.Stamped;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.state.KeyValueIterator;
+
+public class TTDWindowedSchema extends TTDSchema<Stamped<Bytes>> implements RemoteWindowedSchema {
+
+  private final Map<String, WindowStoreStub> tableNameToStore = new HashMap<>();
+
+  public TTDWindowedSchema(final CassandraClientStub client) {
+    super(client);
+  }
+
+  @Override
+  public SimpleStatement create(final String tableName, final Optional<Duration> ttl) {
+    tableNameToStore.put(tableName, new WindowStoreStub());
+    return null;
+  }
+
+  @Override
+  public long count(final String tableName) {
+    return tableNameToStore.containsKey(tableName) ? tableNameToStore.get(tableName).count() : 0L;
+  }
+
+  @Override
+  public BoundStatement insert(
+      final String tableName,
+      final int partitionKey,
+      final Stamped<Bytes> key,
+      final byte[] value
+  ) {
+    tableNameToStore.get(tableName).put(key, value);
+    return null;
+  }
+
+  @Override
+  public BoundStatement delete(
+      final String tableName,
+      final int partitionKey,
+      final Stamped<Bytes> key
+  ) {
+    tableNameToStore.get(tableName).delete(key);
+    return null;
+  }
+
+  @Override
+  public KeyValueIterator<Stamped<Bytes>, byte[]> fetch(
+      final String tableName,
+      final int partition,
+      final Bytes key,
+      long timeFrom,
+      final long timeTo
+  ) {
+    return tableNameToStore.get(tableName).fetch(key, timeFrom, timeTo);
+  }
+
+  @Override
+  public KeyValueIterator<Stamped<Bytes>, byte[]> backFetch(
+      final String tableName,
+      final int partition,
+      final Bytes key,
+      final long timeFrom,
+      final long timeTo
+  ) {
+    return tableNameToStore.get(tableName).backFetch(key, timeFrom, timeTo);
+  }
+
+  @Override
+  public KeyValueIterator<Stamped<Bytes>, byte[]> fetchRange(
+      final String tableName,
+      final int partition,
+      final Bytes fromKey,
+      final Bytes toKey,
+      final long timeFrom,
+      final long timeTo
+  ) {
+    return tableNameToStore.get(tableName).fetchRange(fromKey, toKey, timeFrom, timeTo);
+  }
+
+  @Override
+  public KeyValueIterator<Stamped<Bytes>, byte[]> backFetchRange(
+      final String tableName,
+      final int partition,
+      final Bytes fromKey,
+      final Bytes toKey,
+      final long timeFrom,
+      final long timeTo
+  ) {
+    return tableNameToStore.get(tableName).backFetchRange(fromKey, toKey, timeFrom, timeTo);
+  }
+
+  @Override
+  public KeyValueIterator<Stamped<Bytes>, byte[]> fetchAll(
+      final String tableName,
+      final int partition,
+      final long timeFrom,
+      final long timeTo
+  ) {
+    return tableNameToStore.get(tableName).fetchAll(timeFrom, timeTo);
+  }
+
+  @Override
+  public KeyValueIterator<Stamped<Bytes>, byte[]> backFetchAll(
+      final String tableName,
+      final int partition,
+      final long timeFrom,
+      final long timeTo
+  ) {
+    return tableNameToStore.get(tableName).backFetchAll(timeFrom, timeTo);
+  }
+}

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/api/WindowStoreStub.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/api/WindowStoreStub.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.kafka.api;
+
+import dev.responsive.model.Stamped;
+import java.util.Comparator;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.state.KeyValueIterator;
+
+public class WindowStoreStub {
+  final Comparator<Stamped<Bytes>> keyComparator = Comparator.comparing(k -> k.key);
+  private final NavigableMap<Stamped<Bytes>, byte[]> records =
+      new TreeMap<>(keyComparator.thenComparingLong(k -> k.stamp));
+
+  public long count() {
+    return records.size();
+  }
+
+  public void put(final Stamped<Bytes> key, final byte[] value) {
+    records.put(key, value);
+  }
+
+  public void delete(final Stamped<Bytes> key) {
+    records.remove(key);
+  }
+
+  public KeyValueIterator<Stamped<Bytes>, byte[]> fetch(
+      final Bytes key,
+      long timeFrom,
+      final long timeTo
+  ) {
+    throw new UnsupportedOperationException("Not yet implemented.");
+  }
+
+  public KeyValueIterator<Stamped<Bytes>, byte[]> backFetch(
+      final Bytes key,
+      final long timeFrom,
+      final long timeTo
+  ) {
+    throw new UnsupportedOperationException("Not yet implemented.");
+  }
+
+  public KeyValueIterator<Stamped<Bytes>, byte[]> fetchRange(
+      final Bytes fromKey,
+      final Bytes toKey,
+      final long timeFrom,
+      final long timeTo
+  ) {
+    throw new UnsupportedOperationException("Not yet implemented.");
+  }
+
+  public KeyValueIterator<Stamped<Bytes>, byte[]> backFetchRange(
+      final Bytes fromKey,
+      final Bytes toKey,
+      final long timeFrom,
+      final long timeTo
+  ) {
+    throw new UnsupportedOperationException("Not yet implemented.");
+  }
+
+  public KeyValueIterator<Stamped<Bytes>, byte[]> fetchAll(
+      final long timeFrom,
+      final long timeTo
+  ) {
+    throw new UnsupportedOperationException("Not yet implemented.");
+  }
+
+  public KeyValueIterator<Stamped<Bytes>, byte[]> backFetchAll(
+      final long timeFrom,
+      final long timeTo
+  ) {
+    throw new UnsupportedOperationException("Not yet implemented.");
+  }
+}

--- a/responsive-test-utils/src/test/java/dev/responsive/kafka/api/TopologyTestDriverExampleTest.java
+++ b/responsive-test-utils/src/test/java/dev/responsive/kafka/api/TopologyTestDriverExampleTest.java
@@ -31,19 +31,19 @@ import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.KTable;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
 
 public class TopologyTestDriverExampleTest {
 
-  // TODO: re-enable this test once ResponsiveTopologyTestDriver is fully implemented
-  // @Test
+  @Test
   public void shouldRunWithoutResponsiveConnection() {
     // Given:
     final Properties props = new Properties();
     props.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.StringSerde.class);
     props.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.StringSerde.class);
 
-    final Topology topo = topology();
-    final TopologyTestDriver driver = new ResponsiveTopologyTestDriver(topo, props);
+    final Topology topology = topology();
+    final TopologyTestDriver driver = new ResponsiveTopologyTestDriver(topology, props);
 
     final TestInputTopic<String, String> bids = driver.createInputTopic(
         "bids", new StringSerializer(), new StringSerializer());
@@ -72,7 +72,7 @@ public class TopologyTestDriverExampleTest {
     driver.close();
   }
 
-  Topology topology() {
+  private Topology topology() {
     final StreamsBuilder builder = new StreamsBuilder();
 
     // schema for bids is key: <bid_id> value: <bid_id, amount, person_id>


### PR DESCRIPTION
Fills out the TopologyTestDriver ecosystem of stubbed clients, schemas, writers, and stores with a basic in-memory map for use in a TTD test app