### PR TITLE
Make changelog truncation happen asynchronously by CommitBuffer

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/CommitBuffer.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/CommitBuffer.java
@@ -57,7 +57,8 @@ import org.apache.kafka.streams.processor.internals.RecordBatchingStateRestoreCa
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.slf4j.Logger;
 
-class CommitBuffer<K, S extends RemoteSchema<K>> implements RecordBatchingStateRestoreCallback, Closeable {
+class CommitBuffer<K, S extends RemoteSchema<K>> 
+    implements RecordBatchingStateRestoreCallback, Closeable {
 
   public static final int MAX_BATCH_SIZE = 1000;
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/CommitBuffer.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/CommitBuffer.java
@@ -84,7 +84,7 @@ class CommitBuffer<K, S extends RemoteSchema<K>>
   // flag to skip further truncation attempts when the changelog is set to 'compact' only
   private boolean isDeleteEnabled = true;
   private final boolean truncateChangelog;
-  private KafkaFuture<DeletedRecords> deleteRecordsFuture;
+  private KafkaFuture<DeletedRecords> deleteRecordsFuture = KafkaFuture.completedFuture(null);
 
   static <K, S extends RemoteSchema<K>> CommitBuffer<K, S> from(
       final SharedClients clients,

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsivePartitionedStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsivePartitionedStore.java
@@ -259,5 +259,8 @@ public class ResponsivePartitionedStore implements KeyValueStore<Bytes, byte[]> 
     if (storeRegistry != null) {
       storeRegistry.deregisterStore(registration);
     }
+    if (buffer != null) {
+      buffer.close();
+    }
   }
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveWindowStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveWindowStore.java
@@ -306,6 +306,9 @@ public class ResponsiveWindowStore implements WindowStore<Bytes, byte[]> {
     if (storeRegistry != null) {
       storeRegistry.deregisterStore(registration);
     }
+    if (buffer != null) {
+      buffer.close();
+    }
   }
 
   @Override

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/CommitBufferTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/CommitBufferTest.java
@@ -55,6 +55,7 @@ import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.DeleteRecordsResult;
 import org.apache.kafka.clients.admin.DeletedRecords;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.KafkaFuture;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.PolicyViolationException;
 import org.apache.kafka.common.header.internals.RecordHeaders;
@@ -115,8 +116,8 @@ public class CommitBufferTest {
     schema.create(name, Optional.empty());
     schema.prepare(name);
 
-    when(admin.deleteRecords(Mockito.any()))
-        .thenReturn(new DeleteRecordsResult(Map.of()));
+    when(admin.deleteRecords(Mockito.any())).thenReturn(new DeleteRecordsResult(Map.of(
+            changelogTp, KafkaFuture.completedFuture(new DeletedRecords(100)))));
   }
 
   private void setPartitioner(final int factor) {


### PR DESCRIPTION
Planning to step this up in the soak and have been pretty concerned about doing all these blocking requests on the relatively-hot-path of flushing. Since we don't depend on changelog truncation in any way and it's completely idempotent, retriable, etc we can just kick off a new deleteRecords request after each flush without waiting for it to complete. When the next flush comes around then we can check on the previous delete request's status and kick off a new request if it was succcessful, or else retry with the updated low-watermark offset to delete from

I hope this will help enough to call the feature production ready, but we should still be aware of admin calls and connections which have caused many issues with Streams in the past. If we still run into issues we could go a step further by consolidating all the delete requests across all the truncated changelog partitions (on the node) into a single request. Though I can't imagine that will be too critical until we start running apps with huge numbers of partitions, and we'll probably find other bottlenecks in that case far before we hit one here