### PR TITLE
Log version and git commit id during startup

### DIFF
--- a/kafka-client/build.gradle.kts
+++ b/kafka-client/build.gradle.kts
@@ -50,34 +50,6 @@ tasks.register(writeVersionPropertiesFile) {
     }
 }
 
-// Need to add all generated resource directories as outputs of the main sourceSet
-sourceSets {
-    main {
-        output.dir(file("$buildDir/resources"))
-    }
-}
-
-
-// TODO: there has GOT to be a more concise way to do this than listing it out for every task individually...
-//  might be overkill with some of these already depending on each other so we can probably clean up a bit too
-tasks.release {
-    dependsOn(tasks[writeVersionPropertiesFile])
-}
-
-tasks.publish {
-    dependsOn(tasks[writeVersionPropertiesFile])
-}
-
-tasks.publishToMavenLocal {
-    dependsOn(tasks[writeVersionPropertiesFile])
-}
-
-tasks.jar {
-    dependsOn(tasks[writeVersionPropertiesFile])
-    dependsOn(tasks.processResources)
-    dependsOn(tasks.processTestResources)
-}
-
 tasks.compileJava {
     dependsOn(tasks[writeVersionPropertiesFile])
     dependsOn(tasks.processResources)

--- a/kafka-client/build.gradle.kts
+++ b/kafka-client/build.gradle.kts
@@ -57,6 +57,21 @@ sourceSets {
     }
 }
 
+
+// TODO: there has GOT to be a more concise way to do this than listing it out for every task individually...
+//  might be overkill with some of these already depending on each other so we can probably clean up a bit too
+tasks.release {
+    dependsOn(tasks[writeVersionPropertiesFile])
+}
+
+tasks.publish {
+    dependsOn(tasks[writeVersionPropertiesFile])
+}
+
+tasks.publishToMavenLocal {
+    dependsOn(tasks[writeVersionPropertiesFile])
+}
+
 tasks.jar {
     dependsOn(tasks[writeVersionPropertiesFile])
     dependsOn(tasks.processResources)

--- a/kafka-client/build.gradle.kts
+++ b/kafka-client/build.gradle.kts
@@ -16,7 +16,19 @@
 
 plugins {
     id("responsive.java-library-conventions")
+    id("com.gorylenko.gradle-git-properties") version "2.4.1"
 }
+
+configure<com.gorylenko.GitPropertiesPluginExtension> {
+    // Creates a file with various git properties at build/resources/main/{gitPropertiesName}
+    // See https://github.com/n0mer/gradle-git-properties#usage for all available props
+
+    // Can be a file name or relative path under build/resources/main
+    gitPropertiesName = "version.properties"
+
+    keys = arrayOf("git.build.version","git.commit.id.abbrev").toMutableList()
+}
+
 
 dependencies {
     api(libs.kafka.streams)

--- a/kafka-client/build.gradle.kts
+++ b/kafka-client/build.gradle.kts
@@ -42,7 +42,7 @@ val versionFilePath = "$resourcesDir/version.properties"
 tasks.register(writeVersionPropertiesFile) {
     val versionFile = file(versionFilePath)
     outputs.file(versionFile)
-    doLast {
+    doFirst {
         file(versionFilePath).writeText(
                 "git.build.version=" + gitVersion + "\n" +
                 "git.commit.id=" + gitCommitId + "\n"

--- a/kafka-client/build.gradle.kts
+++ b/kafka-client/build.gradle.kts
@@ -57,6 +57,12 @@ sourceSets {
     }
 }
 
+tasks.jar {
+    dependsOn(tasks[writeVersionPropertiesFile])
+    dependsOn(tasks.processResources)
+    dependsOn(tasks.processTestResources)
+}
+
 tasks.compileJava {
     dependsOn(tasks[writeVersionPropertiesFile])
     dependsOn(tasks.processResources)

--- a/kafka-client/build.gradle.kts
+++ b/kafka-client/build.gradle.kts
@@ -52,13 +52,6 @@ tasks.register(writeVersionPropertiesFile) {
 
 tasks.compileJava {
     dependsOn(tasks[writeVersionPropertiesFile])
-    dependsOn(tasks.processResources)
-}
-
-tasks.compileTestJava {
-    dependsOn(tasks[writeVersionPropertiesFile])
-    dependsOn(tasks.processResources)
-    dependsOn(tasks.processTestResources)
 }
 
 /********************************************/

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
@@ -21,10 +21,12 @@ import dev.responsive.kafka.internal.db.partitioning.Hasher;
 import dev.responsive.kafka.internal.db.partitioning.Murmur3Hasher;
 import dev.responsive.kafka.internal.db.partitioning.SubPartitioner;
 import dev.responsive.kafka.internal.utils.TableName;
+import java.io.InputStream;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.OptionalInt;
+import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.common.config.AbstractConfig;
@@ -35,12 +37,16 @@ import org.apache.kafka.common.config.ConfigDef.Validator;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.types.Password;
 import org.apache.kafka.streams.processor.internals.assignment.StickyTaskAssignor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Configurations for {@link ResponsiveKafkaStreams}
  */
 @SuppressWarnings("checkstyle:linelength")
 public class ResponsiveConfig extends AbstractConfig {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ResponsiveConfig.class);
 
   // ------------------ connection configurations -----------------------------
 
@@ -253,11 +259,33 @@ public class ResponsiveConfig extends AbstractConfig {
    * mid-application, for example during state store init.
    */
   public static ResponsiveConfig loggedConfig(final Map<?, ?> originals) {
+
+    final Properties props = loadVersionPropertiesFromFile();
+    final String version = props.getProperty("git.build.version", "").trim();
+    final String commitId = props.getProperty("git.commit.id.abbrev", "").trim();
+
+    if (!version.isEmpty() && !commitId.isEmpty()) {
+      LOG.info("Responsive Client version: {}", version);
+      LOG.info("Responsive Client commit ID: {}", commitId);
+    }
+
     return new ResponsiveConfig(originals, true);
   }
 
   private ResponsiveConfig(final Map<?, ?> originals, final boolean doLog) {
     super(CONFIG_DEF, originals, doLog);
+  }
+
+  private static Properties loadVersionPropertiesFromFile() {
+    final Properties props = new Properties();
+    try (final InputStream resourceStream = ResponsiveConfig.class
+        .getResourceAsStream("/version.properties")
+    ) {
+      props.load(resourceStream);
+    } catch (final Exception exception) {
+      LOG.warn("Error while loading version.properties", exception);
+    }
+    return props;
   }
 
   public SubPartitioner getSubPartitioner(

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
@@ -262,7 +262,7 @@ public class ResponsiveConfig extends AbstractConfig {
 
     final Properties props = loadVersionPropertiesFromFile();
     final String version = props.getProperty("git.build.version", "").trim();
-    final String commitId = props.getProperty("git.commit.id.abbrev", "").trim();
+    final String commitId = props.getProperty("git.commit.id", "").trim();
 
     if (!version.isEmpty() && !commitId.isEmpty()) {
       LOG.info("Responsive Client version: {}", version);


### PR DESCRIPTION
Added a task to the gradle build that stashes some various useful git properties in a file along with the main build. We can then read this out to log valuable debugging info such as the version and specific commit id of the dependency.

Tested this out both in a local kafka-client integration test, and by pulling in a local build with the fix while running a test in the soak repo. Works with both, and logs for the TTD as well as real applications.

Useful for sanity checks, both in the soak test and future customer logs where we want to verify exactly what version they're running. I only put it in the kafka-client module since that's where it seems most relevant, but we could extend it to others as well if that feels right.