### PR TITLE
bump the test app keyspace create timeout

### DIFF
--- a/kafka-client-examples/simple-example/src/main/java/dev/responsive/examples/simpleapp/SimpleApplication.java
+++ b/kafka-client-examples/simple-example/src/main/java/dev/responsive/examples/simpleapp/SimpleApplication.java
@@ -1,6 +1,9 @@
 package dev.responsive.examples.simpleapp;
 
+import static com.datastax.oss.driver.api.core.config.DefaultDriverOption.REQUEST_TIMEOUT;
+
 import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.config.DriverConfigLoader;
 import com.datastax.oss.driver.api.querybuilder.SchemaBuilder;
 import com.datastax.oss.driver.api.querybuilder.schema.CreateKeyspace;
 import dev.responsive.kafka.api.ResponsiveKafkaStreams;
@@ -134,6 +137,9 @@ public class SimpleApplication {
     return CqlSession.builder()
         .addContactPoint(new InetSocketAddress("scylla-svc", 9042))
         .withLocalDatacenter("datacenter1")
+        .withConfigLoader(DriverConfigLoader.programmaticBuilder()
+            .withLong(REQUEST_TIMEOUT, 10000)
+            .build())
         .build();
   }
 }


### PR DESCRIPTION
Bumps the timeout for the smoke test app. Currently our smoke tests
occasionally fail with:

```
"2023-08-31T16:24:14.542Z",,"""responsive-platform-sindriLocal-system-test-platform-add-the-mean-sojourn-time-diagnoser""","Exception in thread ""main"" com.datastax.oss.driver.api.core.DriverTimeoutException: Query timed out after PT2S"
```

The default of 2 seconds seems short. This patch bumps the timeout to 10 seconds.