### PR TITLE
Cache partition counts for sub-partitioner and set definitions/naming conventions

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/api/CassandraClientFactory.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/CassandraClientFactory.java
@@ -3,12 +3,14 @@ package dev.responsive.kafka.api;
 import com.datastax.oss.driver.api.core.CqlSession;
 import dev.responsive.db.CassandraClient;
 import dev.responsive.kafka.config.ResponsiveConfig;
+import org.apache.kafka.clients.admin.Admin;
 
 public interface CassandraClientFactory {
   CqlSession createCqlSession(ResponsiveConfig config);
 
   CassandraClient createCassandraClient(
       CqlSession session,
-      final ResponsiveConfig responsiveConfigs
+      ResponsiveConfig responsiveConfigs,
+      Admin admin
   );
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/DefaultCassandraClientFactory.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/DefaultCassandraClientFactory.java
@@ -13,6 +13,7 @@ import dev.responsive.db.CassandraClient;
 import dev.responsive.kafka.config.ResponsiveConfig;
 import dev.responsive.utils.SessionUtil;
 import java.net.InetSocketAddress;
+import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.common.config.types.Password;
 
 public class DefaultCassandraClientFactory implements CassandraClientFactory {
@@ -41,8 +42,9 @@ public class DefaultCassandraClientFactory implements CassandraClientFactory {
   @Override
   public CassandraClient createCassandraClient(
       final CqlSession session,
-      final ResponsiveConfig responsiveConfigs
+      final ResponsiveConfig responsiveConfigs,
+      final Admin admin
   ) {
-    return new CassandraClient(session, responsiveConfigs);
+    return new CassandraClient(session, responsiveConfigs, admin);
   }
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveKafkaStreams.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveKafkaStreams.java
@@ -124,7 +124,7 @@ public class ResponsiveKafkaStreams extends KafkaStreams {
         topology,
         verifiedStreamsConfigs(
             configs,
-            cassandraClientFactory.createCassandraClient(session, responsiveConfigs),
+            cassandraClientFactory.createCassandraClient(session, responsiveConfigs, admin),
             admin,
             executor,
             storeRegistry,

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsivePartitionedStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsivePartitionedStore.java
@@ -118,7 +118,7 @@ public class ResponsivePartitionedStore implements KeyValueStore<Bytes, byte[]> 
       );
       partitioner = params.schemaType() == SchemaType.FACT
           ? SubPartitioner.NO_SUBPARTITIONS
-          : config.getSubPartitioner(sharedClients.admin, name, topicPartition.topic());
+          : config.getSubPartitioner(client, name, topicPartition.topic());
 
       buffer = CommitBuffer.from(
           sharedClients,

--- a/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveWindowStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/store/ResponsiveWindowStore.java
@@ -151,7 +151,10 @@ public class ResponsiveWindowStore implements WindowStore<Bytes, byte[]> {
           partition
       );
       partitioner = config.getSubPartitioner(
-          sharedClients.admin, name, topicPartition.topic());
+          client,
+          name,
+          topicPartition.topic()
+      );
 
       buffer = CommitBuffer.from(
           sharedClients,

--- a/kafka-client/src/main/java/dev/responsive/utils/CachedMetadata.java
+++ b/kafka-client/src/main/java/dev/responsive/utils/CachedMetadata.java
@@ -1,0 +1,68 @@
+package dev.responsive.utils;
+
+import static dev.responsive.db.ColumnName.PARTITION_KEY;
+
+import com.datastax.oss.driver.api.core.cql.ResultSet;
+import dev.responsive.db.CassandraClient;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.OptionalInt;
+import java.util.concurrent.ExecutionException;
+import org.apache.kafka.clients.admin.Admin;
+
+/**
+ * Use this any time we need to repeatedly look up metadata that doesn't change, so we can
+ * cache the results rather than make admin/client requests every single time
+ */
+public class CachedMetadata {
+
+  private final Admin admin;
+  private final CassandraClient client;
+
+  private final Map<String, Integer> changelogToKafkaPartitionCount = new HashMap<>();
+  private final Map<String, OptionalInt> tableToSubPartitionCount = new HashMap<>();
+
+  public CachedMetadata(final Admin admin, final CassandraClient client) {
+    this.admin = admin;
+    this.client = client;
+  }
+
+  public int kafkaPartitionCount(final String changelogTopicName) {
+    if (changelogToKafkaPartitionCount.containsKey(changelogTopicName)) {
+      return changelogToKafkaPartitionCount.get(changelogTopicName);
+    } else {
+      try {
+        final int partitionCount = admin.describeTopics(List.of(changelogTopicName))
+            .allTopicNames()
+            .get()
+            .get(changelogTopicName)
+            .partitions()
+            .size();
+        changelogToKafkaPartitionCount.put(changelogTopicName, partitionCount);
+        return partitionCount;
+      } catch (InterruptedException | ExecutionException e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+
+  public OptionalInt subPartitionCount(final String tableName) {
+    if (tableToSubPartitionCount.containsKey(tableName)) {
+      return tableToSubPartitionCount.get(tableName);
+    } else {
+
+      // TODO: is it faster to just write the actual remote partition count into cassandra?
+      final ResultSet result = client.execute(
+          String.format("SELECT DISTINCT %s FROM %s;", PARTITION_KEY.column(), tableName));
+
+      final int numPartitions = result.all().size();
+      final OptionalInt subPartitionCount = numPartitions == 0
+          ? OptionalInt.empty()
+          : OptionalInt.of(numPartitions);
+
+      tableToSubPartitionCount.put(tableName, subPartitionCount);
+      return subPartitionCount;
+    }
+  }
+}

--- a/kafka-client/src/test/java/dev/responsive/db/CassandraClientTest.java
+++ b/kafka-client/src/test/java/dev/responsive/db/CassandraClientTest.java
@@ -24,6 +24,7 @@ import com.datastax.oss.driver.api.core.cql.SimpleStatement;
 import com.datastax.oss.driver.api.core.cql.Statement;
 import dev.responsive.kafka.config.ResponsiveConfig;
 import java.util.Map;
+import org.apache.kafka.clients.admin.Admin;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -37,6 +38,8 @@ class CassandraClientTest {
 
   @Mock
   private CqlSession session;
+  @Mock
+  private Admin admin;
   @Captor
   private ArgumentCaptor<Statement<?>> statementCaptor;
 
@@ -49,7 +52,8 @@ class CassandraClientTest {
             ResponsiveConfig.TENANT_ID_CONFIG, "ignored",
             ResponsiveConfig.STORAGE_HOSTNAME_CONFIG, "ignored",
             ResponsiveConfig.STORAGE_PORT_CONFIG, 0
-        ))
+        )),
+        admin
     );
     when(session.execute(statementCaptor.capture())).thenReturn(null);
 

--- a/kafka-client/src/test/java/dev/responsive/db/CassandraFactSchemaIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/db/CassandraFactSchemaIntegrationTest.java
@@ -32,11 +32,13 @@ import dev.responsive.utils.ResponsiveExtension;
 import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
+import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.common.utils.Bytes;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.testcontainers.containers.CassandraContainer;
 
 @ExtendWith(ResponsiveExtension.class)
@@ -44,6 +46,9 @@ class CassandraFactSchemaIntegrationTest {
 
   private static final long CURRENT_TIME = 100L;
   private static final long MIN_VALID_TS = 0L;
+
+  @Mock
+  private Admin admin;
 
   private String storeName;
   private CassandraClient client;
@@ -63,7 +68,7 @@ class CassandraFactSchemaIntegrationTest {
         .withLocalDatacenter(cassandra.getLocalDatacenter())
         .withKeyspace("responsive_clients") // NOTE: this keyspace is expected to exist
         .build();
-    client = new CassandraClient(session, new ResponsiveConfig(responsiveProps));
+    client = new CassandraClient(session, new ResponsiveConfig(responsiveProps), admin);
   }
 
   @Test

--- a/kafka-client/src/test/java/dev/responsive/db/KeyValueSchemaIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/db/KeyValueSchemaIntegrationTest.java
@@ -24,6 +24,7 @@ import dev.responsive.utils.ResponsiveExtension;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.hamcrest.MatcherAssert;
@@ -32,6 +33,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
 import org.testcontainers.containers.CassandraContainer;
 
 @ExtendWith(ResponsiveExtension.class)
@@ -39,6 +41,9 @@ public class KeyValueSchemaIntegrationTest {
 
   private static final long CURRENT_TS = 100L;
   private static final long MIN_VALID_TS = 0L;
+
+  @Mock
+  private Admin admin;
 
   private RemoteKeyValueSchema schema;
   private String name;
@@ -56,7 +61,7 @@ public class KeyValueSchemaIntegrationTest {
         .withLocalDatacenter(cassandra.getLocalDatacenter())
         .withKeyspace("responsive_clients") // NOTE: this keyspace is expected to exist
         .build();
-    client = new CassandraClient(session, config);
+    client = new CassandraClient(session, config, admin);
     schema = new CassandraKeyValueSchema(client);
     name = info.getTestMethod().orElseThrow().getName();
     schema.create(name, Optional.empty());

--- a/kafka-client/src/test/java/dev/responsive/kafka/store/CommitBufferTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/store/CommitBufferTest.java
@@ -102,7 +102,7 @@ public class CommitBufferTest {
         .withLocalDatacenter(cassandra.getLocalDatacenter())
         .withKeyspace("responsive_clients") // NOTE: this keyspace is expected to exist
         .build();
-    client = new CassandraClient(session, config);
+    client = new CassandraClient(session, config, admin);
     schema = new CassandraKeyValueSchema(client);
     changelogTp = new TopicPartition("log", KAFKA_PARTITION);
     partitioner = SubPartitioner.NO_SUBPARTITIONS;

--- a/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsivePartitionedStoreRestoreIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsivePartitionedStoreRestoreIntegrationTest.java
@@ -173,7 +173,8 @@ public class ResponsivePartitionedStoreRestoreIntegrationTest {
       final ResponsiveConfig config = new ResponsiveConfig(properties);
       final CassandraClient cassandraClient = defaultFactory.createCassandraClient(
           defaultFactory.createCqlSession(config),
-          config
+          config,
+          admin
       );
       final RemoteKeyValueSchema statements = cassandraClient.kvSchema(type);
       statements.prepare(aggName());
@@ -232,7 +233,9 @@ public class ResponsivePartitionedStoreRestoreIntegrationTest {
     final ResponsiveConfig config = new ResponsiveConfig(properties);
     final CassandraClient cassandraClient = defaultFactory.createCassandraClient(
         defaultFactory.createCqlSession(config),
-        config);
+        config,
+        admin
+    );
     final RemoteKeyValueSchema statements = cassandraClient.kvSchema(type);
     statements.prepare(aggName());
     final long cassandraOffset = statements.metadata(aggName(), 0).offset;
@@ -403,10 +406,11 @@ public class ResponsivePartitionedStoreRestoreIntegrationTest {
 
     @Override
     public CassandraClient createCassandraClient(
-        CqlSession session,
-        final ResponsiveConfig responsiveConfigs
+        final CqlSession session,
+        final ResponsiveConfig responsiveConfigs,
+        final Admin admin
     ) {
-      return wrappedFactory.createCassandraClient(session, responsiveConfigs);
+      return wrappedFactory.createCassandraClient(session, responsiveConfigs, admin);
     }
   }
 

--- a/kafka-client/src/test/java/dev/responsive/kafka/store/SubPartitionIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/store/SubPartitionIntegrationTest.java
@@ -124,7 +124,7 @@ public class SubPartitionIntegrationTest {
         .withLocalDatacenter(cassandra.getLocalDatacenter())
         .withKeyspace("responsive_clients") // NOTE: this keyspace is expected to exist
         .build();
-    client = new CassandraClient(session, new ResponsiveConfig(responsiveProps));
+    client = new CassandraClient(session, new ResponsiveConfig(responsiveProps), admin);
   }
 
   @AfterEach
@@ -166,7 +166,7 @@ public class SubPartitionIntegrationTest {
       final RemoteKeyValueSchema schema = new CassandraKeyValueSchema(client);
       schema.prepare(cassandraName);
 
-      assertThat(client.numPartitions(cassandraName), is(OptionalInt.of(32)));
+      assertThat(client.numSubPartitions(cassandraName), is(OptionalInt.of(32)));
       assertThat(client.count(cassandraName, 0), is(2L));
       assertThat(client.count(cassandraName, 16), is(2L));
 

--- a/responsive-test-utils/build.gradle.kts
+++ b/responsive-test-utils/build.gradle.kts
@@ -21,11 +21,7 @@ plugins {
 version = project(":kafka-client").version
 
 dependencies {
-    // TODO: we should make sure to fail the release of kafka-client
-    // if we don't bump this up - or have some other mechanism to
-    // ensure they are released in tandem - otherwise it is possible
-    // that the latest release of kafka-client will be untestable
-    implementation("dev.responsive:kafka-client:0.7.1")
+    implementation(project(":kafka-client"))
 
     implementation(libs.bundles.scylla)
     implementation(libs.kafka.streams.test.utils)

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/clients/TTDCassandraClient.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/clients/TTDCassandraClient.java
@@ -46,7 +46,7 @@ public class TTDCassandraClient extends CassandraClient {
   private final TTDWindowedSchema windowedSchema;
 
   public TTDCassandraClient(final TTDMockAdmin admin, final Time time) {
-    super(new ResponsiveConfig(admin.props()));
+    super(new ResponsiveConfig(admin.props()), admin);
     this.time = time;
     this.admin = admin;
 
@@ -112,8 +112,13 @@ public class TTDCassandraClient extends CassandraClient {
   }
 
   @Override
-  public OptionalInt numPartitions(final String tableName) {
+  public OptionalInt numSubPartitions(final String tableName) {
     return OptionalInt.of(1);
+  }
+
+  @Override
+  public int numKafkaPartitions(final String changelogTopic) {
+    return 1;
   }
 
   @Override


### PR DESCRIPTION
The main change here is the introduction of the `CachedMetadata` class, which as the name suggests caches some of the nontrivial repeated requests for things like the number of kafka partitions or sub-partitions in Cassandra. Also cleans up the sub-partitioner and related APIs a bit, mainly with regards to naming. We should try to stick to the conventions outlined in the SubPartitioner javadocs, as it gets a bit confusing to keep track of which "partition" is being referred to when.

This is related to the refactoring I need for the window store implementation, but  indirectly enough that it makes sense to pull out into its own patch. 