### PR TITLE
Finalize ResponsiveKafkaStreams API and clean up StreamsConfig

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveKafkaStreams.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveKafkaStreams.java
@@ -52,6 +52,18 @@ public class ResponsiveKafkaStreams extends KafkaStreams {
     return new ResponsiveKafkaStreams(topology, configs);
   }
 
+  /**
+   * Create a {@code ResponsiveKafkaStreams} instance.
+   * <p>
+   * Should be used in exactly the same way as the regular {@link KafkaStreams}.
+   * <p>
+   * Note: even if you never call {@link #start()} on a {@code ResponsiveKafkaStreams} instance,
+   * you still must {@link #close()} it to avoid resource leaks.
+   *
+   * @param topology       the topology specifying the computational logic
+   * @param configs        map with all {@link ResponsiveConfig} and {@link StreamsConfig} props
+   * @throws StreamsException if any fatal error occurs
+   */
   public ResponsiveKafkaStreams(
       final Topology topology,
       final Map<?, ?> configs
@@ -60,7 +72,9 @@ public class ResponsiveKafkaStreams extends KafkaStreams {
   }
 
   /**
-   * Create a {@code ResponsiveKafkaStreams} instance
+   * Create a {@code ResponsiveKafkaStreams} instance.
+   * <p>
+   * Should be used in exactly the same way as the regular {@link KafkaStreams}.
    * <p>
    * Note: even if you never call {@link #start()} on a {@code ResponsiveKafkaStreams} instance,
    * you still must {@link #close()} it to avoid resource leaks.
@@ -80,7 +94,9 @@ public class ResponsiveKafkaStreams extends KafkaStreams {
   }
 
   /**
-   * Create a {@code ResponsiveKafkaStreams} instance
+   * Create a {@code ResponsiveKafkaStreams} instance.
+   * <p>
+   * Should be used in exactly the same way as the regular {@link KafkaStreams}.
    * <p>
    * Note: even if you never call {@link #start()} on a {@code ResponsiveKafkaStreams} instance,
    * you still must {@link #close()} it to avoid resource leaks.
@@ -100,6 +116,8 @@ public class ResponsiveKafkaStreams extends KafkaStreams {
 
   /**
    * Create a {@code ResponsiveKafkaStreams} instance.
+   * <p>
+   * Should be used in exactly the same way as the regular {@link KafkaStreams}.
    * <p>
    * Note: even if you never call {@link #start()} on a {@code ResponsiveKafkaStreams} instance,
    * you still must {@link #close()} it to avoid resource leaks.

--- a/kafka-client/src/main/java/dev/responsive/kafka/clients/config/ResponsiveStreamsConfig.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/clients/config/ResponsiveStreamsConfig.java
@@ -1,0 +1,91 @@
+/*
+ *
+ *  * Copyright 2023 Responsive Computing, Inc.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package dev.responsive.kafka.clients.config;
+
+import static dev.responsive.kafka.config.ResponsiveConfig.NUM_STANDBYS_OVERRIDE;
+
+import java.util.Map;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.streams.StreamsConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ResponsiveStreamsConfig extends StreamsConfig {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ResponsiveStreamsConfig.class);
+
+  /**
+   * NOTE: always use this to create instances of {@link StreamsConfig} instead of creating
+   * them directly, to avoid unnecessarily logging the config over and over. The StreamsConfig
+   * will be logged when we invoke the {@link org.apache.kafka.streams.KafkaStreams} constructor,
+   * so we should never log it ourselves.
+   */
+  public static ResponsiveStreamsConfig streamsConfig(final Map<?, ?> props) {
+    return new ResponsiveStreamsConfig(props, false);
+  }
+
+  public static void validateStreamsConfig(final StreamsConfig streamsConfig) {
+    verifyNoStandbys(streamsConfig);
+    verifyNotEosV1(streamsConfig);
+    verifyTopologyOptimizationConfig(streamsConfig);
+  }
+
+  static void verifyNoStandbys(final StreamsConfig config) throws ConfigException {
+    // In this case the default and our desired value are both 0, so we only need to check for
+    // accidental user overrides
+    final int numStandbys = config.getInt(StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG);
+    if (numStandbys != 0) {
+      final String errorMsg = String.format(
+          "Invalid Streams configuration value for '%s': got %d, expected '%d'",
+          StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG,
+          numStandbys,
+          NUM_STANDBYS_OVERRIDE
+      );
+      LOG.error(errorMsg);
+      throw new ConfigException(errorMsg);
+    }
+  }
+
+  @SuppressWarnings("deprecation")
+  static void verifyNotEosV1(final StreamsConfig config) throws ConfigException {
+    if (EXACTLY_ONCE.equals(config.getString(StreamsConfig.PROCESSING_GUARANTEE_CONFIG))) {
+      throw new ConfigException("Responsive driver can only be used with ALOS/EOS-V2");
+    }
+  }
+
+  static void verifyTopologyOptimizationConfig(final StreamsConfig config)
+      throws ConfigException {
+    final String optimizations = config.getString(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG);
+    if (optimizations.equals(StreamsConfig.OPTIMIZE)
+        || optimizations.contains(StreamsConfig.REUSE_KTABLE_SOURCE_TOPICS)) {
+      LOG.error("Responsive stores are not currently compatible with the source topic optimization."
+                    + " This application was configured with {}", optimizations);
+      throw new ConfigException(
+          "Responsive stores cannot be used with reuse.ktable.source.topics optimization, please "
+              + "reach out to us if you are attempting to migrate an existing application that "
+              + "uses this optimization. For new applications, please disable this optimization "
+              + "by setting only the desired subset of optimizations, or else disabling all of"
+              + "them. See StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIGS for the list of options");
+    }
+  }
+
+  private ResponsiveStreamsConfig(final Map<?, ?> props, final boolean logConfigs) {
+    super(props, logConfigs);
+  }
+}

