### PR TITLE
fix: initialize TTDMockAdmin with the changelogs to create up front

### DIFF
--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/clients/TTDCassandraClient.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/clients/TTDCassandraClient.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package dev.responsive.kafka.store;
+package dev.responsive.kafka.clients;
 
 import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
 import com.datastax.oss.driver.api.core.cql.PreparedStatement;
@@ -25,25 +25,30 @@ import dev.responsive.db.CassandraClient;
 import dev.responsive.db.RemoteKeyValueSchema;
 import dev.responsive.db.RemoteWindowedSchema;
 import dev.responsive.kafka.config.ResponsiveConfig;
+import dev.responsive.kafka.store.ResponsiveStoreRegistry;
+import dev.responsive.kafka.store.SchemaType;
+import dev.responsive.kafka.store.TTDKeyValueSchema;
+import dev.responsive.kafka.store.TTDWindowedSchema;
 import dev.responsive.utils.RemoteMonitor;
 import java.time.Duration;
 import java.util.OptionalInt;
-import java.util.Properties;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ScheduledExecutorService;
 import org.apache.kafka.common.utils.Time;
 
 // TODO: use mock return values instead of null here and in the TTD schemas
-public class CassandraClientStub extends CassandraClient {
+public class TTDCassandraClient extends CassandraClient {
   private final Time time;
   private final ResponsiveStoreRegistry storeRegistry = new ResponsiveStoreRegistry();
+  private final TTDMockAdmin admin;
 
   private final TTDKeyValueSchema kvSchema;
   private final TTDWindowedSchema windowedSchema;
 
-  public CassandraClientStub(final Properties props, final Time time) {
-    super(new ResponsiveConfig(props));
+  public TTDCassandraClient(final TTDMockAdmin admin, final Time time) {
+    super(new ResponsiveConfig(admin.props()));
     this.time = time;
+    this.admin = admin;
 
     kvSchema = new TTDKeyValueSchema(this);
     windowedSchema = new TTDWindowedSchema(this);
@@ -55,6 +60,10 @@ public class CassandraClientStub extends CassandraClient {
 
   public ResponsiveStoreRegistry storeRegistry() {
     return storeRegistry;
+  }
+
+  public TTDMockAdmin mockAdmin() {
+    return admin;
   }
 
   public void advanceWallClockTime(final Duration advance) {

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/clients/TTDMockAdmin.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/clients/TTDMockAdmin.java
@@ -1,0 +1,77 @@
+package dev.responsive.kafka.clients;
+
+import static org.apache.kafka.streams.TTDUtils.deriveChangelogTopic;
+import static org.apache.kafka.streams.TTDUtils.extractChangelogTopics;
+
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.kafka.clients.admin.MockAdminClient;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.TopicPartitionInfo;
+import org.apache.kafka.common.config.TopicConfig;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.TopologyDescription;
+import org.apache.kafka.streams.TopologyDescription.Processor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TTDMockAdmin extends MockAdminClient {
+  private static final Logger LOG = LoggerFactory.getLogger(TTDMockAdmin.class);
+  private static final Node BROKER = new Node(0, "dummyHost-1", 1234);
+
+  private final Properties props;
+  private final Topology topology;
+  private final Set<String> createdTopics = new HashSet<>();
+
+  public TTDMockAdmin(final Properties props, final Topology topology) {
+    super(Collections.singletonList(BROKER), BROKER);
+    this.props = props;
+    this.topology = topology;
+
+    final List<String> stateStoreNames = new LinkedList<>();
+    final var processors = topology.describe()
+        .subtopologies()
+        .stream().flatMap(s -> s.nodes().stream())
+        .collect(Collectors.toList());
+
+    for (final TopologyDescription.Node node : processors) {
+      if (node instanceof Processor) {
+        stateStoreNames.addAll(((Processor) node).stores());
+      }
+    }
+
+    final String applicationId = props.getProperty(StreamsConfig.APPLICATION_ID_CONFIG);
+
+    for (final String topic : deriveChangelogTopic(applicationId, stateStoreNames)) {
+      addTopic(
+          false,
+          topic,
+          Collections.singletonList(new TopicPartitionInfo(
+              0, BROKER, Collections.emptyList(), Collections.emptyList())
+          ),
+          Collections.singletonMap(
+              TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT)
+      );
+      createdTopics.add(topic);
+    }
+    LOG.debug("Initialized TTD mock admin with changelog topics = [{}]", createdTopics);
+  }
+
+  public Properties props() {
+    return props;
+  }
+
+  public void verifyChangelogTopicCreation() {
+    final Set<String> missingTopics = new HashSet<>(extractChangelogTopics(topology));
+    missingTopics.retainAll(createdTopics);
+    if (!missingTopics.isEmpty()) {
+      LOG.warn("Not all changelog topics were pre-initialized, missing topics=[{}]", missingTopics);
+    }
+  }
+}

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/store/TTDKeyValueSchema.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/store/TTDKeyValueSchema.java
@@ -18,6 +18,7 @@ package dev.responsive.kafka.store;
 
 import com.datastax.oss.driver.api.core.cql.BoundStatement;
 import dev.responsive.db.RemoteKeyValueSchema;
+import dev.responsive.kafka.clients.TTDCassandraClient;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
@@ -29,7 +30,7 @@ public class TTDKeyValueSchema extends TTDSchema<Bytes> implements RemoteKeyValu
 
   private final Map<String, KVStoreStub> tableNameToStore = new HashMap<>();
 
-  public TTDKeyValueSchema(final CassandraClientStub client) {
+  public TTDKeyValueSchema(final TTDCassandraClient client) {
     super(client);
   }
 

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/store/TTDSchema.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/store/TTDSchema.java
@@ -23,16 +23,17 @@ import dev.responsive.db.RemoteSchema;
 import dev.responsive.db.RemoteWriter;
 import dev.responsive.db.WriterFactory;
 import dev.responsive.db.partitioning.SubPartitioner;
+import dev.responsive.kafka.clients.TTDCassandraClient;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import org.apache.kafka.common.utils.Time;
 
 public abstract class TTDSchema<K> implements RemoteSchema<K> {
 
-  private final CassandraClientStub client;
+  private final TTDCassandraClient client;
   protected final Time time;
 
-  public TTDSchema(final CassandraClientStub client) {
+  public TTDSchema(final TTDCassandraClient client) {
     this.client = client;
     this.time = client.time();
   }

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/store/TTDWindowedSchema.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/store/TTDWindowedSchema.java
@@ -18,6 +18,7 @@ package dev.responsive.kafka.store;
 
 import com.datastax.oss.driver.api.core.cql.BoundStatement;
 import dev.responsive.db.RemoteWindowedSchema;
+import dev.responsive.kafka.clients.TTDCassandraClient;
 import dev.responsive.model.Stamped;
 import java.time.Duration;
 import java.util.HashMap;
@@ -30,7 +31,7 @@ public class TTDWindowedSchema extends TTDSchema<Stamped<Bytes>> implements Remo
 
   private final Map<String, WindowStoreStub> tableNameToStore = new HashMap<>();
 
-  public TTDWindowedSchema(final CassandraClientStub client) {
+  public TTDWindowedSchema(final TTDCassandraClient client) {
     super(client);
   }
 

--- a/responsive-test-utils/src/main/java/org/apache/kafka/streams/TTDUtils.java
+++ b/responsive-test-utils/src/main/java/org/apache/kafka/streams/TTDUtils.java
@@ -1,0 +1,38 @@
+package org.apache.kafka.streams;
+
+import static org.apache.kafka.streams.processor.internals.ProcessorStateManager.storeChangelogTopic;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * A utility class that lives in the o.a.k.streams package so we can access
+ * internal topology metadata such as topics
+ */
+public final class TTDUtils {
+
+  /**
+   * @param appId the application id
+   * @param stores the list of state store names for which to derive changelog topic names
+   * @return the set of expected changelog topics computed for the provided state store names
+   */
+  public static Set<String> deriveChangelogTopic(final String appId, final List<String> stores) {
+    return stores
+        .stream()
+        .map(s -> storeChangelogTopic(appId, s, null))
+        .collect(Collectors.toSet());
+  }
+
+  /**
+   * @param topology a compiled topology (must have already been initialized by the TTD/app)
+   * @return the set of actual changelog topics belonging to all state stores in this topology
+   */
+  public static Set<String> extractChangelogTopics(final Topology topology) {
+    return topology.internalTopologyBuilder
+        .subtopologyToTopicsInfo().values()
+        .stream()
+        .flatMap(t -> t.stateChangelogTopics.keySet().stream())
+        .collect(Collectors.toSet());
+  }
+}

--- a/responsive-test-utils/src/test/java/dev/responsive/kafka/api/ResponsiveTopologyTestDriverTest.java
+++ b/responsive-test-utils/src/test/java/dev/responsive/kafka/api/ResponsiveTopologyTestDriverTest.java
@@ -16,6 +16,7 @@
 
 package dev.responsive.kafka.api;
 
+import dev.responsive.kafka.store.SchemaType;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
@@ -34,13 +35,22 @@ import org.apache.kafka.streams.kstream.KTable;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 public class ResponsiveTopologyTestDriverTest {
 
-  @Test
-  public void shouldRunTimestampedKVWithoutResponsiveConnection() {
+  private static ResponsiveKeyValueParams paramsForType(final SchemaType type) {
+    return type == SchemaType.KEY_VALUE
+        ? ResponsiveKeyValueParams.keyValue("people")
+        : ResponsiveKeyValueParams.fact("people");
+  }
+
+  @ParameterizedTest
+  @EnumSource(SchemaType.class)
+  public void shouldRunAllKVStoreTypesWithoutResponsiveConnection(final SchemaType type) {
     // Given:
-    final TopologyTestDriver driver = setupDriver(ResponsiveKeyValueParams.timestamped("people"));
+    final TopologyTestDriver driver = setupDriver(paramsForType(type));
 
     final TestInputTopic<String, String> bids = driver.createInputTopic(
         "bids", new StringSerializer(), new StringSerializer());
@@ -69,12 +79,13 @@ public class ResponsiveTopologyTestDriverTest {
     driver.close();
   }
 
-  @Test
-  public void shouldRunTtlKVWithoutResponsiveConnection() {
+  @ParameterizedTest
+  @EnumSource(SchemaType.class)
+  public void shouldRunAllKVStoresWithTtlWithoutResponsiveConnection(final SchemaType type) {
     // Given:
     final Duration ttl = Duration.ofMillis(15);
     final TopologyTestDriver driver = setupDriver(
-        ResponsiveKeyValueParams.timestamped("people").withTimeToLive(ttl)
+        paramsForType(type).withTimeToLive(ttl)
     );
 
     final TestInputTopic<String, String> bids = driver.createInputTopic(


### PR DESCRIPTION
The main fix here is in how we "create" topics within the MockAdmin used by the RTTD. Because no real topics are created in the TTD context, everything has to mock its own internal view of the "cluster" which in the admin case, means making sure that it adds any topics that we will later make requests for. For us, this is just changelogs (and should generally only ever be changelogs, as the input topics are completely abstracted away by the TTD entirely including everything like the KafkaClientSupplier)

Before this, we would lazily create topics when requested for in the #describeTopics API. However for FACT tables we skip this particular call, and so incur an error when we next hit the mock admin in the #describeConfigs call.

The fix is to remove any topic-creation inside Admin overrides (since this is extremely fragile and relies on us either overriding every method that is ever added to it or else being super diligent about keeping the TTDMockAdmin up to date with any admin calls ever added to our codebase). Instead, we pass in the appId and topology to the TTDMockAdmin's constructor so that it can derive the changelog topic names from the list of state store names, and add everything up front. Note that we can't get a handle on the changelog topic names directly until after the topology is initialized, and unfortunately this does not occur until we're already inside the TopologyTestDriver constructor, where the exception in this bug originates.

However, as a bit of an added safety measure, I also added a check after we exit the TTD constructor and can make sure that all the changelogs were created as expected. This doesn't really do much, but it'll be nice to have as a warning in case something does change that invalidates any assumption in this fix