### PR TITLE
Support null-value deletes 

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsivePartitionedStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsivePartitionedStore.java
@@ -170,7 +170,7 @@ public class ResponsivePartitionedStore implements KeyValueStore<Bytes, byte[]> 
 
   @Override
   public void put(final Bytes key, final byte[] value) {
-    putIfAbsent(key, value);
+    putInternal(key, value);
   }
 
   @Override

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsivePartitionedStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsivePartitionedStore.java
@@ -170,8 +170,7 @@ public class ResponsivePartitionedStore implements KeyValueStore<Bytes, byte[]> 
 
   @Override
   public void put(final Bytes key, final byte[] value) {
-    buffer.put(key, value, context.timestamp());
-    StoreQueryUtils.updatePosition(position, context);
+    putIfAbsent(key, value);
   }
 
   @Override
@@ -183,23 +182,32 @@ public class ResponsivePartitionedStore implements KeyValueStore<Bytes, byte[]> 
     // batch will not be committed to remote storage)
     final byte[] old = get(key);
     if (old == null) {
-      put(key, value);
+      putInternal(key, value);
     }
     return old;
   }
 
   @Override
   public void putAll(final List<KeyValue<Bytes, byte[]>> entries) {
-    entries.forEach(kv -> put(kv.key, kv.value));
-    StoreQueryUtils.updatePosition(position, context);
+    entries.forEach(kv -> putInternal(kv.key, kv.value));
   }
 
   @Override
   public byte[] delete(final Bytes key) {
     // single writer prevents races (see putIfAbsent)
     final byte[] old = get(key);
-    buffer.tombstone(key, context.timestamp());
+    putInternal(key, null);
+
     return old;
+  }
+
+  private void putInternal(final Bytes key, final byte[] value) {
+    if (value != null) {
+      buffer.put(key, value, context.timestamp());
+    } else {
+      buffer.tombstone(key, context.timestamp());
+    }
+    StoreQueryUtils.updatePosition(position, context);
   }
 
   @Override

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveWindowStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveWindowStore.java
@@ -191,7 +191,15 @@ public class ResponsiveWindowStore implements WindowStore<Bytes, byte[]> {
 
     final Stamped<Bytes> wKey = new Stamped<>(key, windowStartTimestamp);
 
-    buffer.put(wKey, value, context.timestamp());
+    putInternal(wKey, value);
+  }
+
+  private void putInternal(final Stamped<Bytes> wKey, final byte[] value) {
+    if (value != null) {
+      buffer.put(wKey, value, context.timestamp());
+    } else {
+      buffer.tombstone(wKey, context.timestamp());
+    }
     StoreQueryUtils.updatePosition(position, context);
   }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveWindowStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveWindowStore.java
@@ -189,16 +189,16 @@ public class ResponsiveWindowStore implements WindowStore<Bytes, byte[]> {
   public void put(final Bytes key, final byte[] value, final long windowStartTimestamp) {
     observedStreamTime = Math.max(observedStreamTime, windowStartTimestamp);
 
-    final Stamped<Bytes> wKey = new Stamped<>(key, windowStartTimestamp);
+    final Stamped<Bytes> windowedKey = new Stamped<>(key, windowStartTimestamp);
 
-    putInternal(wKey, value);
+    putInternal(windowedKey, value);
   }
 
-  private void putInternal(final Stamped<Bytes> wKey, final byte[] value) {
+  private void putInternal(final Stamped<Bytes> windowedKey, final byte[] value) {
     if (value != null) {
-      buffer.put(wKey, value, context.timestamp());
+      buffer.put(windowedKey, value, context.timestamp());
     } else {
-      buffer.tombstone(wKey, context.timestamp());
+      buffer.tombstone(windowedKey, context.timestamp());
     }
     StoreQueryUtils.updatePosition(position, context);
   }


### PR DESCRIPTION
Both KV and Window stores allow deletion via put with a null value in Kafka Streams. We need to handle these properly as tombstones and enable deletes for window stores 