### PR TITLE
add controller models for new policies

### DIFF
--- a/controller-api/src/main/proto/responsive/controller/v1/controller.proto
+++ b/controller-api/src/main/proto/responsive/controller/v1/controller.proto
@@ -81,6 +81,18 @@ message ApplicationPolicySpec {
 }
 
 message DemoPolicySpec {
+  message FixedReplicaScaleUpStrategySpec {
+    // should this be a higher-level object?
+    int32 replicas = 1;
+  }
+
+  message RateBasedScaleUpStrategySpec {
+    int32 max_scale_replicas = 1;
+  }
+
+  message ScaleToMaxStrategySpec {
+  }
+
   message RateBasedDiagnoserSpec {
     int32 rate = 1;
     optional int32 window_ms = 2;
@@ -89,17 +101,35 @@ message DemoPolicySpec {
   message LagDiagnoserSpec {
   }
 
+  message MeanSojournTimeDiagnoserSpec {
+    int32 max_mean_sojourn_time_seconds = 1;
+
+    oneof scale_up_strategy {
+      FixedReplicaScaleUpStrategySpec fixed_replicas = 2;
+      RateBasedScaleUpStrategySpec rate_based = 3;
+      ScaleToMaxStrategySpec scale_to_max = 4;
+    }
+  }
+
+  message ThreadSaturationDiagnoserSpec {
+    double threshold = 1;
+  }
+
   message DiagnoserSpec {
     oneof diagnoser {
       RateBasedDiagnoserSpec processing_rate_scale_up = 1;
       RateBasedDiagnoserSpec processing_rate_scale_down = 2;
+      RateBasedDiagnoserSpec arrival_rate_scale_up = 6;
       LagDiagnoserSpec lag_scale_up = 3;
+      MeanSojournTimeDiagnoserSpec mean_sojourn_time = 4;
+      ThreadSaturationDiagnoserSpec thread_saturation = 5;
     }
   }
 
   // Constraints
   int32 max_replicas = 1;
   int32 min_replicas = 2;
+  int32 max_scale_up_replicas = 4;
 
   // Diagnosers
   repeated DiagnoserSpec diagnoser = 3;

--- a/operator/src/main/java/dev/responsive/k8s/controller/DemoPolicyProtoFactories.java
+++ b/operator/src/main/java/dev/responsive/k8s/controller/DemoPolicyProtoFactories.java
@@ -29,6 +29,7 @@ final class DemoPolicyProtoFactories {
     return ControllerOuterClass.DemoPolicySpec.newBuilder()
         .setMaxReplicas(demoPolicy.getMaxReplicas())
         .setMinReplicas(demoPolicy.getMinReplicas())
+        .setMaxScaleUpReplicas(demoPolicy.getMaxScaleUpReplicas())
         .addAllDiagnoser(
             DemoPolicyProtoFactories.diagnosersFromK8sResource(demoPolicy.getDiagnosers()))
         .build();

--- a/operator/src/main/java/dev/responsive/k8s/controller/DiagnoserProtoFactories.java
+++ b/operator/src/main/java/dev/responsive/k8s/controller/DiagnoserProtoFactories.java
@@ -1,8 +1,12 @@
 package dev.responsive.k8s.controller;
 
 import dev.responsive.k8s.crd.kafkastreams.DiagnoserSpec;
+import dev.responsive.k8s.crd.kafkastreams.MeanSojournTimeDiagnoserSpec;
 import dev.responsive.k8s.crd.kafkastreams.RateBasedDiagnoserSpec;
 import responsive.controller.v1.controller.proto.ControllerOuterClass;
+import responsive.controller.v1.controller.proto.ControllerOuterClass.DemoPolicySpec.FixedReplicaScaleUpStrategySpec;
+import responsive.controller.v1.controller.proto.ControllerOuterClass.DemoPolicySpec.RateBasedScaleUpStrategySpec;
+import responsive.controller.v1.controller.proto.ControllerOuterClass.DemoPolicySpec.ScaleToMaxStrategySpec;
 
 public class DiagnoserProtoFactories {
   private static ControllerOuterClass.DemoPolicySpec.RateBasedDiagnoserSpec
@@ -13,6 +17,36 @@ public class DiagnoserProtoFactories {
         .setRate(diagnoser.getRate());
     if (diagnoser.getWindowMs().isPresent()) {
       builder.setWindowMs(diagnoser.getWindowMs().get());
+    }
+    return builder.build();
+  }
+
+  private static ControllerOuterClass.DemoPolicySpec.MeanSojournTimeDiagnoserSpec
+      meanSojournTimeDiagnoserFromK8sResource(
+          final MeanSojournTimeDiagnoserSpec diagnoser
+  ) {
+    final var builder = ControllerOuterClass.DemoPolicySpec.MeanSojournTimeDiagnoserSpec
+        .newBuilder()
+        .setMaxMeanSojournTimeSeconds(diagnoser.getMaxMeanSojournTime());
+    final var type = diagnoser.getScaleUpStrategy().getType();
+    switch (type) {
+      case RATE_BASED: {
+        builder.setRateBased(RateBasedScaleUpStrategySpec.newBuilder().build());
+        break;
+      }
+      case SCALE_TO_MAX: {
+        builder.setScaleToMax(ScaleToMaxStrategySpec.newBuilder().build());
+        break;
+      }
+      case FIXED_REPLICA: {
+        builder.setFixedReplicas(FixedReplicaScaleUpStrategySpec.newBuilder()
+            .setReplicas(diagnoser.getScaleUpStrategy().getFixedReplica().get().getReplicas())
+            .build()
+        );
+        break;
+      }
+      default:
+        throw new IllegalStateException("unexpected strategy type: " + type);
     }
     return builder.build();
   }
@@ -37,6 +71,21 @@ public class DiagnoserProtoFactories {
             .setProcessingRateScaleDown(
                 rateBasedDiagnoserFromK8sResource(
                     diagnoserSpec.getProcessingRateScaleDown().get()))
+            .build();
+      }
+      case ARRIVAL_RATE_SCALE_UP: {
+        return ControllerOuterClass.DemoPolicySpec.DiagnoserSpec.newBuilder()
+            .setArrivalRateScaleUp(
+                rateBasedDiagnoserFromK8sResource(
+                    diagnoserSpec.getArrivalRateScaleUp().get()))
+            .build();
+
+      }
+      case MEAN_SOJOURN_TIME: {
+        return ControllerOuterClass.DemoPolicySpec.DiagnoserSpec.newBuilder()
+            .setMeanSojournTime(
+                meanSojournTimeDiagnoserFromK8sResource(
+                    diagnoserSpec.getMeanSojournTime().get()))
             .build();
       }
       default:

--- a/operator/src/main/java/dev/responsive/k8s/crd/kafkastreams/DiagnoserSpec.java
+++ b/operator/src/main/java/dev/responsive/k8s/crd/kafkastreams/DiagnoserSpec.java
@@ -27,12 +27,16 @@ public class DiagnoserSpec {
   public enum Type {
     PROCESSING_RATE_SCALE_UP,
     PROCESSING_RATE_SCALE_DOWN,
-    LAG_SCALE_UP
+    ARRIVAL_RATE_SCALE_UP,
+    LAG_SCALE_UP,
+    MEAN_SOJOURN_TIME
   }
 
   private final Type type;
   private final Optional<RateBasedDiagnoserSpec> processingRateScaleUp;
   private final Optional<RateBasedDiagnoserSpec> processingRateScaleDown;
+  private final Optional<RateBasedDiagnoserSpec> arrivalRateScaleUp;
+  private final Optional<MeanSojournTimeDiagnoserSpec> meanSojournTime;
 
   @JsonCreator
   public DiagnoserSpec(
@@ -40,21 +44,29 @@ public class DiagnoserSpec {
       @JsonProperty("processingRateScaleUp")
       final Optional<RateBasedDiagnoserSpec> processingRateScaleUp,
       @JsonProperty("processingRateScaleDown")
-      final Optional<RateBasedDiagnoserSpec> processingRateScaleDown
+      final Optional<RateBasedDiagnoserSpec> processingRateScaleDown,
+      @JsonProperty("arrivalRateScaleUp")
+      final Optional<RateBasedDiagnoserSpec> arrivalRateScaleUp,
+      @JsonProperty("meanSojournTime")
+      final Optional<MeanSojournTimeDiagnoserSpec> meanSojournTime
   ) {
     this.type = strategy;
     this.processingRateScaleDown = Objects.requireNonNull(processingRateScaleDown);
     this.processingRateScaleUp = Objects.requireNonNull(processingRateScaleUp);
+    this.arrivalRateScaleUp = Objects.requireNonNull(arrivalRateScaleUp);
+    this.meanSojournTime = Objects.requireNonNull(meanSojournTime);
   }
 
   public static DiagnoserSpec lag() {
-    return new DiagnoserSpec(Type.LAG_SCALE_UP, empty(), empty());
+    return new DiagnoserSpec(Type.LAG_SCALE_UP, empty(), empty(), empty(), empty());
   }
 
   public static DiagnoserSpec processingRateScaleUp(final RateBasedDiagnoserSpec diagnoser) {
     return new DiagnoserSpec(
         Type.PROCESSING_RATE_SCALE_UP,
         Optional.of(diagnoser),
+        empty(),
+        empty(),
         empty()
     );
   }
@@ -62,6 +74,28 @@ public class DiagnoserSpec {
   public static DiagnoserSpec processingRateScaleDown(final RateBasedDiagnoserSpec diagnoser) {
     return new DiagnoserSpec(
         Type.PROCESSING_RATE_SCALE_DOWN,
+        empty(),
+        Optional.of(diagnoser),
+        empty(),
+        empty()
+    );
+  }
+
+  public static DiagnoserSpec arrivalRateScaleUp(final RateBasedDiagnoserSpec diagnoser) {
+    return new DiagnoserSpec(
+        Type.ARRIVAL_RATE_SCALE_UP,
+        empty(),
+        empty(),
+        Optional.of(diagnoser),
+        empty()
+    );
+  }
+
+  public static DiagnoserSpec meanSojournTime(final MeanSojournTimeDiagnoserSpec diagnoser) {
+    return new DiagnoserSpec(
+        Type.MEAN_SOJOURN_TIME,
+        empty(),
+        empty(),
         empty(),
         Optional.of(diagnoser)
     );
@@ -79,6 +113,14 @@ public class DiagnoserSpec {
     return processingRateScaleDown;
   }
 
+  public Optional<MeanSojournTimeDiagnoserSpec> getMeanSojournTime() {
+    return meanSojournTime;
+  }
+
+  public Optional<RateBasedDiagnoserSpec> getArrivalRateScaleUp() {
+    return arrivalRateScaleUp;
+  }
+
   public void validate() {
     Objects.requireNonNull(type);
     switch (type) {
@@ -87,6 +129,9 @@ public class DiagnoserSpec {
         break;
       case PROCESSING_RATE_SCALE_DOWN:
         CrdUtils.validatePresent(processingRateScaleDown, "processingRateScaleDown");
+        break;
+      case MEAN_SOJOURN_TIME:
+        CrdUtils.validatePresent(meanSojournTime, "meanSojournTime");
         break;
       default:
         break;

--- a/operator/src/main/java/dev/responsive/k8s/crd/kafkastreams/FixedReplicaScaleUpStrategySpec.java
+++ b/operator/src/main/java/dev/responsive/k8s/crd/kafkastreams/FixedReplicaScaleUpStrategySpec.java
@@ -1,0 +1,13 @@
+package dev.responsive.k8s.crd.kafkastreams;
+
+public class FixedReplicaScaleUpStrategySpec {
+  private final int replicas;
+
+  public FixedReplicaScaleUpStrategySpec(final int replicas) {
+    this.replicas = replicas;
+  }
+
+  public int getReplicas() {
+    return replicas;
+  }
+}

--- a/operator/src/main/java/dev/responsive/k8s/crd/kafkastreams/MeanSojournTimeDiagnoserSpec.java
+++ b/operator/src/main/java/dev/responsive/k8s/crd/kafkastreams/MeanSojournTimeDiagnoserSpec.java
@@ -1,0 +1,22 @@
+package dev.responsive.k8s.crd.kafkastreams;
+
+public class MeanSojournTimeDiagnoserSpec {
+  private final int maxMeanSojournTime;
+  private final ScaleUpStrategySpec scaleUpStrategy;
+
+  public MeanSojournTimeDiagnoserSpec(
+      final int maxMeanSojournTime,
+      final ScaleUpStrategySpec scaleUpStrategy
+  ) {
+    this.maxMeanSojournTime = maxMeanSojournTime;
+    this.scaleUpStrategy = scaleUpStrategy;
+  }
+
+  public int getMaxMeanSojournTime() {
+    return maxMeanSojournTime;
+  }
+
+  public ScaleUpStrategySpec getScaleUpStrategy() {
+    return scaleUpStrategy;
+  }
+}

--- a/operator/src/main/java/dev/responsive/k8s/crd/kafkastreams/ScaleUpStrategySpec.java
+++ b/operator/src/main/java/dev/responsive/k8s/crd/kafkastreams/ScaleUpStrategySpec.java
@@ -1,0 +1,45 @@
+package dev.responsive.k8s.crd.kafkastreams;
+
+import java.util.Objects;
+import java.util.Optional;
+
+public class ScaleUpStrategySpec {
+  public enum Type {
+    FIXED_REPLICA,
+    RATE_BASED,
+    SCALE_TO_MAX
+  }
+
+  private Type type;
+  private Optional<FixedReplicaScaleUpStrategySpec> fixedReplica;
+
+  public ScaleUpStrategySpec(
+      final Type type,
+      final Optional<FixedReplicaScaleUpStrategySpec> fixedReplica
+  ) {
+    this.type = Objects.requireNonNull(type);
+    this.fixedReplica = Objects.requireNonNull(fixedReplica);
+  }
+
+  public static ScaleUpStrategySpec fixedReplica(
+      final FixedReplicaScaleUpStrategySpec fixedReplicaScaleUpStrategySpec) {
+    return new ScaleUpStrategySpec(
+        Type.FIXED_REPLICA, Optional.of(fixedReplicaScaleUpStrategySpec));
+  }
+
+  public static ScaleUpStrategySpec rateBased() {
+    return new ScaleUpStrategySpec(Type.RATE_BASED, Optional.empty());
+  }
+
+  public static ScaleUpStrategySpec scaleToMax() {
+    return new ScaleUpStrategySpec(Type.SCALE_TO_MAX, Optional.empty());
+  }
+
+  public Type getType() {
+    return type;
+  }
+
+  public Optional<FixedReplicaScaleUpStrategySpec> getFixedReplica() {
+    return fixedReplica;
+  }
+}

--- a/operator/src/test/java/dev/responsive/k8s/crd/ResponsivePolicySpecTest.java
+++ b/operator/src/test/java/dev/responsive/k8s/crd/ResponsivePolicySpecTest.java
@@ -107,6 +107,8 @@ class ResponsivePolicySpecTest {
                 new DiagnoserSpec(
                     null,
                     Optional.empty(),
+                    Optional.empty(),
+                    Optional.empty(),
                     Optional.empty()
                 )
             ))))


### PR DESCRIPTION
add models for mean sojourn time and saturation diagnosers

mean sojourn time diagnoser: this diagnoser takes a target for "mean sojourn time"
   and will try to make sure the application can satisfy this target. The mean
   sojourn time is the time expected to process a record appended to a source
   topic partition.

saturation diagnoser: this diagnoser attemmpts to keep thread "saturation" over
   some target. Saturation is the percentage of time a given thread spends not in poll
   (e.g. processing data). A low value means the thread is idle.