### PR TITLE
Consolidate common store logic into AbstractResponsiveStore

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveKafkaStreams.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveKafkaStreams.java
@@ -202,11 +202,11 @@ public class ResponsiveKafkaStreams extends KafkaStreams {
         responsiveConfig,
         responsiveKafkaClientSupplier,
         time,
-        storeRegistry,
         metrics,
         new SharedClients(
             cassandraClient,
-            responsiveKafkaClientSupplier.getAdmin(responsiveConfig.originals())
+            responsiveKafkaClientSupplier.getAdmin(responsiveConfig.originals()),
+            storeRegistry
         )
     );
   }
@@ -216,7 +216,6 @@ public class ResponsiveKafkaStreams extends KafkaStreams {
       final ResponsiveConfig responsiveConfig,
       final ResponsiveKafkaClientSupplier clientSupplier,
       final Time time,
-      final ResponsiveStoreRegistry storeRegistry,
       final Metrics metrics,
       final SharedClients sharedClients
   ) {
@@ -225,7 +224,6 @@ public class ResponsiveKafkaStreams extends KafkaStreams {
         propsWithOverrides(
             responsiveConfig.originals(),
             sharedClients,
-            storeRegistry,
             topology.describe()),
         clientSupplier,
         time
@@ -272,7 +270,6 @@ public class ResponsiveKafkaStreams extends KafkaStreams {
   private static Properties propsWithOverrides(
       final Map<?, ?> configs,
       final SharedClients sharedClients,
-      final ResponsiveStoreRegistry storeRegistry,
       final TopologyDescription topologyDescription
   ) {
     final Properties propsWithOverrides = new Properties();
@@ -280,7 +277,7 @@ public class ResponsiveKafkaStreams extends KafkaStreams {
     propsWithOverrides.putAll(new InternalConfigs.Builder()
             .withCassandraClient(sharedClients.cassandraClient)
             .withKafkaAdmin(sharedClients.admin)
-            .withStoreRegistry(storeRegistry)
+            .withStoreRegistry(sharedClients.storeRegistry)
             .withTopologyDescription(topologyDescription)
             .build());
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/stores/ResponsiveKeyValueBytesStoreSupplier.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/stores/ResponsiveKeyValueBytesStoreSupplier.java
@@ -16,7 +16,7 @@
 
 package dev.responsive.kafka.api.stores;
 
-import dev.responsive.kafka.internal.stores.ResponsiveStore;
+import dev.responsive.kafka.internal.stores.ResponsiveKeyValueStoreWrapper;
 import java.util.Locale;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
@@ -37,7 +37,7 @@ public class ResponsiveKeyValueBytesStoreSupplier implements KeyValueBytesStoreS
 
   @Override
   public KeyValueStore<Bytes, byte[]> get() {
-    return new ResponsiveStore(params);
+    return new ResponsiveKeyValueStoreWrapper(params);
   }
 
   @Override

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraClient.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraClient.java
@@ -150,7 +150,7 @@ public class CassandraClient {
     return numPartitions == 0 ? OptionalInt.empty() : OptionalInt.of(numPartitions);
   }
 
-  public void close() {
+  public void shutdown() {
     executor.shutdown();
     session.close();
   }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraClient.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraClient.java
@@ -150,7 +150,7 @@ public class CassandraClient {
     return numPartitions == 0 ? OptionalInt.empty() : OptionalInt.of(numPartitions);
   }
 
-  public void shutdown() {
+  public void close() {
     executor.shutdown();
     session.close();
   }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraFactSchema.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraFactSchema.java
@@ -301,7 +301,8 @@ public class CassandraFactSchema implements RemoteKeyValueSchema {
       final int partition,
       final Bytes from,
       final Bytes to,
-      long minValidTs) {
+      long minValidTs
+  ) {
     throw new UnsupportedOperationException("range scans are not supported on Idempotent schemas.");
   }
 
@@ -309,7 +310,8 @@ public class CassandraFactSchema implements RemoteKeyValueSchema {
   public KeyValueIterator<Bytes, byte[]> all(
       final String tableName,
       final int partition,
-      long minValidTs) {
+      long minValidTs
+  ) {
     throw new UnsupportedOperationException("all is not supported on Idempotent schemas");
   }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/FactSchemaWriter.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/FactSchemaWriter.java
@@ -29,7 +29,7 @@ public class FactSchemaWriter<K> implements RemoteWriter<K> {
   private final CassandraClient client;
   private final RemoteSchema<K> schema;
   private final String tableName;
-  private final int subpartition;
+  private final int tablePartition;
 
   private final List<Statement<?>> statements;
 
@@ -37,24 +37,24 @@ public class FactSchemaWriter<K> implements RemoteWriter<K> {
       final CassandraClient client,
       final RemoteSchema<K> schema,
       final String tableName,
-      final int subpartition
+      final int tablePartition
   ) {
     this.client = client;
     this.schema = schema;
     this.tableName = tableName;
-    this.subpartition = subpartition;
+    this.tablePartition = tablePartition;
 
     statements = new ArrayList<>();
   }
 
   @Override
   public void insert(final K key, final byte[] value, long epochMillis) {
-    statements.add(schema.insert(tableName, subpartition, key, value, epochMillis));
+    statements.add(schema.insert(tableName, tablePartition, key, value, epochMillis));
   }
 
   @Override
   public void delete(final K key) {
-    statements.add(schema.delete(tableName, subpartition, key));
+    statements.add(schema.delete(tableName, tablePartition, key));
   }
 
   @Override
@@ -69,7 +69,7 @@ public class FactSchemaWriter<K> implements RemoteWriter<K> {
     // it's safe to run these in parallel w/o a guaranteed ordering because commit
     // buffer only maintains the latest value per key, and we only flush that, also
     // fact schema expects immutable values
-    var result = CompletableFuture.completedStage(RemoteWriteResult.success(subpartition));
+    var result = CompletableFuture.completedStage(RemoteWriteResult.success(tablePartition));
     for (final CompletionStage<RemoteWriteResult> future : results) {
       result = result.thenCombine(future, (one, two) -> !one.wasApplied() ? one : two);
     }
@@ -79,19 +79,19 @@ public class FactSchemaWriter<K> implements RemoteWriter<K> {
 
   @Override
   public RemoteWriteResult setOffset(final long offset) {
-    final var result = client.execute(schema.setOffset(tableName, subpartition, offset));
+    final var result = client.execute(schema.setOffset(tableName, tablePartition, offset));
     return result.wasApplied()
-        ? RemoteWriteResult.success(subpartition)
-        : RemoteWriteResult.failure(subpartition);
+        ? RemoteWriteResult.success(tablePartition)
+        : RemoteWriteResult.failure(tablePartition);
   }
 
   @Override
-  public int subpartition() {
-    return subpartition;
+  public int tablePartition() {
+    return tablePartition;
   }
 
   private CompletionStage<RemoteWriteResult> executeAsync(final Statement<?> statement) {
     return client.executeAsync(statement)
-        .thenApply(resp -> RemoteWriteResult.of(subpartition, resp));
+        .thenApply(resp -> RemoteWriteResult.of(tablePartition, resp));
   }
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/FactSchemaWriter.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/FactSchemaWriter.java
@@ -28,7 +28,7 @@ public class FactSchemaWriter<K> implements RemoteWriter<K> {
 
   private final CassandraClient client;
   private final RemoteSchema<K> schema;
-  private final String name;
+  private final String tableName;
   private final int subpartition;
 
   private final List<Statement<?>> statements;
@@ -36,12 +36,12 @@ public class FactSchemaWriter<K> implements RemoteWriter<K> {
   public FactSchemaWriter(
       final CassandraClient client,
       final RemoteSchema<K> schema,
-      final String name,
+      final String tableName,
       final int subpartition
   ) {
     this.client = client;
     this.schema = schema;
-    this.name = name;
+    this.tableName = tableName;
     this.subpartition = subpartition;
 
     statements = new ArrayList<>();
@@ -49,12 +49,12 @@ public class FactSchemaWriter<K> implements RemoteWriter<K> {
 
   @Override
   public void insert(final K key, final byte[] value, long epochMillis) {
-    statements.add(schema.insert(name, subpartition, key, value, epochMillis));
+    statements.add(schema.insert(tableName, subpartition, key, value, epochMillis));
   }
 
   @Override
   public void delete(final K key) {
-    statements.add(schema.delete(name, subpartition, key));
+    statements.add(schema.delete(tableName, subpartition, key));
   }
 
   @Override
@@ -79,7 +79,7 @@ public class FactSchemaWriter<K> implements RemoteWriter<K> {
 
   @Override
   public RemoteWriteResult setOffset(final long offset) {
-    final var result = client.execute(schema.setOffset(name, subpartition, offset));
+    final var result = client.execute(schema.setOffset(tableName, subpartition, offset));
     return result.wasApplied()
         ? RemoteWriteResult.success(subpartition)
         : RemoteWriteResult.failure(subpartition);

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/FactWriterFactory.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/FactWriterFactory.java
@@ -27,15 +27,15 @@ public class FactWriterFactory<K> implements WriterFactory<K> {
   @Override
   public RemoteWriter<K> createWriter(
       final CassandraClient client,
-      final String name,
-      final int partition,
+      final String tableName,
+      final int subpartition,
       final int batchSize
   ) {
     return new FactSchemaWriter<>(
         client,
         schema,
-        name,
-        partition
+        tableName,
+        subpartition
     );
   }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/FactWriterFactory.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/FactWriterFactory.java
@@ -28,14 +28,14 @@ public class FactWriterFactory<K> implements WriterFactory<K> {
   public RemoteWriter<K> createWriter(
       final CassandraClient client,
       final String tableName,
-      final int subpartition,
+      final int tablePartition,
       final int batchSize
   ) {
     return new FactSchemaWriter<>(
         client,
         schema,
         tableName,
-        subpartition
+        tablePartition
     );
   }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/LwtWriter.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/LwtWriter.java
@@ -33,7 +33,7 @@ public class LwtWriter<K> implements RemoteWriter<K> {
   private final Supplier<BatchableStatement<?>> fencingStatementFactory;
   private final RemoteSchema<K> schema;
   private final String tableName;
-  private final int subpartition;
+  private final int tablePartition;
   private final int batchSize;
 
   private final List<BatchableStatement<?>> statements;
@@ -43,14 +43,14 @@ public class LwtWriter<K> implements RemoteWriter<K> {
       final Supplier<BatchableStatement<?>> fencingStatementFactory,
       final RemoteSchema<K> schema,
       final String tableName,
-      final int subpartition,
+      final int tablePartition,
       final int batchSize
   ) {
     this.client = client;
     this.fencingStatementFactory = fencingStatementFactory;
     this.schema = schema;
     this.tableName = tableName;
-    this.subpartition = subpartition;
+    this.tablePartition = tablePartition;
     this.batchSize = batchSize;
 
     statements = new ArrayList<>();
@@ -58,17 +58,17 @@ public class LwtWriter<K> implements RemoteWriter<K> {
 
   @Override
   public void insert(final K key, final byte[] value, long epochMillis) {
-    statements.add(schema.insert(tableName, subpartition, key, value, epochMillis));
+    statements.add(schema.insert(tableName, tablePartition, key, value, epochMillis));
   }
 
   @Override
   public void delete(final K key) {
-    statements.add(schema.delete(tableName, subpartition, key));
+    statements.add(schema.delete(tableName, tablePartition, key));
   }
 
   @Override
   public CompletionStage<RemoteWriteResult> flush() {
-    var result = CompletableFuture.completedStage(RemoteWriteResult.success(subpartition));
+    var result = CompletableFuture.completedStage(RemoteWriteResult.success(tablePartition));
 
     final var it = statements.iterator();
     while (it.hasNext()) {
@@ -90,21 +90,21 @@ public class LwtWriter<K> implements RemoteWriter<K> {
   public RemoteWriteResult setOffset(final long offset) {
     final BatchStatementBuilder builder = new BatchStatementBuilder(BatchType.UNLOGGED);
     builder.addStatement(fencingStatementFactory.get());
-    builder.addStatement(schema.setOffset(tableName, subpartition, offset));
+    builder.addStatement(schema.setOffset(tableName, tablePartition, offset));
 
     final var result = client.execute(builder.build());
     return result.wasApplied()
-        ? RemoteWriteResult.success(subpartition)
-        : RemoteWriteResult.failure(subpartition);
+        ? RemoteWriteResult.success(tablePartition)
+        : RemoteWriteResult.failure(tablePartition);
   }
 
   @Override
-  public int subpartition() {
-    return subpartition;
+  public int tablePartition() {
+    return tablePartition;
   }
 
   private CompletionStage<RemoteWriteResult> executeAsync(final Statement<?> statement) {
     return client.executeAsync(statement)
-        .thenApply(resp -> RemoteWriteResult.of(subpartition, resp));
+        .thenApply(resp -> RemoteWriteResult.of(tablePartition, resp));
   }
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/LwtWriterFactory.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/LwtWriterFactory.java
@@ -85,12 +85,12 @@ public class LwtWriterFactory<K> implements WriterFactory<K> {
   public static <K> LwtWriterFactory<K> reserve(
       final RemoteSchema<K> schema,
       final String tableName,
-      final int[] subpartitions,
+      final int[] tablePartitions,
       final int kafkaPartition,
       final long epoch,
       final boolean windowed
   ) {
-    for (final int sub : subpartitions) {
+    for (final int sub : tablePartitions) {
       final var setEpoch = windowed
           ? reserveEpochWindowed(schema, tableName, sub, epoch)
           : reserveEpoch(schema, tableName, sub, epoch);
@@ -135,15 +135,15 @@ public class LwtWriterFactory<K> implements WriterFactory<K> {
   public RemoteWriter<K> createWriter(
       final CassandraClient client,
       final String tableName,
-      final int subpartition,
+      final int tablePartition,
       final int batchSize
   ) {
     return new LwtWriter<>(
         client,
-        () -> ensureEpoch.bind().setInt(PARTITION_KEY.bind(), subpartition),
+        () -> ensureEpoch.bind().setInt(PARTITION_KEY.bind(), tablePartition),
         schema,
         tableName,
-        subpartition,
+        tablePartition,
         batchSize
     );
   }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/RemoteWriter.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/RemoteWriter.java
@@ -29,5 +29,5 @@ public interface RemoteWriter<K> {
 
   RemoteWriteResult setOffset(final long offset);
 
-  int subpartition();
+  int tablePartition();
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/RemoteWriter.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/RemoteWriter.java
@@ -29,5 +29,5 @@ public interface RemoteWriter<K> {
 
   RemoteWriteResult setOffset(final long offset);
 
-  int partition();
+  int subpartition();
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/WriterFactory.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/WriterFactory.java
@@ -20,8 +20,8 @@ public interface WriterFactory<K> {
 
   RemoteWriter<K> createWriter(
       final CassandraClient client,
-      final String name,
-      final int partition,
+      final String tableName,
+      final int subpartition,
       final int batchSize
   );
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/WriterFactory.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/WriterFactory.java
@@ -21,7 +21,7 @@ public interface WriterFactory<K> {
   RemoteWriter<K> createWriter(
       final CassandraClient client,
       final String tableName,
-      final int subpartition,
+      final int tablePartition,
       final int batchSize
   );
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/AbstractResponsiveStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/AbstractResponsiveStore.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.kafka.internal.stores;
+
+import static org.apache.kafka.streams.processor.internals.ProcessorContextUtils.asInternalProcessorContext;
+
+import dev.responsive.kafka.internal.db.CassandraClient;
+import dev.responsive.kafka.internal.utils.TableName;
+import java.util.Collection;
+import java.util.function.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.processor.StateStoreContext;
+import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
+import org.apache.kafka.streams.query.Position;
+
+public abstract class AbstractResponsiveStore implements StateStore {
+
+  protected final TableName name;
+  protected final Position position; // TODO(IQ): update the position during restoration
+
+  // Initialized during #init
+  @SuppressWarnings("rawtypes")
+  protected InternalProcessorContext context;
+  protected TopicPartition changelog;
+  protected CassandraClient client;
+  protected ResponsiveStoreRegistry storeRegistry;
+  protected ResponsiveStoreRegistration registration;
+
+  private boolean open;
+
+  public AbstractResponsiveStore(final TableName name) {
+    this.name = name;
+    this.position = Position.emptyPosition();
+  }
+
+  @SuppressWarnings("rawtypes")
+  protected void init(
+      final StateStoreContext storeContext,
+      final CassandraClient client,
+      final ResponsiveStoreRegistry storeRegistry,
+      final TopicPartition changelog
+  ) {
+    this.context = asInternalProcessorContext(storeContext);
+    this.client = client;
+    this.storeRegistry = storeRegistry;
+    this.changelog = changelog;
+  }
+
+  protected void open(
+      final StateStore root,
+      final Consumer<Collection<ConsumerRecord<byte[], byte[]>>> restoreBatch
+  ) {
+    context.register(root, new ResponsiveRestoreCallback(restoreBatch));
+    open = true;
+  }
+
+  @Override
+  public String name() {
+    return name.kafkaName();
+  }
+
+  @Override
+  public boolean isOpen() {
+    return open;
+  }
+
+  @Override
+  public boolean persistent() {
+    // Kafka Streams uses this to determine whether it
+    // needs to create and lock state directories. since
+    // the Responsive Client doesn't require flushing state
+    // to disk, we return false even though the store is
+    // persistent in a remote store
+    return false;
+  }
+
+  @Override
+  public Position getPosition() {
+    return position;
+  }
+
+  @Override
+  public void flush() {
+    // Kafka Streams uses this to determine whether it
+    // needs to create and lock state directories. since
+    // the Responsive Client doesn't require flushing state
+    // to disk, we return false even though the store is
+    // persistent in a remote store
+  }
+}

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveGlobalStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveGlobalStore.java
@@ -81,8 +81,8 @@ public class ResponsiveGlobalStore extends AbstractResponsiveStore
       final SharedClients sharedClients = loadSharedClients(storeContext.appConfigs());
 
       // this is bad, but the assumption is that global tables are small
-      // and can fit in a single topicPartition - all writers will write using
-      // the same topicPartition key. we should consider using ALLOW FILTERING
+      // and can fit in a single table partition - all writers will write using
+      // the same partition key. we should consider using ALLOW FILTERING
       // instead. that would make gets/puts more efficient and the queries
       // to be more evently distributed and take the hit only on range queries
       final TopicPartition globalTopicPartition =

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveKeyValueStoreWrapper.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveKeyValueStoreWrapper.java
@@ -36,12 +36,12 @@ import org.apache.kafka.streams.query.QueryResult;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
 
-public class ResponsiveStore implements KeyValueStore<Bytes, byte[]> {
+public class ResponsiveKeyValueStoreWrapper implements KeyValueStore<Bytes, byte[]> {
 
   private final ResponsiveKeyValueParams params;
   private KeyValueStore<Bytes, byte[]> delegate;
 
-  public ResponsiveStore(final ResponsiveKeyValueParams params) {
+  public ResponsiveKeyValueStoreWrapper(final ResponsiveKeyValueParams params) {
     this.params = params;
   }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsivePartitionedStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsivePartitionedStore.java
@@ -17,6 +17,7 @@
 package dev.responsive.kafka.internal.stores;
 
 import static dev.responsive.kafka.internal.utils.SharedClients.loadSharedClients;
+import static org.apache.kafka.streams.processor.internals.ProcessorContextUtils.asInternalProcessorContext;
 import static org.apache.kafka.streams.processor.internals.ProcessorContextUtils.changelogFor;
 
 import dev.responsive.kafka.api.config.ResponsiveConfig;
@@ -87,7 +88,7 @@ public class ResponsivePartitionedStore extends AbstractResponsiveStore
           InternalConfigs.loadStoreRegistry(storeContext.appConfigs()),
           new TopicPartition(
               changelogFor(storeContext, name.kafkaName(), false),
-              context.taskId().partition())
+              asInternalProcessorContext(storeContext).taskId().partition())
       );
 
       partitioner = params.schemaType() == KVSchema.FACT

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveRestoreCallback.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveRestoreCallback.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.kafka.internal.stores;
+
+import java.util.Collection;
+import java.util.function.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.streams.processor.internals.RecordBatchingStateRestoreCallback;
+
+public class ResponsiveRestoreCallback
+    implements RecordBatchingStateRestoreCallback {
+
+  private final Consumer<Collection<ConsumerRecord<byte[], byte[]>>> restoreBatch;
+
+  public ResponsiveRestoreCallback(
+      final Consumer<Collection<ConsumerRecord<byte[], byte[]>>> restoreBatch
+  ) {
+    this.restoreBatch = restoreBatch;
+  }
+
+  @Override
+  public void restoreBatch(final Collection<ConsumerRecord<byte[], byte[]>> records) {
+    restoreBatch.accept(records);
+  }
+}

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveWindowStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveWindowStore.java
@@ -18,6 +18,7 @@ package dev.responsive.kafka.internal.stores;
 
 import static dev.responsive.kafka.api.config.ResponsiveConfig.responsiveConfig;
 import static dev.responsive.kafka.internal.utils.SharedClients.loadSharedClients;
+import static org.apache.kafka.streams.processor.internals.ProcessorContextUtils.asInternalProcessorContext;
 import static org.apache.kafka.streams.processor.internals.ProcessorContextUtils.changelogFor;
 
 import dev.responsive.kafka.api.config.ResponsiveConfig;
@@ -108,7 +109,7 @@ public class ResponsiveWindowStore extends AbstractResponsiveStore
           InternalConfigs.loadStoreRegistry(storeContext.appConfigs()),
           new TopicPartition(
               changelogFor(storeContext, name.kafkaName(), false),
-              context.taskId().partition())
+              asInternalProcessorContext(storeContext).taskId().partition())
       );
 
       partitioner = config.getSubPartitioner(sharedClients.admin, name, changelog.topic());

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/utils/SharedClients.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/utils/SharedClients.java
@@ -2,6 +2,7 @@ package dev.responsive.kafka.internal.utils;
 
 import dev.responsive.kafka.internal.config.InternalConfigs;
 import dev.responsive.kafka.internal.db.CassandraClient;
+import dev.responsive.kafka.internal.stores.ResponsiveStoreRegistry;
 import java.util.Map;
 import org.apache.kafka.clients.admin.Admin;
 
@@ -12,21 +13,28 @@ import org.apache.kafka.clients.admin.Admin;
 public class SharedClients {
   public final CassandraClient cassandraClient;
   public final Admin admin;
+  public final ResponsiveStoreRegistry storeRegistry;
 
   public static SharedClients loadSharedClients(final Map<String, Object> configs) {
     return new SharedClients(
         InternalConfigs.loadCassandraClient(configs),
-        InternalConfigs.loadKafkaAdmin(configs)
+        InternalConfigs.loadKafkaAdmin(configs),
+        InternalConfigs.loadStoreRegistry(configs)
     );
   }
 
-  public SharedClients(final CassandraClient cassandraClient, final Admin admin) {
+  public SharedClients(
+      final CassandraClient cassandraClient,
+      final Admin admin,
+      final ResponsiveStoreRegistry storeRegistry
+  ) {
     this.cassandraClient = cassandraClient;
     this.admin = admin;
+    this.storeRegistry = storeRegistry;
   }
 
   public void closeAll() {
-    cassandraClient.shutdown();
+    cassandraClient.close();
     admin.close();
   }
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/utils/SharedClients.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/utils/SharedClients.java
@@ -34,7 +34,7 @@ public class SharedClients {
   }
 
   public void closeAll() {
-    cassandraClient.close();
+    cassandraClient.shutdown();
     admin.close();
   }
 }

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/ResponsiveKeyValueStoreWrapperTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/ResponsiveKeyValueStoreWrapperTest.java
@@ -20,9 +20,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.instanceOf;
 
 import dev.responsive.kafka.api.stores.ResponsiveKeyValueParams;
-import dev.responsive.kafka.internal.stores.ResponsiveGlobalStore;
-import dev.responsive.kafka.internal.stores.ResponsivePartitionedStore;
-import dev.responsive.kafka.internal.stores.ResponsiveStore;
 import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StateStoreContext;
 import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
@@ -37,11 +34,11 @@ import org.mockito.quality.Strictness;
 
 @ExtendWith(MockitoExtension.class)
 @MockitoSettings(strictness = Strictness.LENIENT)
-public class ResponsiveStoreTest {
+public class ResponsiveKeyValueStoreWrapperTest {
 
   private static final String NAME = "foo";
-  private final ResponsiveStore store =
-      new ResponsiveStore(ResponsiveKeyValueParams.keyValue(NAME));
+  private final ResponsiveKeyValueStoreWrapper store =
+      new ResponsiveKeyValueStoreWrapper(ResponsiveKeyValueParams.keyValue(NAME));
 
   @Mock
   private StateStore root;

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/internal/stores/TTDSchema.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/internal/stores/TTDSchema.java
@@ -55,7 +55,7 @@ public abstract class TTDSchema<K> implements RemoteSchema<K> {
       final SubPartitioner partitioner,
       final int kafkaPartition
   ) {
-    return (client, name, partition, batchSize) -> new TTDWriter<K>(this, tableName, partition);
+    return (client, name, tablePartition, batchSize) -> new TTDWriter<K>(this, tableName, tablePartition);
   }
 
   @Override
@@ -109,7 +109,7 @@ public abstract class TTDSchema<K> implements RemoteSchema<K> {
     }
 
     @Override
-    public int subpartition() {
+    public int tablePartition() {
       return partition;
     }
   }

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/internal/stores/TTDSchema.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/internal/stores/TTDSchema.java
@@ -109,7 +109,7 @@ public abstract class TTDSchema<K> implements RemoteSchema<K> {
     }
 
     @Override
-    public int partition() {
+    public int subpartition() {
       return partition;
     }
   }


### PR DESCRIPTION
There's a lot of shared and increasingly-complex logic in the three StateStore implementations. This would be a good time to extract it all into an abstract class that can be extended by the ResponsiveGlobalStore, ResponsivePartitionedStore, and ResponsiveWindowStore implementations (as well as ResponsiveSessionStore one day)

There aren't any real logical changes here, but it's an important refactoring that will help keep things organized and consistent across the state stores. Specifically, I'd like to have this merged and ready to take advantage of for both the standby-task fix and the upcoming WindowStore implementation, as well as some smaller ongoing side efforts like the restoration metrics