### PR TITLE
respect TTL semantically even if data is not physically cleared

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/db/CassandraFactSchema.java
+++ b/kafka-client/src/main/java/dev/responsive/db/CassandraFactSchema.java
@@ -282,7 +282,7 @@ public class CassandraFactSchema implements RemoteKeyValueSchema {
       final int partitionKey,
       final Bytes key,
       final byte[] value,
-      long timestamp
+      final long timestamp
   ) {
     return insert.get(table)
         .bind()

--- a/kafka-client/src/main/java/dev/responsive/db/CassandraFactSchema.java
+++ b/kafka-client/src/main/java/dev/responsive/db/CassandraFactSchema.java
@@ -118,7 +118,7 @@ public class CassandraFactSchema implements RemoteKeyValueSchema {
         .ifNotExists()
         .withPartitionKey(ROW_TYPE.column(), DataTypes.TINYINT)
         .withPartitionKey(DATA_KEY.column(), DataTypes.BLOB)
-        .withClusteringColumn(TIMESTAMP.column(), DataTypes.TIMESTAMP)
+        .withColumn(TIMESTAMP.column(), DataTypes.TIMESTAMP)
         .withColumn(DATA_VALUE.column(), DataTypes.BLOB);
   }
 
@@ -202,6 +202,9 @@ public class CassandraFactSchema implements RemoteKeyValueSchema {
             .where(ROW_TYPE.relation().isEqualTo(RowType.DATA_ROW.literal()))
             .where(DATA_KEY.relation().isEqualTo(bindMarker(DATA_KEY.bind())))
             .where(TIMESTAMP.relation().isGreaterThanOrEqualTo(bindMarker(TIMESTAMP.bind())))
+            // ALLOW FILTERING is OK b/c the query only scans one partition (it actually  only
+            // returns a single value)
+            .allowFiltering()
             .build()
     ));
 

