### PR TITLE
Extract AWS/ECR login steps to separate Github action

### DIFF
--- a/.github/actions/ecr-login/action.yaml
+++ b/.github/actions/ecr-login/action.yaml
@@ -1,0 +1,39 @@
+name: 'ECR Login'
+description: "Configure AWS credentials and log in to ECR"
+inputs:
+  role-to-assume:
+    default: arn:aws:iam::292505934682:role/github-responsive-pub-main
+    required: false
+    description: "the role to assume"
+  role-session-name:
+    required: true
+    description: "the name of the session"
+  aws-region:
+    required: true
+    description: "the region (generally us-east-1 or us-west-2)"
+  public:
+    default: "false"
+    required: false
+    description: "whether to set registry-type: public (true/false)"
+
+runs:
+  using: composite
+  steps:
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v2
+      with:
+        role-to-assume: ${{ inputs.role-to-assume }}
+        role-session-name: ${{ inputs.role-session-name }}
+        aws-region: ${{ inputs.role-to-assume }}
+
+    - name: Login to Amazon ECR
+      if: ${{ inputs.public == 'false' }}
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
+
+    - name: Login to Amazon ECR (public)
+      if: ${{ inputs.public == 'true' }}
+      id: login-ecr-public
+      uses: aws-actions/amazon-ecr-login@v1
+      with:
+        registry-type: public

--- a/.github/workflows/github-main.yaml
+++ b/.github/workflows/github-main.yaml
@@ -21,68 +21,58 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
 
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+      - name: "Login to AWS & ECR"
+        uses: ./.github/actions/ecr-login
         with:
-          role-to-assume: arn:aws:iam::292505934682:role/github-responsive-pub-main
           role-session-name: github-publish-artifacts
           aws-region: us-east-1
+          public: "true"
 
-      - name: Login to Amazon ECR
-        id: login-ecr-public
-        uses: aws-actions/amazon-ecr-login@v1
-        with:
-          registry-type: public
-
-      - name: Setup Gradle
+      - name: "Setup Gradle"
         uses: gradle/gradle-build-action@v2
         with:
           arguments: build
 
-      - name: Publish
+      - name: "Publish"
         uses: gradle/gradle-build-action@v2
         with:
           arguments: publishMavenJavaPublicationToS3Repository # publish only to S3
         if: github.ref == 'refs/heads/main'
 
       # We need this to emulate other architectures for multi-platform docker builds
-      - name: Set up QEMU for Docker
+      - name: "Set up QEMU for Docker"
         uses: docker/setup-qemu-action@v2
 
       # We use the build extensions to do multi-architecture docker builds
-      - name: Set up Docker Buildx
+      - name: "Set up Docker Buildx"
         uses: docker/setup-buildx-action@v2
 
-      - name: Publish Images
+      - name: "Publish Images"
         uses: gradle/gradle-build-action@v2
         with:
           arguments: pushCRD pushDockerMultiArch pushHelm -PdockerRegistry=${{ steps.login-ecr-public.outputs.registry }}/j8q9y0n6 -PhelmRegistry=${{ steps.login-ecr-public.outputs.registry }}/j8q9y0n6
         #if: github.ref == 'refs/heads/main'
 
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
+      - name: "Login to AWS & ECR"
+        uses: ./.github/actions/ecr-login
         with:
-          role-to-assume: arn:aws:iam::292505934682:role/github-responsive-pub-main
           role-session-name: github-publish-artifacts
           aws-region: us-west-2
 
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
-
-      - uses: actions/checkout@v3
+      - name: "Checkout sindri"
+        uses: actions/checkout@v3
         with:
           repository: responsivedev/sindri
           path: sindri
           ref: refs/heads/master
           token: ${{ secrets.TOOLS_GHA_TOKEN }}
 
-      - name: Install Kind
+      - name: "Install Kind"
         uses: helm/kind-action@v1.5.0
         with:
             install_only: true
 
