### PR TITLE
Convert to pure ResponsiveKafkaStreams constructor setup

### DIFF
--- a/kafka-client-examples/simple-example/src/main/java/dev/responsive/examples/simpleapp/SimpleApplication.java
+++ b/kafka-client-examples/simple-example/src/main/java/dev/responsive/examples/simpleapp/SimpleApplication.java
@@ -106,7 +106,7 @@ public class SimpleApplication {
     counts.toStream().to(source + "-counts", Produced.with(Serdes.ByteArray(), Serdes.Long()));
     final Properties properties = new Properties();
     properties.putAll(rawCfg);
-    return ResponsiveKafkaStreams.create(builder.build(properties), properties);
+    return new ResponsiveKafkaStreams(builder.build(properties), properties);
   }
 
   private void maybeCreateTopics() {

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveKafkaStreams.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveKafkaStreams.java
@@ -55,8 +55,7 @@ public class ResponsiveKafkaStreams extends KafkaStreams {
     return create(
         topology,
         configs,
-        new DefaultKafkaClientSupplier(),
-        new DefaultCassandraClientFactory()
+        new DefaultKafkaClientSupplier()
     );
   }
 
@@ -65,7 +64,7 @@ public class ResponsiveKafkaStreams extends KafkaStreams {
       final Map<?, ?> configs,
       final KafkaClientSupplier clientSupplier
   ) {
-    return create(
+    return connect(
         topology,
         configs,
         clientSupplier,
@@ -73,26 +72,12 @@ public class ResponsiveKafkaStreams extends KafkaStreams {
     );
   }
 
-  public static ResponsiveKafkaStreams create(
+  @SuppressWarnings("unchecked")
+  static ResponsiveKafkaStreams connect(
       final Topology topology,
       final Map<?, ?> configs,
       final KafkaClientSupplier clientSupplier,
       final CassandraClientFactory cassandraClientFactory
-  ) {
-    return connect(
-        topology,
-        configs,
-        cassandraClientFactory,
-        clientSupplier
-    );
-  }
-
-  @SuppressWarnings("unchecked")
-  private static ResponsiveKafkaStreams connect(
-      final Topology topology,
-      final Map<?, ?> configs,
-      final CassandraClientFactory cassandraClientFactory,
-      final KafkaClientSupplier clientSupplier
   ) {
     for (Map.Entry<?, ?> entry : configs.entrySet()) {
       if (!(entry.getKey() instanceof String)) {

--- a/kafka-client/src/test/java/dev/responsive/kafka/api/ResponsivePartitionedStoreRestoreIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/api/ResponsivePartitionedStoreRestoreIntegrationTest.java
@@ -92,6 +92,7 @@ import org.apache.kafka.common.serialization.LongSerializer;
 import org.apache.kafka.common.serialization.Serdes.LongSerde;
 import org.apache.kafka.streams.KafkaClientSupplier;
 import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.kstream.KStream;
 import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier;
@@ -340,9 +341,10 @@ public class ResponsivePartitionedStoreRestoreIntegrationTest {
 
     final Properties builderProperties = new Properties();
     builderProperties.putAll(properties);
-    return ResponsiveKafkaStreams.connect(
+    return new ResponsiveKafkaStreams(
         builder.build(builderProperties),
-        properties,
+        ResponsiveConfig.loggedConfig(properties),
+        new StreamsConfig(properties),
         clientSupplier,
         cassandraClientFactory
     );

--- a/kafka-client/src/test/java/dev/responsive/kafka/api/ResponsivePartitionedStoreRestoreIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/api/ResponsivePartitionedStoreRestoreIntegrationTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package dev.responsive.kafka.store;
+package dev.responsive.kafka.api;
 
 import static dev.responsive.utils.IntegrationTestUtils.getCassandraValidName;
 import static dev.responsive.utils.IntegrationTestUtils.pipeInput;
@@ -52,11 +52,6 @@ import com.datastax.oss.driver.api.core.cql.BatchStatement;
 import com.datastax.oss.driver.api.core.cql.Statement;
 import dev.responsive.db.CassandraClient;
 import dev.responsive.db.RemoteKeyValueSchema;
-import dev.responsive.kafka.api.CassandraClientFactory;
-import dev.responsive.kafka.api.DefaultCassandraClientFactory;
-import dev.responsive.kafka.api.ResponsiveKafkaStreams;
-import dev.responsive.kafka.api.ResponsiveKeyValueParams;
-import dev.responsive.kafka.api.ResponsiveStores;
 import dev.responsive.kafka.config.ResponsiveConfig;
 import dev.responsive.kafka.store.SchemaTypes.KVSchema;
 import dev.responsive.utils.IntegrationTestUtils;
@@ -345,7 +340,7 @@ public class ResponsivePartitionedStoreRestoreIntegrationTest {
 
     final Properties builderProperties = new Properties();
     builderProperties.putAll(properties);
-    return ResponsiveKafkaStreams.create(
+    return ResponsiveKafkaStreams.connect(
         builder.build(builderProperties),
         properties,
         clientSupplier,

--- a/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsiveGlobalStoreIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsiveGlobalStoreIntegrationTest.java
@@ -152,7 +152,7 @@ public class ResponsiveGlobalStoreIntegrationTest {
     final KStream<Long, Long> stream = builder.stream(INPUT_TOPIC);
     stream.join(globalTable, (k, v) -> k, Long::sum).to(OUTPUT_TOPIC);
 
-    return ResponsiveKafkaStreams.create(builder.build(), properties);
+    return new ResponsiveKafkaStreams(builder.build(), properties);
   }
 
 }

--- a/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsivePartitionedStoreEosIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsivePartitionedStoreEosIntegrationTest.java
@@ -275,7 +275,7 @@ public class ResponsivePartitionedStoreEosIntegrationTest {
         .process(() -> new TestProcessor(instance, state, name), name)
         .to(outputTopic());
 
-    return ResponsiveKafkaStreams.create(builder.build(), properties);
+    return new ResponsiveKafkaStreams(builder.build(), properties);
   }
 
   private static class SharedState {

--- a/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsiveWindowIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/store/ResponsiveWindowIntegrationTest.java
@@ -183,7 +183,7 @@ public class ResponsiveWindowIntegrationTest {
     properties.put(APPLICATION_SERVER_CONFIG, "host1:1024");
     try (
         final ResponsiveKafkaStreams kafkaStreams =
-            ResponsiveKafkaStreams.create(builder.build(), properties);
+            new ResponsiveKafkaStreams(builder.build(), properties);
         final KafkaProducer<Long, Long> producer = new KafkaProducer<>(properties)
     ) {
       kafkaStreams.start();
@@ -202,7 +202,7 @@ public class ResponsiveWindowIntegrationTest {
     // the old Kafka Streams and creating a new one
     properties.put(APPLICATION_SERVER_CONFIG, "host2:1024");
     try (
-        final ResponsiveKafkaStreams kafkaStreams = ResponsiveKafkaStreams.create(
+        final ResponsiveKafkaStreams kafkaStreams = new ResponsiveKafkaStreams(
             builder.build(),
             properties
         );
@@ -282,7 +282,7 @@ public class ResponsiveWindowIntegrationTest {
     final AtomicLong timestamp = new AtomicLong(baseTs);
     properties.put(APPLICATION_SERVER_CONFIG, "host1:1024");
     try (
-        final ResponsiveKafkaStreams kafkaStreams = ResponsiveKafkaStreams.create(
+        final ResponsiveKafkaStreams kafkaStreams = new ResponsiveKafkaStreams(
             builder.build(), properties
         );
         final KafkaProducer<Long, Long> producer = new KafkaProducer<>(properties)
@@ -302,7 +302,7 @@ public class ResponsiveWindowIntegrationTest {
     properties.put(APPLICATION_SERVER_CONFIG, "host2:1024");
     try (
         final ResponsiveKafkaStreams kafkaStreams =
-            ResponsiveKafkaStreams.create(builder.build(), properties);
+            new ResponsiveKafkaStreams(builder.build(), properties);
         final KafkaProducer<Long, Long> producer = new KafkaProducer<>(properties)
     ) {
       kafkaStreams.start();

--- a/kafka-client/src/test/java/dev/responsive/kafka/store/SubPartitionIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/store/SubPartitionIntegrationTest.java
@@ -139,7 +139,7 @@ public class SubPartitionIntegrationTest {
     final KafkaProducer<Long, Long> producer = new KafkaProducer<>(properties);
 
     try (
-        final var streams = ResponsiveKafkaStreams.create(
+        final var streams = new ResponsiveKafkaStreams(
             simpleDslTopology(ResponsiveStores.materialized(
                 ResponsiveKeyValueParams.timestamped(storeName))), properties);
         final var serializer = new LongSerializer();
@@ -193,7 +193,7 @@ public class SubPartitionIntegrationTest {
     final KafkaProducer<Long, Long> producer = new KafkaProducer<>(properties);
 
     try (
-        final var streams = ResponsiveKafkaStreams.create(
+        final var streams = new ResponsiveKafkaStreams(
             simpleDslTopology(new ResponsiveMaterialized<>(
                 Materialized.as(ResponsiveStores.factStore(storeName)),
                 false


### PR DESCRIPTION
This PR changes the way applications are created from the somewhat awkward static `ResponsiveKafkaStreams.connect` constructors, to something that is fully analogous with vanilla KafkaStreams basic constructors (and thus easily migrated via find-and-replace).

It was a huge hassle and takes a really long sequence of constructors with iterative parameters, but it was worth it I think.
I did leave in the one static constructor that I believe is currently being used, and will remove it in a separate PR I have planned with other changes that will break our current user's code and need to be updated, so we can do that when everyone is ready