### PR TITLE
Allow all topology optimizations and disable truncation for source-topic changelogs

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/internal/config/ResponsiveStreamsConfig.java
+++ b/kafka-client/src/main/java/dev/responsive/internal/config/ResponsiveStreamsConfig.java
@@ -43,7 +43,6 @@ public class ResponsiveStreamsConfig extends StreamsConfig {
   public static void validateStreamsConfig(final StreamsConfig streamsConfig) {
     verifyNoStandbys(streamsConfig);
     verifyNotEosV1(streamsConfig);
-    verifyTopologyOptimizationConfig(streamsConfig);
   }
 
   static void verifyNoStandbys(final StreamsConfig config) throws ConfigException {
@@ -66,22 +65,6 @@ public class ResponsiveStreamsConfig extends StreamsConfig {
   static void verifyNotEosV1(final StreamsConfig config) throws ConfigException {
     if (EXACTLY_ONCE.equals(config.getString(StreamsConfig.PROCESSING_GUARANTEE_CONFIG))) {
       throw new ConfigException("Responsive driver can only be used with ALOS/EOS-V2");
-    }
-  }
-
-  static void verifyTopologyOptimizationConfig(final StreamsConfig config)
-      throws ConfigException {
-    final String optimizations = config.getString(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG);
-    if (optimizations.equals(StreamsConfig.OPTIMIZE)
-        || optimizations.contains(StreamsConfig.REUSE_KTABLE_SOURCE_TOPICS)) {
-      LOG.error("Responsive stores are not currently compatible with the source topic optimization."
-                    + " This application was configured with {}", optimizations);
-      throw new ConfigException(
-          "Responsive stores cannot be used with reuse.ktable.source.topics optimization, please "
-              + "reach out to us if you are attempting to migrate an existing application that "
-              + "uses this optimization. For new applications, please disable this optimization "
-              + "by setting only the desired subset of optimizations, or else disabling all of"
-              + "them. See StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIGS for the list of options");
     }
   }
 

--- a/kafka-client/src/test/java/dev/responsive/internal/config/ResponsiveStreamsConfigTest.java
+++ b/kafka-client/src/test/java/dev/responsive/internal/config/ResponsiveStreamsConfigTest.java
@@ -20,7 +20,6 @@ package dev.responsive.internal.config;
 
 import static dev.responsive.internal.config.ResponsiveStreamsConfig.verifyNoStandbys;
 import static dev.responsive.internal.config.ResponsiveStreamsConfig.verifyNotEosV1;
-import static dev.responsive.internal.config.ResponsiveStreamsConfig.verifyTopologyOptimizationConfig;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Map;
@@ -74,78 +73,5 @@ class ResponsiveStreamsConfigTest {
             StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE
         )))
     );
-  }
-
-  @Test
-  public void shouldNotThrowOnEOSV2() {
-    verifyTopologyOptimizationConfig(new StreamsConfig(Map.of(
-        StreamsConfig.APPLICATION_ID_CONFIG, "foo",
-        CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "foo.bar",
-        StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE_V2
-    )));
-  }
-
-  @Test
-  public void shouldNotThrowOnALOS() {
-    verifyTopologyOptimizationConfig(new StreamsConfig(Map.of(
-        StreamsConfig.APPLICATION_ID_CONFIG, "foo",
-        CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "foo.bar",
-        StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.AT_LEAST_ONCE
-    )));
-  }
-  
-  @Test
-  public void shouldThrowOnEnableAllOptimizations() {
-    assertThrows(
-        ConfigException.class,
-        () -> verifyTopologyOptimizationConfig(new StreamsConfig(Map.of(
-            StreamsConfig.APPLICATION_ID_CONFIG, "foo",
-            CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "foo.bar",
-            StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.OPTIMIZE
-        )))
-    );
-  }
-
-  @Test
-  public void shouldThrowOnEnableReuseSourceTopicOptimizations() {
-    assertThrows(
-        ConfigException.class,
-        () -> verifyTopologyOptimizationConfig(new StreamsConfig(Map.of(
-            StreamsConfig.APPLICATION_ID_CONFIG, "foo",
-            CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "foo.bar",
-            StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.REUSE_KTABLE_SOURCE_TOPICS
-        )))
-    );
-  }
-
-  @Test
-  public void shouldThrowOnEnableReuseSourceTopicMultiOptimization() {
-    assertThrows(
-        ConfigException.class,
-        () -> verifyTopologyOptimizationConfig(new StreamsConfig(Map.of(
-            StreamsConfig.APPLICATION_ID_CONFIG, "foo",
-            CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "foo.bar",
-            StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG,
-            StreamsConfig.REUSE_KTABLE_SOURCE_TOPICS + "," + StreamsConfig.MERGE_REPARTITION_TOPICS
-        )))
-    );
-  }
-
-  @Test
-  public void shouldNotThrowWhenOptimizationsOff() {
-    verifyTopologyOptimizationConfig(new StreamsConfig(Map.of(
-        StreamsConfig.APPLICATION_ID_CONFIG, "foo",
-        CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "foo.bar")
-    ));
-  }
-
-  @Test
-  public void shouldNotThrowWhenOptimizationsDoNotIncludeReuseSourceTopic() {
-    verifyTopologyOptimizationConfig(new StreamsConfig(Map.of(
-        StreamsConfig.APPLICATION_ID_CONFIG, "foo",
-        CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "foo.bar",
-        StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG,
-        StreamsConfig.SINGLE_STORE_SELF_JOIN + "," + StreamsConfig.MERGE_REPARTITION_TOPICS)
-    ));
   }
 }


### PR DESCRIPTION
We should now be able to handle all topology optimizations, specifically reusing source topics as changelogs which is currently a restricted config.

We can simply remove all validation of the `topology.optimization` config, though we do want to be guard against users accidentally deleting source topic data and therefore should make sure to disable changelog truncation for any source tables with this source-changelog optimization