-      - name: Run Smoke Test
+      - name: "Run Smoke Test"
         run: |
           sindri/scripts/update-client-versions -s master -p true -i public.ecr.aws/j8q9y0n6/responsiveinc/simple-example -t `./gradlew kafka-client:cV  | grep "Project version" | sed 's/Project version: //'`
           sindri/scripts/run-smoke-test -s master -w system-tests-pub
@@ -91,7 +81,7 @@ jobs:
             DD_API_KEY: ${{ secrets.DD_API_KEY }}
             PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
 
-      - name: Push next pub version to Sindri
+      - name: "Push next pub version to Sindri"
         working-directory: sindri
         run: |
           git config --global user.name 'Responsive Tools'

--- a/.github/workflows/github-pr.yaml
+++ b/.github/workflows/github-pr.yaml
@@ -20,25 +20,13 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
 
-      - name: Configure AWS Credentials for Public ECR Login
-        uses: aws-actions/configure-aws-credentials@v2
+      - name: "Login to AWS & ECR"
+        uses: ./.github/actions/ecr-login
         with:
           role-to-assume: arn:aws:iam::292505934682:role/github-responsivedev-org
           role-session-name: github-publish-artifacts
           aws-region: us-east-1
-
-      - name: Login to Amazon ECR Public
-        id: login-ecr-public
-        uses: aws-actions/amazon-ecr-login@v1
-        with:
-          registry-type: public
-
-      - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          role-to-assume: arn:aws:iam::292505934682:role/github-responsivedev-org
-          role-session-name: github-pr-builder
-          aws-region: us-west-2
+          public: "true"
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
@@ -53,9 +41,12 @@ jobs:
           ref: refs/heads/master
           token: ${{ secrets.TOOLS_GHA_TOKEN }}
 
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+      - name: "Login to AWS & ECR"
+        uses: ./.github/actions/ecr-login
+        with:
+          role-to-assume: arn:aws:iam::292505934682:role/github-responsivedev-org
+          role-session-name: github-pr-builder
+          aws-region: us-west-2
 
       - name: Install Kind
         uses: helm/kind-action@v1.5.0

--- a/.github/workflows/github-publish.yaml
+++ b/.github/workflows/github-publish.yaml
@@ -28,18 +28,26 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
 
+<<<<<<< Updated upstream
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
+=======
+      - name: "Login to AWS & ECR"
+        uses: ./.github/actions/ecr-login
+>>>>>>> Stashed changes
         with:
-          role-to-assume: arn:aws:iam::292505934682:role/github-responsive-pub-main
           role-session-name: github-publish-artifacts
           aws-region: us-east-1
+<<<<<<< Updated upstream
 
       - name: Login to Amazon ECR
         id: login-ecr-public
         uses: aws-actions/amazon-ecr-login@v1
         with:
           registry-type: public
+=======
+          public: "true"
+>>>>>>> Stashed changes
 
       - name: Build & Test
         uses: gradle/gradle-build-action@v2
@@ -97,18 +105,26 @@ jobs:
         with:
             install_only: true
 
+<<<<<<< Updated upstream
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v2
+=======
+      - name: "Login to AWS & ECR"
+        uses: ./.github/actions/ecr-login
+>>>>>>> Stashed changes
         with:
-          role-to-assume: arn:aws:iam::292505934682:role/github-responsive-pub-main
           role-session-name: github-publish-artifacts
           aws-region: us-west-2
 
+<<<<<<< Updated upstream
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
       - name: Set Operator Version
+=======
+      - name: 'Set Operator Version'
+>>>>>>> Stashed changes
         run: |
           echo "OPERATOR_VERSION=$(./gradlew operator:cV | grep Project.version | sed 's/Project version: //')" >> $GITHUB_ENV
 


### PR DESCRIPTION
While introducing some actions to tackle the module groups/versioning stuff, I happened to notice that there are quite a few other kinds of highly repetitive procedures within our three workflows. It would be nice to extract as much of these as possible into separate actions that can be called from workflow jobs, whether new or while updating the existing ones.

Should also help to make the workflows a bit easier to read/comprehend