--- a/kafka-client/src/main/java/dev/responsive/kafka/config/ResponsiveConfig.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/config/ResponsiveConfig.java
@@ -132,8 +132,10 @@ public class ResponsiveConfig extends AbstractConfig {
   private static final String SUBPARTITION_HASHER_DOC = "Hasher to use for sub-partitioning.";
   private static final Class<?> SUBPARTITION_HASHER_DEFAULT = Murmur3Hasher.class;
 
-  // ------------------ required StreamsConfig overrides ----------------------
+  // ------------------ StreamsConfig overrides ----------------------
 
+  // These configuration values are required by Responsive, and a ConfigException will
+  // be thrown if they are overridden to anything else
   public static final int NUM_STANDBYS_OVERRIDE = 0;
   public static final String TASK_ASSIGNOR_CLASS_OVERRIDE = StickyTaskAssignor.class.getName();
 

--- a/kafka-client/src/main/java/dev/responsive/utils/StoreUtil.java
+++ b/kafka-client/src/main/java/dev/responsive/utils/StoreUtil.java
@@ -19,28 +19,12 @@ package dev.responsive.utils;
 import java.time.Duration;
 import java.util.Map;
 import org.apache.kafka.common.config.TopicConfig;
-import org.apache.kafka.streams.StreamsConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public final class StoreUtil {
 
   private static final Logger LOG = LoggerFactory.getLogger(StoreUtil.class);
-
-  public static void validateTopologyOptimizationConfig(final StreamsConfig config) {
-    final String optimizations = config.getString(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG);
-    if (optimizations.equals(StreamsConfig.OPTIMIZE)
-        || optimizations.contains(StreamsConfig.REUSE_KTABLE_SOURCE_TOPICS)) {
-      LOG.error("Responsive stores are not currently compatible with the source topic optimization."
-                    + " This application was configured with {}", optimizations);
-      throw new IllegalArgumentException(
-          "Responsive stores cannot be used with reuse.ktable.source.topics optimization, please "
-              + "reach out to us if you are attempting to migrate an existing application that "
-              + "uses this optimization. For new applications, please disable this optimization "
-              + "by setting only the desired subset of optimizations, or else disabling all of"
-              + "them. See StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIGS for the list of options");
-    }
-  }
 
   public static void validateLogConfigs(
       final Map<String, String> config,

--- a/kafka-client/src/test/java/dev/responsive/kafka/api/ResponsivePartitionedStoreRestoreIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/api/ResponsivePartitionedStoreRestoreIntegrationTest.java
@@ -90,6 +90,7 @@ import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.LongDeserializer;
 import org.apache.kafka.common.serialization.LongSerializer;
 import org.apache.kafka.common.serialization.Serdes.LongSerde;
+import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.KafkaClientSupplier;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
@@ -346,6 +347,7 @@ public class ResponsivePartitionedStoreRestoreIntegrationTest {
         ResponsiveConfig.loggedConfig(properties),
         new StreamsConfig(properties),
         clientSupplier,
+        Time.SYSTEM,
         cassandraClientFactory
     );
   }

--- a/kafka-client/src/test/java/dev/responsive/kafka/clients/config/ResponsiveStreamsConfigTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/clients/config/ResponsiveStreamsConfigTest.java
@@ -1,0 +1,151 @@
+/*
+ *
+ *  * Copyright 2023 Responsive Computing, Inc.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package dev.responsive.kafka.clients.config;
+
+import static dev.responsive.kafka.clients.config.ResponsiveStreamsConfig.verifyNoStandbys;
+import static dev.responsive.kafka.clients.config.ResponsiveStreamsConfig.verifyNotEosV1;
+import static dev.responsive.kafka.clients.config.ResponsiveStreamsConfig.verifyTopologyOptimizationConfig;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Map;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.streams.StreamsConfig;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ResponsiveStreamsConfigTest {
+
+  @Test
+  public void shouldThrowOnNonZeroNumStandbyReplicas() {
+    assertThrows(
+        ConfigException.class,
+        () -> verifyNoStandbys(new StreamsConfig(Map.of(
+            StreamsConfig.APPLICATION_ID_CONFIG, "foo",
+            CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "foo.bar",
+            StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 1
+        )))
+    );
+  }
+
+  @Test
+  public void shouldNotThrowWhenNumStandbysUnset() {
+    verifyNoStandbys(new StreamsConfig(Map.of(
+        StreamsConfig.APPLICATION_ID_CONFIG, "foo",
+        CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "foo.bar"
+    )));
+  }
+
+  @Test
+  public void shouldNotThrowWhenNumStandbysSetToZero() {
+    verifyNoStandbys(new StreamsConfig(Map.of(
+        StreamsConfig.APPLICATION_ID_CONFIG, "foo",
+        CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "foo.bar",
+        StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG, 0
+    )));
+  }
+
+  @SuppressWarnings("deprecation")
+  @Test
+  public void shouldThrowOnEOSV1() {
+    assertThrows(
+        ConfigException.class,
+        () -> verifyNotEosV1(new StreamsConfig(Map.of(
+            StreamsConfig.APPLICATION_ID_CONFIG, "foo",
+            CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "foo.bar",
+            StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE
+        )))
+    );
+  }
+
+  @Test
+  public void shouldNotThrowOnEOSV2() {
+    verifyTopologyOptimizationConfig(new StreamsConfig(Map.of(
+        StreamsConfig.APPLICATION_ID_CONFIG, "foo",
+        CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "foo.bar",
+        StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_V2
+    )));
+  }
+
+  @Test
+  public void shouldNotThrowOnALOS() {
+    verifyTopologyOptimizationConfig(new StreamsConfig(Map.of(
+        StreamsConfig.APPLICATION_ID_CONFIG, "foo",
+        CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "foo.bar",
+        StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.AT_LEAST_ONCE
+    )));
+  }
+  
+  @Test
+  public void shouldThrowOnEnableAllOptimizations() {
+    assertThrows(
+        ConfigException.class,
+        () -> verifyTopologyOptimizationConfig(new StreamsConfig(Map.of(
+            StreamsConfig.APPLICATION_ID_CONFIG, "foo",
+            CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "foo.bar",
+            StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.OPTIMIZE
+        )))
+    );
+  }
+
+  @Test
+  public void shouldThrowOnEnableReuseSourceTopicOptimizations() {
+    assertThrows(
+        ConfigException.class,
+        () -> verifyTopologyOptimizationConfig(new StreamsConfig(Map.of(
+            StreamsConfig.APPLICATION_ID_CONFIG, "foo",
+            CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "foo.bar",
+            StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.REUSE_KTABLE_SOURCE_TOPICS
+        )))
+    );
+  }
+
+  @Test
+  public void shouldThrowOnEnableReuseSourceTopicMultiOptimization() {
+    assertThrows(
+        ConfigException.class,
+        () -> verifyTopologyOptimizationConfig(new StreamsConfig(Map.of(
+            StreamsConfig.APPLICATION_ID_CONFIG, "foo",
+            CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "foo.bar",
+            StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG,
+            StreamsConfig.REUSE_KTABLE_SOURCE_TOPICS + "," + StreamsConfig.MERGE_REPARTITION_TOPICS
+        )))
+    );
+  }
+
+  @Test
+  public void shouldNotThrowWhenOptimizationsOff() {
+    verifyTopologyOptimizationConfig(new StreamsConfig(Map.of(
+        StreamsConfig.APPLICATION_ID_CONFIG, "foo",
+        CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "foo.bar")
+    ));
+  }
+
+  @Test
+  public void shouldNotThrowWhenOptimizationsDoNotIncludeReuseSourceTopic() {
+    verifyTopologyOptimizationConfig(new StreamsConfig(Map.of(
+        StreamsConfig.APPLICATION_ID_CONFIG, "foo",
+        CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "foo.bar",
+        StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG,
+        StreamsConfig.SINGLE_STORE_SELF_JOIN + "," + StreamsConfig.MERGE_REPARTITION_TOPICS)
+    ));
+  }
+}

--- a/kafka-client/src/test/java/dev/responsive/utils/StoreUtilTest.java
+++ b/kafka-client/src/test/java/dev/responsive/utils/StoreUtilTest.java
@@ -2,9 +2,9 @@ package dev.responsive.utils;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.Collections;
 import java.util.Map;
-import org.apache.kafka.clients.CommonClientConfigs;
-import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.common.config.TopicConfig;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -13,61 +13,60 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class StoreUtilTest {
 
   @Test
-  public void shouldThrowOnEnableAllOptimizations() {
+  public void shouldThrowOnCompactAndTruncateChangelogTrue() {
     assertThrows(
         IllegalArgumentException.class,
-        () -> StoreUtil.validateTopologyOptimizationConfig(new StreamsConfig(Map.of(
-            StreamsConfig.APPLICATION_ID_CONFIG, "foo",
-            CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "foo.bar",
-            StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.OPTIMIZE
-
-        )))
+        () -> StoreUtil.validateLogConfigs(Map.of(
+            TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT
+        ), true, "store")
     );
   }
 
   @Test
-  public void shouldThrowOnEnableReuseSourceTopicOptimizations() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> StoreUtil.validateTopologyOptimizationConfig(new StreamsConfig(Map.of(
-            StreamsConfig.APPLICATION_ID_CONFIG, "foo",
-            CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "foo.bar",
-            StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.REUSE_KTABLE_SOURCE_TOPICS
-
-        )))
-    );
+  public void shouldNotThrowOnDeleteAndTruncateChangelogTrue() {
+    StoreUtil.validateLogConfigs(Map.of(
+        TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_DELETE
+    ), true, "store");
   }
 
   @Test
-  public void shouldThrowOnEnableReuseSourceTopicMultiOptimization() {
-    assertThrows(
-        IllegalArgumentException.class,
-        () -> StoreUtil.validateTopologyOptimizationConfig(new StreamsConfig(Map.of(
-            StreamsConfig.APPLICATION_ID_CONFIG, "foo",
-            CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "foo.bar",
-            StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG,
-            StreamsConfig.REUSE_KTABLE_SOURCE_TOPICS + "," + StreamsConfig.MERGE_REPARTITION_TOPICS
-
-        )))
-    );
+  public void shouldNotThrowOnCompactDeleteAndTruncateChangelogTrue() {
+    StoreUtil.validateLogConfigs(Map.of(
+        TopicConfig.CLEANUP_POLICY_CONFIG,
+        TopicConfig.CLEANUP_POLICY_COMPACT + "," + TopicConfig.CLEANUP_POLICY_DELETE
+    ), true, "store");
   }
 
   @Test
-  public void shouldNotThrowWhenOptimizationsOff() {
-    StoreUtil.validateTopologyOptimizationConfig(new StreamsConfig(Map.of(
-        StreamsConfig.APPLICATION_ID_CONFIG, "foo",
-        CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "foo.bar")
-    ));
+  public void shouldNotThrowWhenCleanupPolicyUnspecifiedAndTruncateChangelogTrue() {
+    StoreUtil.validateLogConfigs(Collections.emptyMap(), true, "store");
   }
 
   @Test
-  public void shouldNotThrowWhenOptimizationsDoNotIncludeReuseSourceTopic() {
-    StoreUtil.validateTopologyOptimizationConfig(new StreamsConfig(Map.of(
-        StreamsConfig.APPLICATION_ID_CONFIG, "foo",
-        CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "foo.bar",
-        StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG,
-        StreamsConfig.SINGLE_STORE_SELF_JOIN + "," + StreamsConfig.MERGE_REPARTITION_TOPICS)
-    ));
+  public void shouldNotThrowOnCompactAndTruncateChangelogFalse() {
+    StoreUtil.validateLogConfigs(Map.of(
+        TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_COMPACT
+    ), false, "store");
+  }
+
+  @Test
+  public void shouldNotThrowOnDeleteAndTruncateChangelogFalse() {
+    StoreUtil.validateLogConfigs(Map.of(
+        TopicConfig.CLEANUP_POLICY_CONFIG, TopicConfig.CLEANUP_POLICY_DELETE
+    ), false, "store");
+  }
+
+  @Test
+  public void shouldNotThrowOnCompactDeleteAndTruncateChangelogFalse() {
+    StoreUtil.validateLogConfigs(Map.of(
+        TopicConfig.CLEANUP_POLICY_CONFIG,
+        TopicConfig.CLEANUP_POLICY_COMPACT + "," + TopicConfig.CLEANUP_POLICY_DELETE
+    ), false, "store");
+  }
+
+  @Test
+  public void shouldNotThrowWhenCleanupPolicyUnspecifiedAndTruncateChangelogFalse() {
+    StoreUtil.validateLogConfigs(Collections.emptyMap(), false, "store");
   }
 
 }

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/api/ResponsiveTopologyTestDriver.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/api/ResponsiveTopologyTestDriver.java
@@ -34,8 +34,9 @@ public class ResponsiveTopologyTestDriver extends TopologyTestDriver {
   private final TTDCassandraClient client;
 
   /**
-   * Create a new test diver instance.
-   * Default test properties are used to initialize the driver instance
+   * Create a new test diver instance with default test properties.
+   * <p>
+   * Can be used exactly the same as the usual {@link TopologyTestDriver}
    *
    * @param topology the topology to be tested
    */
@@ -47,6 +48,8 @@ public class ResponsiveTopologyTestDriver extends TopologyTestDriver {
    * Create a new test diver instance.
    * Initialized the internally mocked wall-clock time with
    * {@link System#currentTimeMillis() current system time}.
+   * <p>
+   * Can be used exactly the same as the usual {@link TopologyTestDriver}
    *
    * @param topology the topology to be tested
    * @param config   the configuration for the topology
@@ -56,7 +59,9 @@ public class ResponsiveTopologyTestDriver extends TopologyTestDriver {
   }
 
   /**
-   * Create a new test diver instance.
+   * Create a new test diver instance with default test properties.
+   * <p>
+   * Can be used exactly the same as the usual {@link TopologyTestDriver}
    *
    * @param topology the topology to be tested
    * @param initialWallClockTimeMs the initial value of internally mocked wall-clock time
@@ -70,6 +75,8 @@ public class ResponsiveTopologyTestDriver extends TopologyTestDriver {
 
   /**
    * Create a new test diver instance.
+   * <p>
+   * Can be used exactly the same as the usual {@link TopologyTestDriver}
    *
    * @param topology               the topology to be tested
    * @param config                 the configuration for the topology


### PR DESCRIPTION
Get this ready to publish the API Reference docs. Fills in a few niche missing constructors (KafkaStreams allows you to pass in a `Time` object), adds javadocs for everything, and cleans up the way we handle StreamsConfigs and validate the properties.

Introduces a new ResponsiveStreamsConfig class so we can do "quiet logging". Will follow up with the same for the other kafka clients that we're excessively logging 