### PR TITLE
Separate metadata into its own table for Fact Tables

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/db/CassandraFactSchema.java
+++ b/kafka-client/src/main/java/dev/responsive/db/CassandraFactSchema.java
@@ -21,18 +21,15 @@ import static dev.responsive.db.ColumnName.DATA_KEY;
 import static dev.responsive.db.ColumnName.DATA_VALUE;
 import static dev.responsive.db.ColumnName.METADATA_KEY;
 import static dev.responsive.db.ColumnName.OFFSET;
-import static dev.responsive.db.ColumnName.ROW_TYPE;
-import static dev.responsive.db.RowType.DATA_ROW;
-import static dev.responsive.db.RowType.METADATA_ROW;
+import static dev.responsive.db.ColumnName.PARTITION_KEY;
 
 import com.datastax.oss.driver.api.core.cql.BoundStatement;
 import com.datastax.oss.driver.api.core.cql.PreparedStatement;
 import com.datastax.oss.driver.api.core.cql.Row;
-import com.datastax.oss.driver.api.core.cql.SimpleStatement;
 import com.datastax.oss.driver.api.core.type.DataTypes;
 import com.datastax.oss.driver.api.querybuilder.QueryBuilder;
 import com.datastax.oss.driver.api.querybuilder.SchemaBuilder;
-import com.datastax.oss.driver.api.querybuilder.schema.CreateTable;
+import com.datastax.oss.driver.api.querybuilder.schema.CreateTableWithOptions;
 import com.datastax.oss.driver.api.querybuilder.schema.compaction.TimeWindowCompactionStrategy;
 import dev.responsive.db.partitioning.SubPartitioner;
 import java.nio.ByteBuffer;
