### PR TITLE
fix and re-enable global stores

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/ResponsiveGlobalConsumer.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/ResponsiveGlobalConsumer.java
@@ -90,6 +90,18 @@ public class ResponsiveGlobalConsumer extends DelegatingConsumer<byte[], byte[]>
     );
   }
 
+  @Override
+  public void unsubscribe() {
+    // since this consumer has ENABLE_AUTO_COMMIT_CONFIG set to true,
+    // it is not guaranteed that any commits will happen before calling
+    // unsubscribe - the GlobalStreamThread will call unsubscribe
+    // when it's finished restoring, so we should make sure to commit
+    // any offsets at this point so that when it resumes normal operation
+    // it doesn't experience any time travel
+    commitSync();
+    super.unsubscribe();
+  }
+
   @Deprecated
   public ConsumerRecords<byte[], byte[]> poll(final long timeoutMs) {
     return poll(Duration.ofMillis(timeoutMs));

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraClient.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraClient.java
@@ -53,6 +53,7 @@ public class CassandraClient {
   private final RemoteKeyValueSchema kvSchema;
   private final RemoteKeyValueSchema factSchema;
   private final RemoteWindowedSchema windowedSchema;
+  private final RemoteKeyValueSchema globalSchema;
 
   /**
    * @param session the Cassandra session, expected to be initialized
@@ -67,6 +68,7 @@ public class CassandraClient {
     this.kvSchema = new CassandraKeyValueSchema(this);
     this.factSchema = new CassandraFactSchema(this);
     this.windowedSchema = new CassandraWindowedSchema(this);
+    this.globalSchema = new CassandraGlobalKeyValueSchema(this);
   }
 
   protected CassandraClient(final ResponsiveConfig config) {
@@ -153,6 +155,14 @@ public class CassandraClient {
   public void shutdown() {
     executor.shutdown();
     session.close();
+  }
+
+  public RemoteKeyValueSchema prepareGlobalSchema(final ResponsiveKeyValueParams params)
+      throws InterruptedException, TimeoutException {
+    globalSchema.create(params.name().cassandraName(), params.timeToLive());
+    awaitTableAndPrepareSchema(params.name().cassandraName(), globalSchema);
+
+    return globalSchema;
   }
 
   public RemoteKeyValueSchema prepareKVTableSchema(final ResponsiveKeyValueParams params)

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraGlobalKeyValueSchema.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraGlobalKeyValueSchema.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.kafka.internal.db;
+
+import com.datastax.oss.driver.api.querybuilder.SchemaBuilder;
+import com.datastax.oss.driver.api.querybuilder.schema.compaction.CompactionStrategy;
+import java.time.Duration;
+
+/**
+ * Global schemas share many properties with Fact Schemas in that we want
+ * each key to be its own partition, and we don't need LWTs for EOS support.
+ * The only place it differs is that we expect overwrites, and that the pattern
+ * is read-heavy with few updates. Because of this, we use leveled compaction
+ * strategy instead of time windowed.
+ */
+public class CassandraGlobalKeyValueSchema extends CassandraFactSchema {
+
+  public CassandraGlobalKeyValueSchema(final CassandraClient client) {
+    super(client);
+  }
+
+  @Override
+  protected CompactionStrategy<?> compactionStrategy(final Duration compactionWindow) {
+    return SchemaBuilder.leveledCompactionStrategy();
+  }
+}

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraKeyValueSchema.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraKeyValueSchema.java
@@ -114,10 +114,6 @@ public class CassandraKeyValueSchema implements RemoteKeyValueSchema {
       final SubPartitioner partitioner,
       final int kafkaPartition
   ) {
-    // TODO: what happens if the user has data with the key "_offset"?
-    // we should consider using a special serialization format for keys
-    // (e.g. adding a magic byte of 0x00 to the offset and 0x01 to all
-    // th data keys) so that it's impossible for a collision to happen
     partitioner.all(kafkaPartition).forEach(sub -> {
       client.execute(
           QueryBuilder.insertInto(table)
@@ -141,10 +137,12 @@ public class CassandraKeyValueSchema implements RemoteKeyValueSchema {
         .setInt(PARTITION_KEY.bind(), partition);
     final List<Row> result = client.execute(bound).all();
 
-    if (result.size() != 1) {
+    if (result.size() > 1) {
       throw new IllegalStateException(String.format(
-          "Expected exactly one offset row for %s[%s] but got %d",
+          "Expected at most one offset row for %s[%s] but got %d",
           table, partition, result.size()));
+    } else if (result.isEmpty()) {
+      return new MetadataRow(NO_COMMITTED_OFFSET, -1L);
     } else {
       return new MetadataRow(
           result.get(0).getLong(OFFSET.column()),

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/FactSchemaWriter.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/FactSchemaWriter.java
@@ -85,11 +85,6 @@ public class FactSchemaWriter<K> implements RemoteWriter<K> {
         : RemoteWriteResult.failure(partition);
   }
 
-  @Override
-  public int partition() {
-    return partition;
-  }
-
   private CompletionStage<RemoteWriteResult> executeAsync(final Statement<?> statement) {
     return client.executeAsync(statement)
         .thenApply(resp -> RemoteWriteResult.of(partition, resp));

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/LwtWriter.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/LwtWriter.java
@@ -98,11 +98,6 @@ public class LwtWriter<K> implements RemoteWriter<K> {
         : RemoteWriteResult.failure(partition);
   }
 
-  @Override
-  public int partition() {
-    return partition;
-  }
-
   private CompletionStage<RemoteWriteResult> executeAsync(final Statement<?> statement) {
     return client.executeAsync(statement)
         .thenApply(resp -> RemoteWriteResult.of(partition, resp));

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/RemoteWriter.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/RemoteWriter.java
@@ -29,5 +29,4 @@ public interface RemoteWriter<K> {
 
   RemoteWriteResult setOffset(final long offset);
 
-  int partition();
 }

--- a/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveGlobalStoreIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveGlobalStoreIntegrationTest.java
@@ -54,6 +54,7 @@ import org.apache.kafka.streams.kstream.GlobalKTable;
 import org.apache.kafka.streams.kstream.KStream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -94,7 +95,7 @@ public class ResponsiveGlobalStoreIntegrationTest {
     admin.deleteTopics(List.of(INPUT_TOPIC, GLOBAL_TOPIC, OUTPUT_TOPIC));
   }
 
-  //@Test
+  @Test
   public void shouldUseGlobalTable() throws Exception {
     // Given:
     final Map<String, Object> properties = getMutableProperties();

--- a/kafka-client/src/test/java/dev/responsive/kafka/integration/SubPartitionIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/integration/SubPartitionIntegrationTest.java
@@ -20,6 +20,7 @@ import static dev.responsive.kafka.api.config.ResponsiveConfig.STORAGE_DESIRED_N
 import static dev.responsive.kafka.api.config.ResponsiveConfig.STORE_FLUSH_RECORDS_TRIGGER_CONFIG;
 import static dev.responsive.kafka.api.config.ResponsiveConfig.SUBPARTITION_HASHER_CONFIG;
 import static dev.responsive.kafka.api.config.ResponsiveConfig.responsiveConfig;
+import static dev.responsive.kafka.internal.stores.ResponsiveStoreRegistration.NO_COMMITTED_OFFSET;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG;
@@ -228,7 +229,7 @@ public class SubPartitionIntegrationTest {
       assertThat(meta1.offset, is(notNullValue()));
 
       // throws because it doesn't exist
-      Assertions.assertThrows(IllegalStateException.class, () -> schema.metadata(cassandraName, 2));
+      Assertions.assertEquals(schema.metadata(cassandraName, 2).offset, NO_COMMITTED_OFFSET);
 
       // these store ValueAndTimestamp, so we need to just pluck the last 8 bytes
       final var hasher = SubPartitioner.NO_SUBPARTITIONS;

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/ResponsiveStoreTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/ResponsiveStoreTest.java
@@ -48,7 +48,7 @@ public class ResponsiveStoreTest {
   @Mock
   private InternalProcessorContext<?, ?> context;
 
-  //@Test
+  @Test
   public void shouldCreateGlobalStore() {
     // Given:
     Mockito.when(context.taskType()).thenReturn(TaskType.GLOBAL);

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/internal/clients/TTDCassandraClient.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/internal/clients/TTDCassandraClient.java
@@ -121,6 +121,13 @@ public class TTDCassandraClient extends CassandraClient {
   }
 
   @Override
+  public RemoteKeyValueSchema prepareGlobalSchema(final ResponsiveKeyValueParams params) {
+    // for testing, just use the KV schema since partitions are ignored anyway,
+    // which is the main difference between the stores
+    return prepareKVTableSchema(params);
+  }
+
+  @Override
   public RemoteKeyValueSchema prepareKVTableSchema(final ResponsiveKeyValueParams params) {
     kvSchema.create(params.name().cassandraName(), params.timeToLive());
     kvSchema.prepare(params.name().cassandraName());

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/internal/stores/TTDSchema.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/internal/stores/TTDSchema.java
@@ -108,10 +108,6 @@ public abstract class TTDSchema<K> implements RemoteSchema<K> {
       return RemoteWriteResult.success(partition);
     }
 
-    @Override
-    public int partition() {
-      return partition;
-    }
   }
 
 }


### PR DESCRIPTION
This PR does three things (let me know if you'd rather me split it up!):

1. It fixes an issue with time-travel where offsets are not committed after restoration but an `unsubscribe` is called, meaning those offsets get re-processed
2. It fixes a potential time-travel issue where restore reprocesses records during an unclean shutdown (essentially the same situation as above, but if a commit isn't called during normal processing) by persisting the last written offset to a metadata table
3. It improves the implementation to use Fact schema instead of the normal schema so we don't push everything into a single partition