--- a/kafka-client/src/main/java/dev/responsive/db/CassandraKeyValueSchema.java
+++ b/kafka-client/src/main/java/dev/responsive/db/CassandraKeyValueSchema.java
@@ -293,7 +293,7 @@ public class CassandraKeyValueSchema implements RemoteKeyValueSchema {
       final int partitionKey,
       final Bytes key,
       final byte[] value,
-      long timestamp
+      final long timestamp
   ) {
     return insert.get(table)
         .bind()

--- a/kafka-client/src/main/java/dev/responsive/db/CassandraWindowedSchema.java
+++ b/kafka-client/src/main/java/dev/responsive/db/CassandraWindowedSchema.java
@@ -313,7 +313,8 @@ public class CassandraWindowedSchema implements RemoteWindowedSchema {
       final int partitionKey,
       final Stamped<Bytes> key,
       final byte[] value,
-      long timestamp) {
+      final long timestamp
+  ) {
     return insert.get(table)
         .bind()
         .setInt(PARTITION_KEY.bind(), partitionKey)

--- a/kafka-client/src/main/java/dev/responsive/db/CassandraWindowedSchema.java
+++ b/kafka-client/src/main/java/dev/responsive/db/CassandraWindowedSchema.java
@@ -301,7 +301,7 @@ public class CassandraWindowedSchema implements RemoteWindowedSchema {
    * @param partitionKey the partitioning key
    * @param key          the data key
    * @param value        the data value
-   * @param timestamp    the timestamp of the event
+   * @param epochMillis    the timestamp of the event
    * @return a statement that, when executed, will insert the row
    * matching {@code partitionKey} and {@code key} in the
    * {@code table} with value {@code value}
@@ -313,7 +313,7 @@ public class CassandraWindowedSchema implements RemoteWindowedSchema {
       final int partitionKey,
       final Stamped<Bytes> key,
       final byte[] value,
-      final long timestamp
+      final long epochMillis
   ) {
     return insert.get(table)
         .bind()

--- a/kafka-client/src/main/java/dev/responsive/db/CassandraWindowedSchema.java
+++ b/kafka-client/src/main/java/dev/responsive/db/CassandraWindowedSchema.java
@@ -37,9 +37,7 @@ import com.datastax.oss.driver.api.core.metadata.schema.ClusteringOrder;
 import com.datastax.oss.driver.api.core.type.DataTypes;
 import com.datastax.oss.driver.api.querybuilder.QueryBuilder;
 import com.datastax.oss.driver.api.querybuilder.SchemaBuilder;
-import com.datastax.oss.driver.api.querybuilder.schema.CreateTable;
 import com.datastax.oss.driver.api.querybuilder.schema.CreateTableWithOptions;
-import com.datastax.oss.driver.api.querybuilder.schema.RelationOptions;
 import dev.responsive.db.partitioning.SubPartitioner;
 import dev.responsive.model.Stamped;
 import dev.responsive.utils.Iterators;
@@ -299,14 +297,14 @@ public class CassandraWindowedSchema implements RemoteWindowedSchema {
    * Inserts data into {@code table}. Note that this will overwrite
    * any existing entry in the table with the same key.
    *
-   * @param table         the table to insert into
-   * @param partitionKey  the partitioning key
-   * @param key           the data key
-   * @param value         the data value
-   *
+   * @param table        the table to insert into
+   * @param partitionKey the partitioning key
+   * @param key          the data key
+   * @param value        the data value
+   * @param timestamp    the timestamp of the event
    * @return a statement that, when executed, will insert the row
-   *         matching {@code partitionKey} and {@code key} in the
-   *         {@code table} with value {@code value}
+   * matching {@code partitionKey} and {@code key} in the
+   * {@code table} with value {@code value}
    */
   @Override
   @CheckReturnValue
@@ -314,8 +312,8 @@ public class CassandraWindowedSchema implements RemoteWindowedSchema {
       final String table,
       final int partitionKey,
       final Stamped<Bytes> key,
-      final byte[] value
-  ) {
+      final byte[] value,
+      long timestamp) {
     return insert.get(table)
         .bind()
         .setInt(PARTITION_KEY.bind(), partitionKey)

--- a/kafka-client/src/main/java/dev/responsive/db/ColumnName.java
+++ b/kafka-client/src/main/java/dev/responsive/db/ColumnName.java
@@ -37,7 +37,8 @@ public enum ColumnName {
   DATA_VALUE("value", "value", b -> bytes((byte[]) b)),
   OFFSET("offset", "offset"),
   EPOCH("epoch", "epoch"),
-  WINDOW_START("windowStart", "windowstart", ts -> timestamp((long) ts));
+  WINDOW_START("windowStart", "windowstart", ts -> timestamp((long) ts)),
+  TIMESTAMP("ts", "ts", ts -> timestamp((long) ts));
 
   static final Bytes METADATA_KEY
       = Bytes.wrap("_metadata".getBytes(StandardCharsets.UTF_8));

--- a/kafka-client/src/main/java/dev/responsive/db/ColumnName.java
+++ b/kafka-client/src/main/java/dev/responsive/db/ColumnName.java
@@ -42,6 +42,7 @@ public enum ColumnName {
 
   static final Bytes METADATA_KEY
       = Bytes.wrap("_metadata".getBytes(StandardCharsets.UTF_8));
+  static final long METADATA_TS = -1L;
   private final String column;
   private final String bind;
   private final Function<Object, Literal> getLiteral;

--- a/kafka-client/src/main/java/dev/responsive/db/FactSchemaWriter.java
+++ b/kafka-client/src/main/java/dev/responsive/db/FactSchemaWriter.java
@@ -48,8 +48,8 @@ public class FactSchemaWriter<K> implements RemoteWriter<K> {
   }
 
   @Override
-  public void insert(final K key, final byte[] value) {
-    statements.add(schema.insert(name, partition, key, value));
+  public void insert(final K key, final byte[] value, long timestamp) {
+    statements.add(schema.insert(name, partition, key, value, timestamp));
   }
 
   @Override

--- a/kafka-client/src/main/java/dev/responsive/db/FactSchemaWriter.java
+++ b/kafka-client/src/main/java/dev/responsive/db/FactSchemaWriter.java
@@ -48,8 +48,8 @@ public class FactSchemaWriter<K> implements RemoteWriter<K> {
   }
 
   @Override
-  public void insert(final K key, final byte[] value, long timestamp) {
-    statements.add(schema.insert(name, partition, key, value, timestamp));
+  public void insert(final K key, final byte[] value, long epochMillis) {
+    statements.add(schema.insert(name, partition, key, value, epochMillis));
   }
 
   @Override

--- a/kafka-client/src/main/java/dev/responsive/db/LwtWriter.java
+++ b/kafka-client/src/main/java/dev/responsive/db/LwtWriter.java
@@ -57,8 +57,8 @@ public class LwtWriter<K> implements RemoteWriter<K> {
   }
 
   @Override
-  public void insert(final K key, final byte[] value) {
-    statements.add(schema.insert(name, partition, key, value));
+  public void insert(final K key, final byte[] value, long timestamp) {
+    statements.add(schema.insert(name, partition, key, value, timestamp));
   }
 
   @Override

--- a/kafka-client/src/main/java/dev/responsive/db/LwtWriter.java
+++ b/kafka-client/src/main/java/dev/responsive/db/LwtWriter.java
@@ -57,8 +57,8 @@ public class LwtWriter<K> implements RemoteWriter<K> {
   }
 
   @Override
-  public void insert(final K key, final byte[] value, long timestamp) {
-    statements.add(schema.insert(name, partition, key, value, timestamp));
+  public void insert(final K key, final byte[] value, long epochMillis) {
+    statements.add(schema.insert(name, partition, key, value, epochMillis));
   }
 
   @Override

--- a/kafka-client/src/main/java/dev/responsive/db/RemoteKeyValueSchema.java
+++ b/kafka-client/src/main/java/dev/responsive/db/RemoteKeyValueSchema.java
@@ -27,9 +27,15 @@ import org.apache.kafka.streams.state.KeyValueIterator;
  */
 public interface RemoteKeyValueSchema extends RemoteSchema<Bytes> {
 
-  byte[] get(String tableName, int partition, Bytes key);
+  byte[] get(String tableName, int partition, Bytes key, long minValidTs);
 
-  KeyValueIterator<Bytes, byte[]> range(String tableName, int partition, Bytes from, Bytes to);
+  KeyValueIterator<Bytes, byte[]> range(
+      String tableName,
+      int partition,
+      Bytes from,
+      Bytes to,
+      long minValidTs
+  );
 
-  KeyValueIterator<Bytes, byte[]> all(String tableName, int partition);
+  KeyValueIterator<Bytes, byte[]> all(String tableName, int partition, long minValidTs);
 }

--- a/kafka-client/src/main/java/dev/responsive/db/RemoteKeyValueSchema.java
+++ b/kafka-client/src/main/java/dev/responsive/db/RemoteKeyValueSchema.java
@@ -27,8 +27,38 @@ import org.apache.kafka.streams.state.KeyValueIterator;
  */
 public interface RemoteKeyValueSchema extends RemoteSchema<Bytes> {
 
+  /**
+   * Retrieves the value of the given {@code partitionKey} and {@code key}
+   * from {@code table}.
+   *
+   * @param tableName  the table to retrieve from
+   * @param partition  the partition
+   * @param key        the data key
+   * @param minValidTs the minimum valid timestamp to apply semantic TTL,
+   *                   in epochMillis
+   *
+   * @return the value previously set
+   */
   byte[] get(String tableName, int partition, Bytes key, long minValidTs);
 
+  /**
+   * Retrieves a range of key value pairs from the given {@code partitionKey} and
+   * {@code table} such that the keys (compared lexicographically) fall within the
+   * range of {@code from} to {@code to}.
+   *
+   * <p>Note that the returned iterator returns values from the remote server
+   * as it's iterated (data fetching is handling by the underlying Cassandra
+   * session).
+   *
+   * @param tableName  the table to retrieve from
+   * @param partition  the partition
+   * @param from       the starting key (inclusive)
+   * @param to         the ending key (exclusive)
+   * @param minValidTs the minimum timestamp, in epochMillis, to consider
+   *                   valid
+   *
+   * @return an iterator of all key-value pairs in the range
+   */
   KeyValueIterator<Bytes, byte[]> range(
       String tableName,
       int partition,
@@ -37,5 +67,20 @@ public interface RemoteKeyValueSchema extends RemoteSchema<Bytes> {
       long minValidTs
   );
 
+
+  /**
+   * Retrieves all key value pairs from the given {@code partitionKey} and
+   * {@code table} such that the keys are sorted lexicographically
+   *
+   * <p>Note that the returned iterator returns values from the remote server
+   * as it's iterated (data fetching is handling by the underlying Cassandra
+   * session).
+   *
+   * @param tableName  the table to retrieve from
+   * @param partition  the partition
+   * @param minValidTs the minimum valid timestamp, in epochMilliis, to return
+   *
+   * @return an iterator of all key-value pairs
+   */
   KeyValueIterator<Bytes, byte[]> all(String tableName, int partition, long minValidTs);
 }

--- a/kafka-client/src/main/java/dev/responsive/db/RemoteSchema.java
+++ b/kafka-client/src/main/java/dev/responsive/db/RemoteSchema.java
@@ -41,8 +41,19 @@ public interface RemoteSchema<K> {
   void prepare(final String tableName);
 
   /**
-   * Generates a statement that can insert data into the table
-   * specified.
+   * Inserts data into {@code table}. Note that this will overwrite
+   * any existing entry in the table with the same key.
+   *
+   * @param table         the table to insert into
+   * @param partitionKey  the partitioning key
+   * @param key           the data key
+   * @param value         the data value
+   * @param epochMillis   the event time with which this event
+   *                      was inserted in epochMillis
+   *
+   * @return a statement that, when executed, will insert the row
+   * matching {@code partitionKey} and {@code key} in the
+   * {@code table} with value {@code value}
    */
   @CheckReturnValue
   BoundStatement insert(
@@ -50,12 +61,17 @@ public interface RemoteSchema<K> {
       final int partitionKey,
       final K key,
       final byte[] value,
-      final long timestamp
+      final long epochMillis
   );
 
   /**
-   * Generates a statement that can delete data from the table
-   * specified.
+   * @param table         the table to delete from
+   * @param partitionKey  the partitioning key
+   * @param key           the data key
+   *
+   * @return a statement that, when executed, will delete the row
+   *         matching {@code partitionKey} and {@code key} in the
+   *         {@code table}
    */
   @CheckReturnValue
   BoundStatement delete(

--- a/kafka-client/src/main/java/dev/responsive/db/RemoteSchema.java
+++ b/kafka-client/src/main/java/dev/responsive/db/RemoteSchema.java
@@ -50,7 +50,7 @@ public interface RemoteSchema<K> {
       final int partitionKey,
       final K key,
       final byte[] value,
-      long timestamp
+      final long timestamp
   );
 
   /**

--- a/kafka-client/src/main/java/dev/responsive/db/RemoteSchema.java
+++ b/kafka-client/src/main/java/dev/responsive/db/RemoteSchema.java
@@ -49,11 +49,12 @@ public interface RemoteSchema<K> {
       final String table,
       final int partitionKey,
       final K key,
-      final byte[] value
+      final byte[] value,
+      long timestamp
   );
 
   /**
-   * Generates a statement that can delete data into the table
+   * Generates a statement that can delete data from the table
    * specified.
    */
   @CheckReturnValue

--- a/kafka-client/src/main/java/dev/responsive/db/RemoteWriter.java
+++ b/kafka-client/src/main/java/dev/responsive/db/RemoteWriter.java
@@ -21,7 +21,7 @@ import java.util.concurrent.CompletionStage;
 
 public interface RemoteWriter<K> {
 
-  void insert(final K key, final byte[] value, long timestamp);
+  void insert(final K key, final byte[] value, long epochMillis);
 
   void delete(final K key);
 

--- a/kafka-client/src/main/java/dev/responsive/db/RemoteWriter.java
+++ b/kafka-client/src/main/java/dev/responsive/db/RemoteWriter.java
@@ -21,7 +21,7 @@ import java.util.concurrent.CompletionStage;
 
 public interface RemoteWriter<K> {
 
-  void insert(final K key, final byte[] value);
+  void insert(final K key, final byte[] value, long timestamp);
 
   void delete(final K key);
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveWindowStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveWindowStore.java
@@ -202,7 +202,7 @@ public class ResponsiveWindowStore implements WindowStore<Bytes, byte[]> {
 
     final Stamped<Bytes> wKey = new Stamped<>(key, windowStartTimestamp);
 
-    buffer.put(wKey, value);
+    buffer.put(wKey, value, context.timestamp());
     StoreQueryUtils.updatePosition(position, context);
   }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/SizeTrackingBuffer.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/SizeTrackingBuffer.java
@@ -24,10 +24,10 @@ public class SizeTrackingBuffer<K> {
   }
 
   public void put(final K key, final Result<K> value) {
-    bytes += sizeOf(key, value);
+    bytes += value.size(extractor);
     final Result<K> old = buffer.put(key, value);
     if (old != null) {
-      bytes -= sizeOf(key, old);
+      bytes -= old.size(extractor);
     }
   }
 
@@ -38,11 +38,5 @@ public class SizeTrackingBuffer<K> {
 
   public NavigableMap<K, Result<K>> getReader() {
     return reader;
-  }
-
-  private long sizeOf(final K key, final Result<K> value) {
-    return extractor.bytes(key).get().length
-        + (value.isTombstone ? 0 : value.value.length)
-        + Long.BYTES; // timestamp size
   }
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/SizeTrackingBuffer.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/SizeTrackingBuffer.java
@@ -41,6 +41,8 @@ public class SizeTrackingBuffer<K> {
   }
 
   private long sizeOf(final K key, final Result<K> value) {
-    return extractor.bytes(key).get().length + (value.isTombstone ? 0 : value.value.length);
+    return extractor.bytes(key).get().length
+        + (value.isTombstone ? 0 : value.value.length)
+        + Long.BYTES; // timestamp size
   }
 }

--- a/kafka-client/src/main/java/dev/responsive/model/Result.java
+++ b/kafka-client/src/main/java/dev/responsive/model/Result.java
@@ -16,6 +16,8 @@
 
 package dev.responsive.model;
 
+import dev.responsive.db.KeySpec;
+
 public class Result<K> {
 
   public final K key;
@@ -36,5 +38,11 @@ public class Result<K> {
     this.value = value;
     this.isTombstone = isTombstone;
     this.timestamp = timestamp;
+  }
+
+  public int size(final KeySpec<K> extractor) {
+    return extractor.bytes(key).get().length
+        + (isTombstone ? 0 : value.length)
+        + Long.BYTES; // timestamp size
   }
 }

--- a/kafka-client/src/main/java/dev/responsive/model/Result.java
+++ b/kafka-client/src/main/java/dev/responsive/model/Result.java
@@ -21,18 +21,20 @@ public class Result<K> {
   public final K key;
   public final byte[] value;
   public final boolean isTombstone;
+  public final long timestamp;
 
-  public static <K> Result<K> value(final K key, final byte[] value) {
-    return new Result<>(key, value, false);
+  public static <K> Result<K> value(final K key, final byte[] value, long timestamp) {
+    return new Result<>(key, value, false, timestamp);
   }
 
-  public static <K> Result<K> tombstone(final K key) {
-    return new Result<>(key, null, true);
+  public static <K> Result<K> tombstone(final K key, long timestamp) {
+    return new Result<>(key, null, true, timestamp);
   }
 
-  private Result(final K key, final byte[] value, final boolean isTombstone) {
+  private Result(final K key, final byte[] value, final boolean isTombstone, long timestamp) {
     this.key = key;
     this.value = value;
     this.isTombstone = isTombstone;
+    this.timestamp = timestamp;
   }
 }

--- a/kafka-client/src/main/java/dev/responsive/utils/Iterators.java
+++ b/kafka-client/src/main/java/dev/responsive/utils/Iterators.java
@@ -99,6 +99,13 @@ public final class Iterators {
     return new WindowKeyIterator<>(delegate, windowSize);
   }
 
+  public static <I, O, V> KeyValueIterator<O, V> mapKeys(
+      final KeyValueIterator<I, V> delegate,
+      final Function<I, O> mapper
+  ) {
+    return new KeyMappingIterator<>(delegate, mapper);
+  }
+
   private static class PeekingIterator<T> implements Iterator<T> {
 
     private final Iterator<T> delegate;
@@ -281,6 +288,42 @@ public final class Iterators {
         return delegate.next();
       }
       throw new NoSuchElementException();
+    }
+  }
+
+  private static class KeyMappingIterator<I, O, V> implements KeyValueIterator<O, V> {
+
+    private final KeyValueIterator<I, V> delegate;
+    private final Function<I, O> mapper;
+
+    private KeyMappingIterator(final KeyValueIterator<I, V> delegate, final Function<I, O> mapper) {
+      this.delegate = delegate;
+      this.mapper = mapper;
+    }
+
+    @Override
+    public boolean hasNext() {
+      return delegate.hasNext();
+    }
+
+    @Override
+    public KeyValue<O, V> next() {
+      if (hasNext()) {
+        final var next = delegate.next();
+        return new KeyValue<>(mapper.apply(next.key), next.value);
+      }
+      throw new NoSuchElementException();
+    }
+
+    @Override
+    public void close() {
+      delegate.close();
+    }
+
+    @Override
+    public O peekNextKey() {
+      final var next = delegate.peekNextKey();
+      return mapper.apply(next);
     }
   }
 

--- a/kafka-client/src/test/java/dev/responsive/kafka/store/LocalRemoteKvIteratorTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/store/LocalRemoteKvIteratorTest.java
@@ -29,6 +29,8 @@ import org.junit.jupiter.api.Test;
 
 public class LocalRemoteKvIteratorTest {
 
+  private static final long TIMESTAMP = 100L;
+
   @Test
   public void shouldReturnUniqueKeysLexicographicallyFromTwoSources() {
     // Given:
@@ -39,7 +41,7 @@ public class LocalRemoteKvIteratorTest {
 
     final TestKvIterator<Result<Bytes>> buffered = new TestKvIterator<>(
         List.of(k2),
-        List.of(Result.value(k2, val))
+        List.of(Result.value(k2, val, TIMESTAMP))
     );
     final TestKvIterator<byte[]> remote = new TestKvIterator<>(
         List.of(k1, k3),
@@ -67,7 +69,7 @@ public class LocalRemoteKvIteratorTest {
 
     final TestKvIterator<Result<Bytes>> buffered = new TestKvIterator<>(
         List.of(k1, k2),
-        List.of(Result.value(k1, valLocal), Result.value(k2, valLocal))
+        List.of(Result.value(k1, valLocal, TIMESTAMP), Result.value(k2, valLocal, TIMESTAMP))
     );
     final TestKvIterator<byte[]> remote = new TestKvIterator<>(
         List.of(k1, k2),
@@ -94,7 +96,7 @@ public class LocalRemoteKvIteratorTest {
 
     final TestKvIterator<Result<Bytes>> buffered = new TestKvIterator<>(
         List.of(k1),
-        List.of(Result.tombstone(k1))
+        List.of(Result.tombstone(k1, TIMESTAMP))
     );
     final TestKvIterator<byte[]> remote = new TestKvIterator<>(
         List.of(k2),
@@ -121,7 +123,7 @@ public class LocalRemoteKvIteratorTest {
 
     final TestKvIterator<Result<Bytes>> buffered = new TestKvIterator<>(
         List.of(k1),
-        List.of(Result.tombstone(k1))
+        List.of(Result.tombstone(k1, TIMESTAMP))
     );
     final TestKvIterator<byte[]> remote = new TestKvIterator<>(
         List.of(k1, k2),
@@ -148,7 +150,10 @@ public class LocalRemoteKvIteratorTest {
 
     final TestKvIterator<Result<Bytes>> buffered = new TestKvIterator<>(
         List.of(k1, k2, k3),
-        List.of(Result.value(k1, val), Result.tombstone(k2), Result.value(k3, val))
+        List.of(
+            Result.value(k1, val, TIMESTAMP),
+            Result.tombstone(k2, TIMESTAMP),
+            Result.value(k3, val, TIMESTAMP))
     );
     final TestKvIterator<byte[]> remote = new TestKvIterator<>(List.of(), List.of());
 

--- a/kafka-client/src/test/java/dev/responsive/kafka/store/LwtWriterTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/store/LwtWriterTest.java
@@ -28,10 +28,8 @@ import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
 import com.datastax.oss.driver.api.core.cql.BoundStatement;
 import com.datastax.oss.driver.api.core.cql.Statement;
 import com.datastax.oss.driver.internal.core.cql.DefaultBatchStatement;
-import dev.responsive.db.BytesKeySpec;
 import dev.responsive.db.CassandraClient;
 import dev.responsive.db.CassandraKeyValueSchema;
-import dev.responsive.db.KeySpec;
 import dev.responsive.db.LwtWriter;
 import dev.responsive.db.WriterFactory;
 import java.util.ArrayList;
@@ -52,8 +50,7 @@ import org.mockito.quality.Strictness;
 @MockitoSettings(strictness = Strictness.LENIENT)
 class LwtWriterTest {
 
-  private static final long OFFSET = 123L;
-  private static final KeySpec<Bytes> KEY_SPEC = new BytesKeySpec();
+  private static final long CURRENT_TS = 100L;
 
   @Mock
   private WriterFactory<Bytes> writerFactory;
@@ -93,9 +90,9 @@ class LwtWriterTest {
     );
 
     // When:
-    writer.insert(Bytes.wrap(new byte[]{0}), new byte[]{0});
+    writer.insert(Bytes.wrap(new byte[]{0}), new byte[]{0}, CURRENT_TS);
     writer.delete(Bytes.wrap(new byte[]{1}));
-    writer.insert(Bytes.wrap(new byte[]{2}), new byte[]{2});
+    writer.insert(Bytes.wrap(new byte[]{2}), new byte[]{2}, CURRENT_TS);
     writer.flush();
 
     // Then:
@@ -136,9 +133,9 @@ class LwtWriterTest {
     );
 
     // When:
-    writer.insert(Bytes.wrap(new byte[]{0}), new byte[]{0});
+    writer.insert(Bytes.wrap(new byte[]{0}), new byte[]{0}, CURRENT_TS);
     writer.delete(Bytes.wrap(new byte[]{1}));
-    writer.insert(Bytes.wrap(new byte[]{2}), new byte[]{2});
+    writer.insert(Bytes.wrap(new byte[]{2}), new byte[]{2}, CURRENT_TS);
     writer.flush();
 
     // Then:
@@ -156,8 +153,8 @@ class LwtWriterTest {
         final String tableName,
         final int partition,
         final Bytes key,
-        final byte[] value
-    ) {
+        final byte[] value,
+        long timestamp) {
       return capturingStatement("insertData", new Object[]{tableName, partition, key, value});
     }
 

--- a/kafka-client/src/test/java/dev/responsive/kafka/store/LwtWriterTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/store/LwtWriterTest.java
@@ -154,7 +154,7 @@ class LwtWriterTest {
         final int partition,
         final Bytes key,
         final byte[] value,
-        long timestamp) {
+        long epochMillis) {
       return capturingStatement("insertData", new Object[]{tableName, partition, key, value});
     }
 

--- a/kafka-client/src/test/java/dev/responsive/model/ResultTest.java
+++ b/kafka-client/src/test/java/dev/responsive/model/ResultTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.model;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import dev.responsive.db.BytesKeySpec;
+import org.apache.kafka.common.utils.Bytes;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+class ResultTest {
+
+  @Test
+  public void shouldComputeSize() {
+    // Given:
+    final Result<Bytes> result = Result.value(Bytes.wrap(new byte[10]), new byte[10], 1L);
+
+    // When:
+    final int size = result.size(new BytesKeySpec());
+
+    // Then:
+    // 10 for key, 10 for value, 8 for timestamp
+    assertThat(size, Matchers.is(28));
+  }
+
+  @Test
+  public void shouldComputeSizeForTombstone() {
+    // Given:
+    final Result<Bytes> result = Result.tombstone(Bytes.wrap(new byte[10]), 1L);
+
+    // When:
+    final int size = result.size(new BytesKeySpec());
+
+    // Then:
+    // 10 for key, 8 for timestamp
+    assertThat(size, Matchers.is(18));
+  }
+
+}

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/store/TTDKeyValueSchema.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/store/TTDKeyValueSchema.java
@@ -49,7 +49,7 @@ public class TTDKeyValueSchema extends TTDSchema<Bytes> implements RemoteKeyValu
       final int partitionKey,
       final Bytes key,
       final byte[] value,
-      final long timestamp
+      final long epochMillis
   ) {
     tableNameToStore.get(tableName).put(key, value);
     return null;

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/store/TTDKeyValueSchema.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/store/TTDKeyValueSchema.java
@@ -49,7 +49,7 @@ public class TTDKeyValueSchema extends TTDSchema<Bytes> implements RemoteKeyValu
       final int partitionKey,
       final Bytes key,
       final byte[] value,
-      long timestamp
+      final long timestamp
   ) {
     tableNameToStore.get(tableName).put(key, value);
     return null;

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/store/TTDKeyValueSchema.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/store/TTDKeyValueSchema.java
@@ -48,7 +48,8 @@ public class TTDKeyValueSchema extends TTDSchema<Bytes> implements RemoteKeyValu
       final String tableName,
       final int partitionKey,
       final Bytes key,
-      final byte[] value
+      final byte[] value,
+      long timestamp
   ) {
     tableNameToStore.get(tableName).put(key, value);
     return null;
@@ -61,7 +62,7 @@ public class TTDKeyValueSchema extends TTDSchema<Bytes> implements RemoteKeyValu
   }
 
   @Override
-  public byte[] get(final String tableName, final int partition, final Bytes key) {
+  public byte[] get(final String tableName, final int partition, final Bytes key, long minValidTs) {
     return tableNameToStore.get(tableName).get(key);
   }
 
@@ -70,13 +71,14 @@ public class TTDKeyValueSchema extends TTDSchema<Bytes> implements RemoteKeyValu
       final String tableName,
       final int partition,
       Bytes from,
-      final Bytes to
-  ) {
+      final Bytes to,
+      long minValidTs) {
     return tableNameToStore.get(tableName).range(from, to);
   }
 
   @Override
-  public KeyValueIterator<Bytes, byte[]> all(final String tableName, final int partition) {
+  public KeyValueIterator<Bytes, byte[]> all(final String tableName, final int partition,
+                                             long minValidTs) {
     return tableNameToStore.get(tableName).all();
   }
 }

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/store/TTDSchema.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/store/TTDSchema.java
@@ -85,8 +85,8 @@ public abstract class TTDSchema<K> implements RemoteSchema<K> {
 
     @SuppressWarnings("ResultOfMethodCallIgnored")
     @Override
-    public void insert(final K key, final byte[] value, long timestamp) {
-      schema.insert(tableName, partition, key, value, timestamp);
+    public void insert(final K key, final byte[] value, long epochMillis) {
+      schema.insert(tableName, partition, key, value, epochMillis);
     }
 
     @SuppressWarnings("ResultOfMethodCallIgnored")

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/store/TTDSchema.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/store/TTDSchema.java
@@ -85,8 +85,8 @@ public abstract class TTDSchema<K> implements RemoteSchema<K> {
 
     @SuppressWarnings("ResultOfMethodCallIgnored")
     @Override
-    public void insert(final K key, final byte[] value) {
-      schema.insert(tableName, partition, key, value);
+    public void insert(final K key, final byte[] value, long timestamp) {
+      schema.insert(tableName, partition, key, value, timestamp);
     }
 
     @SuppressWarnings("ResultOfMethodCallIgnored")

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/store/TTDWindowedSchema.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/store/TTDWindowedSchema.java
@@ -50,7 +50,7 @@ public class TTDWindowedSchema extends TTDSchema<Stamped<Bytes>> implements Remo
       final int partitionKey,
       final Stamped<Bytes> key,
       final byte[] value,
-      final long timestamp
+      final long epochMillis
   ) {
     tableNameToStore.get(tableName).put(key, value);
     return null;

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/store/TTDWindowedSchema.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/store/TTDWindowedSchema.java
@@ -49,8 +49,8 @@ public class TTDWindowedSchema extends TTDSchema<Stamped<Bytes>> implements Remo
       final String tableName,
       final int partitionKey,
       final Stamped<Bytes> key,
-      final byte[] value
-  ) {
+      final byte[] value,
+      long timestamp) {
     tableNameToStore.get(tableName).put(key, value);
     return null;
   }

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/store/TTDWindowedSchema.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/store/TTDWindowedSchema.java
@@ -50,7 +50,8 @@ public class TTDWindowedSchema extends TTDSchema<Stamped<Bytes>> implements Remo
       final int partitionKey,
       final Stamped<Bytes> key,
       final byte[] value,
-      long timestamp) {
+      final long timestamp
+  ) {
     tableNameToStore.get(tableName).put(key, value);
     return null;
   }


### PR DESCRIPTION
this PR changes the table schema to include a `TIMESTAMP` clustering column so that we can semantically respect the TTL based on event time even if wall clock TTL hasn't kicked in.