@@ -76,30 +73,43 @@ public class CassandraFactSchema implements RemoteKeyValueSchema {
 
   @Override
   @CheckReturnValue
-  public SimpleStatement create(final String tableName, Optional<Duration> ttl) {
+  public void create(final String tableName, Optional<Duration> ttl) {
     LOG.info("Creating fact data table {} in remote store.", tableName);
-    final CreateTable createTable = SchemaBuilder
+    CreateTableWithOptions createTable = SchemaBuilder
         .createTable(tableName)
         .ifNotExists()
-        .withPartitionKey(ROW_TYPE.column(), DataTypes.TINYINT)
         .withPartitionKey(DATA_KEY.column(), DataTypes.BLOB)
-        .withColumn(DATA_VALUE.column(), DataTypes.BLOB)
-        .withColumn(OFFSET.column(), DataTypes.BIGINT);
+        .withColumn(DATA_VALUE.column(), DataTypes.BLOB);
 
     if (ttl.isPresent()) {
       final int ttlSeconds = Math.toIntExact(ttl.get().getSeconds());
       // 20 is a magic number recommended by scylla for the number of buckets
       final Duration compactionWindow = Duration.ofSeconds(ttlSeconds / 20);
-      return createTable.withDefaultTimeToLiveSeconds(ttlSeconds)
+      createTable = createTable.withDefaultTimeToLiveSeconds(ttlSeconds)
           .withCompaction(
               SchemaBuilder.timeWindowCompactionStrategy()
                   .withCompactionWindow(
                       compactionWindow.toMinutes(),
                       TimeWindowCompactionStrategy.CompactionWindowUnit.MINUTES)
-          ).build();
+          );
     } else {
-      return createTable.withCompaction(SchemaBuilder.timeWindowCompactionStrategy()).build();
+      createTable = createTable.withCompaction(SchemaBuilder.timeWindowCompactionStrategy());
     }
+
+    // separate metadata from the main table for the fact schema, this is acceptable
+    // because we don't use the metadata at all for fencing operations and writes to
+    // it do not need to be atomic (transactional with the original table). we cannot
+    // effectively use the same table (as we do with the normal KeyValueSchema) because
+    // TWCS cannot properly compact files if there are any overwrites, which there are
+    // for the metadata columns
+    final CreateTableWithOptions createMetadataTable = SchemaBuilder
+        .createTable(metadataTable(tableName))
+        .ifNotExists()
+        .withPartitionKey(PARTITION_KEY.column(), DataTypes.INT)
+        .withColumn(OFFSET.column(), DataTypes.BIGINT);
+
+    client.execute(createTable.build());
+    client.execute(createMetadataTable.build());
   }
 
   /**
@@ -120,9 +130,8 @@ public class CassandraFactSchema implements RemoteKeyValueSchema {
       final int kafkaPartition
   ) {
     client.execute(
-        QueryBuilder.insertInto(table)
-            .value(ROW_TYPE.column(), QueryBuilder.literal(METADATA_ROW.val()))
-            .value(DATA_KEY.column(), QueryBuilder.literal(metadataKey(kafkaPartition)))
+        QueryBuilder.insertInto(metadataTable(table))
+            .value(PARTITION_KEY.column(), PARTITION_KEY.literal(kafkaPartition))
             .value(OFFSET.column(), OFFSET.literal(-1L))
             .ifNotExists()
             .build()
@@ -133,9 +142,9 @@ public class CassandraFactSchema implements RemoteKeyValueSchema {
 
   @Override
   public MetadataRow metadata(final String table, final int partition) {
-    final BoundStatement bound = getMeta.get(table)
+    final BoundStatement bound = getMeta.get(metadataTable(table))
         .bind()
-        .setByteBuffer(DATA_KEY.bind(), metadataKey(partition));
+        .setInt(PARTITION_KEY.bind(), partition);
     final List<Row> result = client.execute(bound).all();
 
     if (result.size() != 1) {
@@ -155,10 +164,11 @@ public class CassandraFactSchema implements RemoteKeyValueSchema {
       final int partition,
       final long offset
   ) {
-    LOG.info("Setting offset for {}[{}] to {}", table, partition, offset);
-    return setOffset.get(table)
+    LOG.info("Setting offset in metadata table {} for {}[{}] to {}",
+        metadataTable(table), table, partition, offset);
+    return setOffset.get(metadataTable(table))
         .bind()
-        .setByteBuffer(DATA_KEY.bind(), metadataKey(partition))
+        .setInt(PARTITION_KEY.bind(), partition)
         .setLong(OFFSET.bind(), offset);
   }
 
@@ -167,7 +177,6 @@ public class CassandraFactSchema implements RemoteKeyValueSchema {
     insert.computeIfAbsent(tableName, k -> client.prepare(
         QueryBuilder
             .insertInto(tableName)
-            .value(ROW_TYPE.column(), DATA_ROW.literal())
             .value(DATA_KEY.column(), bindMarker(DATA_KEY.bind()))
             .value(DATA_VALUE.column(), bindMarker(DATA_VALUE.bind()))
             .build()
@@ -177,7 +186,6 @@ public class CassandraFactSchema implements RemoteKeyValueSchema {
         QueryBuilder
             .selectFrom(tableName)
             .columns(DATA_VALUE.column())
-            .where(ROW_TYPE.relation().isEqualTo(DATA_ROW.literal()))
             .where(DATA_KEY.relation().isEqualTo(bindMarker(DATA_KEY.bind())))
             .build()
     ));
@@ -185,25 +193,22 @@ public class CassandraFactSchema implements RemoteKeyValueSchema {
     delete.computeIfAbsent(tableName, k -> client.prepare(
         QueryBuilder
             .deleteFrom(tableName)
-            .where(ROW_TYPE.relation().isEqualTo(DATA_ROW.literal()))
             .where(DATA_KEY.relation().isEqualTo(bindMarker(DATA_KEY.bind())))
             .build()
     ));
 
-    getMeta.computeIfAbsent(tableName, k -> client.prepare(
+    getMeta.computeIfAbsent(metadataTable(tableName), k -> client.prepare(
         QueryBuilder
-            .selectFrom(tableName)
+            .selectFrom(metadataTable(tableName))
             .column(OFFSET.column())
-            .where(ROW_TYPE.relation().isEqualTo(METADATA_ROW.literal()))
-            .where(DATA_KEY.relation().isEqualTo(bindMarker(DATA_KEY.bind())))
+            .where(PARTITION_KEY.relation().isEqualTo(bindMarker(PARTITION_KEY.bind())))
             .build()
     ));
 
-    setOffset.computeIfAbsent(tableName, k -> client.prepare(QueryBuilder
-        .update(tableName)
+    setOffset.computeIfAbsent(metadataTable(tableName), k -> client.prepare(QueryBuilder
+        .update(metadataTable(tableName))
         .setColumn(OFFSET.column(), bindMarker(OFFSET.bind()))
-        .where(ROW_TYPE.relation().isEqualTo(METADATA_ROW.literal()))
-        .where(DATA_KEY.relation().isEqualTo(bindMarker(DATA_KEY.bind())))
+        .where(PARTITION_KEY.relation().isEqualTo(bindMarker(PARTITION_KEY.bind())))
         .build()
     ));
   }
@@ -308,11 +313,9 @@ public class CassandraFactSchema implements RemoteKeyValueSchema {
     throw new UnsupportedOperationException("all is not supported on Idempotent schemas");
   }
 
-  private static ByteBuffer metadataKey(final int partition) {
-    final ByteBuffer key = ByteBuffer.wrap(new byte[METADATA_KEY.get().length + Integer.BYTES]);
-    key.put(METADATA_KEY.get());
-    key.putInt(partition);
-    return key.position(0);
+  // Visible for Testing
+  static String metadataTable(final String tableName) {
+    return tableName + "_md";
   }
 
 }

--- a/kafka-client/src/main/java/dev/responsive/db/RemoteSchema.java
+++ b/kafka-client/src/main/java/dev/responsive/db/RemoteSchema.java
@@ -32,7 +32,6 @@ public interface RemoteSchema<K> {
    * Creates a table with the supplied {@code tableName} with the
    * desired schema.
    */
-  @CheckReturnValue
   void create(String tableName, Optional<Duration> ttl);
 
   /**

--- a/kafka-client/src/main/java/dev/responsive/db/RemoteSchema.java
+++ b/kafka-client/src/main/java/dev/responsive/db/RemoteSchema.java
@@ -17,7 +17,6 @@
 package dev.responsive.db;
 
 import com.datastax.oss.driver.api.core.cql.BoundStatement;
-import com.datastax.oss.driver.api.core.cql.SimpleStatement;
 import dev.responsive.db.partitioning.SubPartitioner;
 import java.time.Duration;
 import java.util.Optional;
@@ -34,7 +33,7 @@ public interface RemoteSchema<K> {
    * desired schema.
    */
   @CheckReturnValue
-  SimpleStatement create(String tableName, Optional<Duration> ttl);
+  void create(String tableName, Optional<Duration> ttl);
 
   /**
    * Prepares statements with this schema for the table with

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveGlobalStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveGlobalStore.java
@@ -96,7 +96,7 @@ public class ResponsiveGlobalStore implements KeyValueStore<Bytes, byte[]> {
 
       final RemoteMonitor monitor = client.awaitTable(name.cassandraName(), sharedClients.executor);
       schema = client.kvSchema(SchemaType.KEY_VALUE);
-      client.execute(schema.create(name.cassandraName(), Optional.empty()));
+      schema.create(name.cassandraName(), Optional.empty());
       monitor.await(Duration.ofSeconds(60));
       LOG.info("Global table {} is available for querying.", name);
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsivePartitionedStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsivePartitionedStore.java
@@ -104,7 +104,7 @@ public class ResponsivePartitionedStore implements KeyValueStore<Bytes, byte[]> 
       CassandraClient client = sharedClients.cassandraClient;
 
       schema = client.kvSchema(params.schemaType());
-      client.execute(schema.create(params.name().cassandraName(), params.timeToLive()));
+      schema.create(params.name().cassandraName(), params.timeToLive());
 
       final RemoteMonitor monitor = client.awaitTable(name.cassandraName(), sharedClients.executor);
       monitor.await(Duration.ofSeconds(60));

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveWindowStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveWindowStore.java
@@ -138,7 +138,7 @@ public class ResponsiveWindowStore implements WindowStore<Bytes, byte[]> {
       client = sharedClients.cassandraClient;
 
       schema = client.windowedSchema();
-      client.execute(schema.create(name.cassandraName(), Optional.empty()));
+      schema.create(name.cassandraName(), Optional.empty());
 
       final RemoteMonitor monitor = client.awaitTable(name.cassandraName(), sharedClients.executor);
       monitor.await(Duration.ofSeconds(60));

--- a/kafka-client/src/test/java/dev/responsive/db/CassandraFactSchemaIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/db/CassandraFactSchemaIntegrationTest.java
@@ -88,11 +88,9 @@ class CassandraFactSchemaIntegrationTest {
     final var table = session.getMetadata()
         .getKeyspace(session.getKeyspace().get())
         .get()
-        .getTable(CassandraFactSchema.metadataTable(storeName))
+        .getTable(storeName + "_md")
         .get();
-    assertThat(
-        table.describe(false),
-        containsStringIgnoringCase(CassandraFactSchema.metadataTable(storeName)));
+    assertThat(table.describe(false), containsStringIgnoringCase(storeName + "_md"));
   }
 
   @SuppressWarnings("OptionalGetWithoutIsPresent")

--- a/kafka-client/src/test/java/dev/responsive/db/CassandraFactSchemaIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/db/CassandraFactSchemaIntegrationTest.java
@@ -18,6 +18,7 @@ package dev.responsive.db;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.containsStringIgnoringCase;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
@@ -66,7 +67,7 @@ class CassandraFactSchemaIntegrationTest {
   public void shouldInitializeWithCorrectMetadata() {
     // Given:
     final RemoteKeyValueSchema schema = client.kvSchema(SchemaType.FACT);
-    client.execute(schema.create(storeName, Optional.empty()));
+    schema.create(storeName, Optional.empty());
     schema.prepare(storeName);
 
     // When:
@@ -82,6 +83,16 @@ class CassandraFactSchemaIntegrationTest {
     assertThat(metadata1.epoch, is(-1L));
     assertThat(metadata2.offset, is(10L));
     assertThat(metadata2.epoch, is(-1L));
+
+    // ensure it uses a separate table for metadata
+    final var table = session.getMetadata()
+        .getKeyspace(session.getKeyspace().get())
+        .get()
+        .getTable(CassandraFactSchema.metadataTable(storeName))
+        .get();
+    assertThat(
+        table.describe(false),
+        containsStringIgnoringCase(CassandraFactSchema.metadataTable(storeName)));
   }
 
   @SuppressWarnings("OptionalGetWithoutIsPresent")
@@ -92,7 +103,7 @@ class CassandraFactSchemaIntegrationTest {
     final var ttl = Duration.ofDays(30);
 
     // When:
-    client.execute(schema.create(storeName, Optional.of(ttl)));
+    schema.create(storeName, Optional.of(ttl));
 
     // Then:
     final var table = session.getMetadata()
@@ -117,7 +128,7 @@ class CassandraFactSchemaIntegrationTest {
     final RemoteKeyValueSchema schema = client.kvSchema(SchemaType.FACT);
 
     // When:
-    client.execute(schema.create(storeName, Optional.empty()));
+    schema.create(storeName, Optional.empty());
 
     // Then:
     final var table = session.getMetadata()
@@ -134,7 +145,7 @@ class CassandraFactSchemaIntegrationTest {
   public void shouldInsertAndDelete() {
     // Given:
     final RemoteKeyValueSchema schema = client.kvSchema(SchemaType.FACT);
-    client.execute(schema.create(storeName, Optional.empty()));
+    schema.create(storeName, Optional.empty());
     schema.prepare(storeName);
     schema.init(storeName, SubPartitioner.NO_SUBPARTITIONS, 1);
 

--- a/kafka-client/src/test/java/dev/responsive/db/KeyValueSchemaIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/db/KeyValueSchemaIntegrationTest.java
@@ -56,7 +56,7 @@ public class KeyValueSchemaIntegrationTest {
     client = new CassandraClient(session, config);
     schema = new CassandraKeyValueSchema(client);
     name = info.getTestMethod().orElseThrow().getName();
-    client.execute(schema.create(name, Optional.empty()));
+    schema.create(name, Optional.empty());
     schema.prepare(name);
   }
 

--- a/kafka-client/src/test/java/dev/responsive/kafka/store/CommitBufferTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/store/CommitBufferTest.java
@@ -104,7 +104,7 @@ public class CommitBufferTest {
     changelogTp = new TopicPartition("log", KAFKA_PARTITION);
     partitioner = SubPartitioner.NO_SUBPARTITIONS;
 
-    client.execute(schema.create(name, Optional.empty()));
+    schema.create(name, Optional.empty());
     schema.prepare(name);
 
     when(admin.deleteRecords(Mockito.any()))

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/store/TTDKeyValueSchema.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/store/TTDKeyValueSchema.java
@@ -17,7 +17,6 @@
 package dev.responsive.kafka.store;
 
 import com.datastax.oss.driver.api.core.cql.BoundStatement;
-import com.datastax.oss.driver.api.core.cql.SimpleStatement;
 import dev.responsive.db.RemoteKeyValueSchema;
 import java.time.Duration;
 import java.util.HashMap;
@@ -35,9 +34,8 @@ public class TTDKeyValueSchema extends TTDSchema<Bytes> implements RemoteKeyValu
   }
 
   @Override
-  public SimpleStatement create(final String tableName, final Optional<Duration> ttl) {
+  public void create(final String tableName, final Optional<Duration> ttl) {
     tableNameToStore.put(tableName, new KVStoreStub(ttl.orElse(null), time));
-    return null;
   }
 
   @Override

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/store/TTDWindowedSchema.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/store/TTDWindowedSchema.java
@@ -17,7 +17,6 @@
 package dev.responsive.kafka.store;
 
 import com.datastax.oss.driver.api.core.cql.BoundStatement;
-import com.datastax.oss.driver.api.core.cql.SimpleStatement;
 import dev.responsive.db.RemoteWindowedSchema;
 import dev.responsive.model.Stamped;
 import java.time.Duration;
@@ -36,7 +35,7 @@ public class TTDWindowedSchema extends TTDSchema<Stamped<Bytes>> implements Remo
   }
 
   @Override
-  public SimpleStatement create(final String tableName, final Optional<Duration> ttl) {
+  public void create(final String tableName, final Optional<Duration> ttl) {
     tableNameToStore.put(tableName, new WindowStoreStub());
     return null;
   }

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/store/TTDWindowedSchema.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/store/TTDWindowedSchema.java
@@ -37,7 +37,6 @@ public class TTDWindowedSchema extends TTDSchema<Stamped<Bytes>> implements Remo
   @Override
   public void create(final String tableName, final Optional<Duration> ttl) {
     tableNameToStore.put(tableName, new WindowStoreStub());
-    return null;
   }
 
   @Override


### PR DESCRIPTION
TWCS doesn't perform well if there are rows that are replaced. This assumption was not respected with the metadata (offset) rows, that were replaced regularly potentially messing up compaction.

The only meaningful change is in `kafka-client/src/main/java/dev/responsive/db/CassandraFactSchema.java`