### PR TITLE
add support for different backends, starting with MongoDB

### DIFF
--- a/kafka-client/build.gradle.kts
+++ b/kafka-client/build.gradle.kts
@@ -68,6 +68,7 @@ dependencies {
     api(libs.kafka.streams)
 
     implementation(libs.bundles.scylla)
+    implementation(libs.mongodb.driver.sync)
 
     testImplementation(libs.kafka.clients) {
         artifact {

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
@@ -68,6 +68,10 @@ public class ResponsiveConfig extends AbstractConfig {
   public static final String CLIENT_SECRET_CONFIG = "responsive.client.secret";
   private static final String CLIENT_SECRET_DOC = "The client secret for authenticated access";
 
+  public static final String STORAGE_BACKEND_TYPE_CONFIG = "responsive.storage.backend.type";
+  private static final String STORAGE_BACKEND_TYPE_DOC = "The storage backend";
+  private static final StorageBackend STORAGE_BACKEND_TYPE_DEFAULT = StorageBackend.CASSANDRA;
+
   // ------------------ request configurations --------------------------------
 
   public static final String REQUEST_TIMEOUT_MS_CONFIG = "responsive.request.timeout.ms";
@@ -187,6 +191,13 @@ public class ResponsiveConfig extends AbstractConfig {
           new NonEmptyPassword(CLIENT_SECRET_CONFIG),
           Importance.HIGH,
           CLIENT_SECRET_DOC
+      ).define(
+          STORAGE_BACKEND_TYPE_CONFIG,
+          Type.STRING,
+          STORAGE_BACKEND_TYPE_DEFAULT.name(),
+          ConfigDef.CaseInsensitiveValidString.in(StorageBackend.names()),
+          Importance.HIGH,
+          STORAGE_BACKEND_TYPE_DOC
       ).define(
           REQUEST_TIMEOUT_MS_CONFIG,
           Type.LONG,

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/config/StorageBackend.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/config/StorageBackend.java
@@ -14,24 +14,15 @@
  * limitations under the License.
  */
 
-package dev.responsive.kafka.internal.utils;
+package dev.responsive.kafka.api.config;
 
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Test;
+import java.util.Arrays;
 
-class TableNameTest {
+public enum StorageBackend {
+  CASSANDRA,
+  MONGO_DB;
 
-  @Test
-  public void shouldReplaceInvalidCharsWithUnderscores() {
-    // Given:
-    final var kafkaName = "foo.Bar-baz_qux";
-
-    // When:
-    final var name = new TableName(kafkaName);
-
-    // Then:
-    MatcherAssert.assertThat(name.remoteName(), Matchers.is("foo_bar_baz__qux"));
+  public static String[] names() {
+    return Arrays.stream(values()).map(Enum::name).toArray(String[]::new);
   }
-
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/config/InternalConfigs.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/config/InternalConfigs.java
@@ -1,9 +1,12 @@
 package dev.responsive.kafka.internal.config;
 
+import com.mongodb.client.MongoClient;
 import dev.responsive.kafka.internal.db.CassandraClient;
+import dev.responsive.kafka.internal.db.mongo.ResponsiveMongoClient;
 import dev.responsive.kafka.internal.stores.ResponsiveStoreRegistry;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.streams.TopologyDescription;
 import org.slf4j.Logger;
@@ -16,11 +19,13 @@ public final class InternalConfigs {
       "__internal.responsive.cassandra.client__";
   private static final String INTERNAL_ADMIN_CLIENT_CONFIG =
           "__internal.responsive.admin.client__";
+  private static final String INTERNAL_MONGODB_CLIENT_CONFIG
+      = "__internal.responsive.mongo.client__";
 
   private static final String TOPOLOGY_DESCRIPTION_CONFIG
       = "__internal.responsive.topology.description__";
 
-  public static <T> T loadFromConfig(
+  public static <T> Optional<T> loadFromConfig(
       final Map<String, Object> configs,
       final String configName,
       final Class<T> type,
@@ -28,10 +33,7 @@ public final class InternalConfigs {
   ) {
     final Object o = configs.get(configName);
     if (o == null) {
-      final IllegalStateException fatalException =
-          new IllegalStateException(name + " was missing");
-      LOG.error(fatalException.getMessage(), fatalException);
-      throw fatalException;
+      return Optional.empty();
     } else if (!(type.isInstance(o))) {
       final IllegalStateException fatalException = new IllegalStateException(
           String.format("%s is not an instance of %s", o.getClass().getName(), type.getName())
@@ -39,19 +41,21 @@ public final class InternalConfigs {
       LOG.error(fatalException.getMessage(), fatalException);
       throw fatalException;
     }
-    return type.cast(o);
+    return Optional.of(type.cast(o));
   }
 
   private InternalConfigs() {
   }
 
-  public static TopologyDescription loadTopologyDescription(final Map<String, Object> config) {
+  public static Optional<TopologyDescription> loadTopologyDescription(
+      final Map<String, Object> config
+  ) {
     return loadFromConfig(
         config, TOPOLOGY_DESCRIPTION_CONFIG, TopologyDescription.class, "Topology description"
     );
   }
 
-  public static CassandraClient loadCassandraClient(final Map<String, Object> configs) {
+  public static Optional<CassandraClient> loadCassandraClient(final Map<String, Object> configs) {
     return loadFromConfig(
         configs,
         InternalConfigs.INTERNAL_CASSANDRA_CLIENT_CONFIG,
@@ -61,20 +65,43 @@ public final class InternalConfigs {
   }
 
   public static Admin loadKafkaAdmin(final Map<String, Object> configs) {
-    return loadFromConfig(
+    final var admin = loadFromConfig(
         configs,
         InternalConfigs.INTERNAL_ADMIN_CLIENT_CONFIG,
         Admin.class,
         "Shared Admin client"
     );
+    if (admin.isEmpty()) {
+      final IllegalStateException fatalException =
+          new IllegalStateException("Shared Admin client was missing");
+      LOG.error(fatalException.getMessage(), fatalException);
+      throw fatalException;
+    }
+    return admin.get();
   }
 
   public static ResponsiveStoreRegistry loadStoreRegistry(final Map<String, Object> configs) {
-    return loadFromConfig(
+    final var registry = loadFromConfig(
         configs,
         STORE_REGISTRY_CONFIG,
         ResponsiveStoreRegistry.class,
         "Store registry"
+    );
+    if (registry.isEmpty()) {
+      final IllegalStateException fatalException =
+          new IllegalStateException("Store registry was missing");
+      LOG.error(fatalException.getMessage(), fatalException);
+      throw fatalException;
+    }
+    return registry.get();
+  }
+
+  public static Optional<ResponsiveMongoClient> loadMongoClient(final Map<String, Object> configs) {
+    return loadFromConfig(
+        configs,
+        InternalConfigs.INTERNAL_MONGODB_CLIENT_CONFIG,
+        ResponsiveMongoClient.class,
+        "MongoDB Client"
     );
   }
 
@@ -101,6 +128,11 @@ public final class InternalConfigs {
       return this;
     }
 
+    public Builder withMongoDbClient(final ResponsiveMongoClient client) {
+      configs.put(INTERNAL_MONGODB_CLIENT_CONFIG, client);
+      return this;
+    }
+
     public Map<String, Object> build() {
       return Map.copyOf(configs);
     }
@@ -108,12 +140,14 @@ public final class InternalConfigs {
 
   public static Map<String, Object> getConfigs(
       final CassandraClient cassandraClient,
+      final MongoClient mongoClient,
       final Admin admin,
       final ResponsiveStoreRegistry registry,
       final TopologyDescription topologyDescription
   ) {
     return Map.of(
         INTERNAL_CASSANDRA_CLIENT_CONFIG, cassandraClient,
+        INTERNAL_MONGODB_CLIENT_CONFIG, mongoClient,
         INTERNAL_ADMIN_CLIENT_CONFIG, admin,
         STORE_REGISTRY_CONFIG, registry,
         TOPOLOGY_DESCRIPTION_CONFIG, topologyDescription

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraClient.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraClient.java
@@ -46,10 +46,10 @@ public class CassandraClient {
   private final CqlSession session;
 
   private final ResponsiveConfig config;
-  private final TableFactory<RemoteKVTable> kvFactory;
-  private final TableFactory<RemoteKVTable> factFactory;
-  private final TableFactory<RemoteWindowedTable> windowedFactory;
-  private final TableFactory<RemoteKVTable> globalFactory;
+  private final TableCache<RemoteKVTable> kvFactory;
+  private final TableCache<RemoteKVTable> factFactory;
+  private final TableCache<RemoteWindowedTable> windowedFactory;
+  private final TableCache<RemoteKVTable> globalFactory;
 
   /**
    * @param session the Cassandra session, expected to be initialized
@@ -61,10 +61,10 @@ public class CassandraClient {
     this.session = session;
     this.config = config;
 
-    this.kvFactory = new TableFactory<>(this, CassandraKeyValueTable::create);
-    this.factFactory = new TableFactory<>(this, CassandraFactTable::create);
-    this.windowedFactory = new TableFactory<>(this, CassandraWindowedTable::create);
-    this.globalFactory = new TableFactory<>(this, CassandraFactTable::create);
+    this.kvFactory = new TableCache<>(spec -> CassandraKeyValueTable.create(spec, this));
+    this.factFactory = new TableCache<>(spec -> CassandraFactTable.create(spec, this));
+    this.windowedFactory = new TableCache<>(spec -> CassandraWindowedTable.create(spec, this));
+    this.globalFactory = new TableCache<>(spec -> CassandraFactTable.create(spec, this));
   }
 
   protected CassandraClient(final ResponsiveConfig config) {
@@ -151,19 +151,19 @@ public class CassandraClient {
     session.close();
   }
 
-  public TableFactory<RemoteKVTable> globalFactory() {
+  public TableCache<RemoteKVTable> globalFactory() {
     return globalFactory;
   }
 
-  public TableFactory<RemoteKVTable> kvFactory() {
+  public TableCache<RemoteKVTable> kvFactory() {
     return kvFactory;
   }
 
-  public TableFactory<RemoteKVTable> factFactory() {
+  public TableCache<RemoteKVTable> factFactory() {
     return factFactory;
   }
 
-  public TableFactory<RemoteWindowedTable> windowedFactory() {
+  public TableCache<RemoteWindowedTable> windowedFactory() {
     return windowedFactory;
   }
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraClientFactory.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraClientFactory.java
@@ -7,7 +7,7 @@ public interface CassandraClientFactory {
 
   CqlSession createCqlSession(final ResponsiveConfig config);
 
-  CassandraClient createCassandraClient(
+  CassandraClient createClient(
       final CqlSession session,
       final ResponsiveConfig config
   );

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraFactTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraFactTable.java
@@ -227,8 +227,8 @@ public class CassandraFactTable implements RemoteKVTable {
   }
 
   @Override
-  public CassandraClient cassandraClient() {
-    return client;
+  public long approximateNumEntries(final int partition) {
+    return client.count(name(), partition);
   }
 
   @Override

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraKeyValueTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraKeyValueTable.java
@@ -216,7 +216,7 @@ public class CassandraKeyValueTable implements RemoteKVTable {
               .build()
       );
     });
-    return LwtWriterFactory.reserve(this, partitioner, kafkaPartition);
+    return LwtWriterFactory.reserve(this, client, partitioner, kafkaPartition);
   }
 
   @Override
@@ -334,8 +334,8 @@ public class CassandraKeyValueTable implements RemoteKVTable {
   }
 
   @Override
-  public CassandraClient cassandraClient() {
-    return client;
+  public long approximateNumEntries(final int partition) {
+    return client.count(name(), partition);
   }
 
   private static KeyValue<Bytes, byte[]> rows(final Row row) {

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraTableSpecFactory.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraTableSpecFactory.java
@@ -37,11 +37,11 @@ import dev.responsive.kafka.internal.stores.SchemaTypes;
 public class CassandraTableSpecFactory {
 
   public static CassandraTableSpec globalSpec(final ResponsiveKeyValueParams params) {
-    return new GlobalTableSpec(new BaseTableSpec(params.name().cassandraName()));
+    return new GlobalTableSpec(new BaseTableSpec(params.name().remoteName()));
   }
 
   public static CassandraTableSpec fromKVParams(final ResponsiveKeyValueParams params) {
-    CassandraTableSpec spec = new BaseTableSpec(params.name().cassandraName());
+    CassandraTableSpec spec = new BaseTableSpec(params.name().remoteName());
 
     if (params.timeToLive().isPresent()) {
       spec = new TtlTableSpec(spec, params.timeToLive().get());
@@ -55,7 +55,7 @@ public class CassandraTableSpecFactory {
   }
 
   public static CassandraTableSpec fromWindowParams(final ResponsiveWindowParams params) {
-    return new BaseTableSpec(params.name().cassandraName());
+    return new BaseTableSpec(params.name().remoteName());
   }
 
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraWindowedTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraWindowedTable.java
@@ -80,7 +80,7 @@ public class CassandraWindowedTable implements RemoteWindowedTable {
   private final PreparedStatement setOffset;
 
   public static CassandraWindowedTable create(
-      CassandraTableSpec spec,
+      final CassandraTableSpec spec,
       final CassandraClient client
   ) throws InterruptedException, TimeoutException {
     final String name = spec.tableName();
@@ -310,7 +310,12 @@ public class CassandraWindowedTable implements RemoteWindowedTable {
               .build()
       );
     });
-    return LwtWriterFactory.reserveWindowed(this, partitioner, kafkaPartition);
+    return LwtWriterFactory.reserveWindowed(
+        this,
+        client,
+        partitioner,
+        kafkaPartition
+    );
   }
 
   @Override
@@ -344,8 +349,8 @@ public class CassandraWindowedTable implements RemoteWindowedTable {
   }
 
   @Override
-  public CassandraClient cassandraClient() {
-    return client;
+  public long approximateNumEntries(final int partition) {
+    return client.count(name(), partition);
   }
 
   /**

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/DefaultCassandraClientFactory.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/DefaultCassandraClientFactory.java
@@ -38,7 +38,7 @@ public class DefaultCassandraClientFactory implements CassandraClientFactory {
   }
 
   @Override
-  public CassandraClient createCassandraClient(
+  public CassandraClient createClient(
       final CqlSession session,
       final ResponsiveConfig responsiveConfigs
   ) {

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/RemoteTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/RemoteTable.java
@@ -29,7 +29,7 @@ public interface RemoteTable<K> {
    * their initialized values.
    *
    * @return a {@link WriterFactory} that gives the callee access
-   *         to run statements on {@code table}
+   * to run statements on {@code table}
    */
   WriterFactory<K> init(
       final SubPartitioner partitioner,
@@ -90,6 +90,5 @@ public interface RemoteTable<K> {
       final long offset
   );
 
-  CassandraClient cassandraClient();
-
+  long approximateNumEntries(int partition);
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/TableCache.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/TableCache.java
@@ -28,23 +28,18 @@ import javax.annotation.concurrent.ThreadSafe;
  * table are only prepared once during the lifetime of the application.
  */
 @ThreadSafe
-public class TableFactory<T extends RemoteTable<?>> {
+public class TableCache<T extends RemoteTable<?>> {
 
   @FunctionalInterface
   public interface Factory<T> {
-    T create(final CassandraTableSpec spec, final CassandraClient client)
+    T create(final CassandraTableSpec spec)
         throws InterruptedException, TimeoutException;
   }
 
   private final Map<String, T> tables = new HashMap<>();
-  private final CassandraClient client;
   private final Factory<T> factory;
 
-  public TableFactory(
-      final CassandraClient client,
-      final Factory<T> factory
-  ) {
-    this.client = client;
+  public TableCache(final Factory<T> factory) {
     this.factory = factory;
   }
 
@@ -59,7 +54,7 @@ public class TableFactory<T extends RemoteTable<?>> {
       return existing;
     }
 
-    final T table = factory.create(spec, client);
+    final T table = factory.create(spec);
     tables.put(spec.tableName(), table);
     return table;
   }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/WriterFactory.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/WriterFactory.java
@@ -16,10 +16,12 @@
 
 package dev.responsive.kafka.internal.db;
 
+import dev.responsive.kafka.internal.utils.SharedClients;
+
 public interface WriterFactory<K> {
 
   RemoteWriter<K> createWriter(
-      final CassandraClient client,
+      final SharedClients client,
       final int partition,
       final int batchSize
   );

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/KVDoc.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/KVDoc.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.kafka.internal.db.mongo;
+
+import org.bson.codecs.pojo.annotations.BsonId;
+import org.bson.types.ObjectId;
+
+public class KVDoc {
+
+  @BsonId
+  ObjectId id;
+  byte[] key;
+  byte[] value;
+  long epoch;
+
+  public KVDoc() {
+  }
+
+  public KVDoc(final byte[] key, final byte[] value, final long epoch) {
+    this.key = key;
+    this.value = value;
+    this.epoch = epoch;
+  }
+
+  public ObjectId getId() {
+    return id;
+  }
+
+  public void setId(final ObjectId id) {
+    this.id = id;
+  }
+
+  public void setKey(final byte[] key) {
+    this.key = key;
+  }
+
+  public void setValue(final byte[] value) {
+    this.value = value;
+  }
+
+  public void setEpoch(final long epoch) {
+    this.epoch = epoch;
+  }
+
+  public byte[] getKey() {
+    return key;
+  }
+
+  public byte[] getValue() {
+    return value;
+  }
+
+  public long getEpoch() {
+    return epoch;
+  }
+}

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MetadataDoc.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MetadataDoc.java
@@ -14,33 +14,42 @@
  * limitations under the License.
  */
 
-package dev.responsive.kafka.internal.db;
+package dev.responsive.kafka.internal.db.mongo;
 
-import dev.responsive.kafka.internal.utils.SharedClients;
+import org.bson.codecs.pojo.annotations.BsonId;
+import org.bson.types.ObjectId;
 
-public class FactWriterFactory<K> implements WriterFactory<K> {
+public class MetadataDoc {
 
-  private final RemoteTable<K> table;
+  @BsonId
+  ObjectId id;
+  int partition;
+  long offset;
 
-  public FactWriterFactory(final RemoteTable<K> table) {
-    this.table = table;
+  public MetadataDoc() {
   }
 
-  @Override
-  public RemoteWriter<K> createWriter(
-      final SharedClients client,
-      final int partition,
-      final int batchSize
-  ) {
-    return new FactSchemaWriter<>(
-        client.cassandraClient(),
-        table,
-        partition
-    );
+  public ObjectId id() {
+    return id;
   }
 
-  @Override
-  public String toString() {
-    return "FactWriterFactory{}";
+  public void setId(final ObjectId id) {
+    this.id = id;
+  }
+
+  public int partition() {
+    return partition;
+  }
+
+  public void setPartition(final int partition) {
+    this.partition = partition;
+  }
+
+  public long offset() {
+    return offset;
+  }
+
+  public void setOffset(final long offset) {
+    this.offset = offset;
   }
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoKVTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoKVTable.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.kafka.internal.db.mongo;
+
+import static com.mongodb.MongoClientSettings.getDefaultCodecRegistry;
+import static dev.responsive.kafka.internal.stores.ResponsiveStoreRegistration.NO_COMMITTED_OFFSET;
+import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
+import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
+
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.UpdateOptions;
+import com.mongodb.client.model.Updates;
+import com.mongodb.client.result.UpdateResult;
+import dev.responsive.kafka.internal.db.MetadataRow;
+import dev.responsive.kafka.internal.db.RemoteKVTable;
+import dev.responsive.kafka.internal.db.WriterFactory;
+import dev.responsive.kafka.internal.db.partitioning.SubPartitioner;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.bson.codecs.configuration.CodecProvider;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.codecs.pojo.PojoCodecProvider;
+import org.bson.types.ObjectId;
+
+public class MongoKVTable implements RemoteKVTable {
+
+  private final String name;
+  private final MongoCollection<KVDoc> collection;
+  private final MongoCollection<MetadataDoc> metadata;
+
+  private final ConcurrentMap<Integer, ObjectId> metadataRows = new ConcurrentHashMap<>();
+
+  public MongoKVTable(final MongoClient client, final String name) {
+    this.name = name;
+    CodecProvider pojoCodecProvider = PojoCodecProvider.builder().automatic(true).build();
+    CodecRegistry pojoCodecRegistry = fromRegistries(
+        getDefaultCodecRegistry(),
+        fromProviders(pojoCodecProvider)
+    );
+
+    final MongoDatabase database = client.getDatabase(name).withCodecRegistry(pojoCodecRegistry);
+    collection = database.getCollection(name, KVDoc.class);
+    metadata = database.getCollection(name, MetadataDoc.class);
+  }
+
+  @Override
+  public String name() {
+    return name;
+  }
+
+  @Override
+  public WriterFactory<Bytes> init(final SubPartitioner partitioner, final int kafkaPartition) {
+    metadataRows.computeIfAbsent(kafkaPartition, kp -> {
+      final UpdateResult updateResult = metadata.updateOne(
+          Filters.eq("partition", kafkaPartition),
+          Updates.setOnInsert("offset", NO_COMMITTED_OFFSET),
+          new UpdateOptions().upsert(true));
+
+      if (updateResult.getUpsertedId() != null) {
+        return updateResult.getUpsertedId().asObjectId().getValue();
+      }
+
+      // find existing one
+      final MetadataDoc metadataPartition = metadata.find(
+          Filters.eq("partition", kafkaPartition)
+      ).first();
+      if (metadataPartition == null) {
+        throw new IllegalStateException("No metadata partition despite upsert");
+      }
+      return metadataPartition.id();
+    });
+
+    return new MongoWriterFactory<>(this);
+  }
+
+  @Override
+  public byte[] get(final int partition, final Bytes key, final long minValidTs) {
+    final KVDoc v = collection.find(Filters.eq("key", key.get())).first();
+    return v == null ? null : v.getValue();
+  }
+
+  @Override
+  public KeyValueIterator<Bytes, byte[]> range(final int partition, final Bytes from,
+                                               final Bytes to,
+                                               final long minValidTs) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public KeyValueIterator<Bytes, byte[]> all(final int partition, final long minValidTs) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public BoundStatement insert(
+      final int partitionKey,
+      final Bytes key,
+      final byte[] value,
+      final long epochMillis
+  ) {
+    collection.updateOne(
+        Filters.eq("key", key.get()),
+        Updates.set("value", value),
+        new UpdateOptions().upsert(true));
+    return null;
+  }
+
+  @Override
+  public BoundStatement delete(final int partitionKey, final Bytes key) {
+    collection.deleteOne(Filters.eq("key", key));
+    return null;
+  }
+
+  @Override
+  public MetadataRow metadata(final int partition) {
+    final MetadataDoc result = metadata.find(
+        Filters.eq("_id", metadataRows.get(partition))
+    ).first();
+    if (result == null) {
+      throw new IllegalStateException("Expected to find metadata row");
+    }
+    return new MetadataRow(result.offset, -1L);
+  }
+
+  @Override
+  public BoundStatement setOffset(final int partition, final long offset) {
+    final UpdateResult modifiedCount = metadata.updateOne(
+        Filters.eq("_id", metadataRows.get(partition)),
+        Updates.set("offset", offset)
+    );
+    return null;
+  }
+
+  @Override
+  public long approximateNumEntries(final int partition) {
+    return 0;
+  }
+
+}

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoWriter.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoWriter.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.kafka.internal.db.mongo;
+
+import dev.responsive.kafka.internal.db.RemoteTable;
+import dev.responsive.kafka.internal.db.RemoteWriter;
+import dev.responsive.kafka.internal.stores.RemoteWriteResult;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+public class MongoWriter<K> implements RemoteWriter<K> {
+
+  private final RemoteTable<K> table;
+  private final int partition;
+
+  public MongoWriter(final RemoteTable<K> table, final int partition) {
+    this.table = table;
+    this.partition = partition;
+  }
+
+  @Override
+  public void insert(final K key, final byte[] value, final long epochMillis) {
+    table.insert(partition, key, value, epochMillis);
+  }
+
+  @Override
+  public void delete(final K key) {
+    table.delete(partition, key);
+  }
+
+  @Override
+  public CompletionStage<RemoteWriteResult> flush() {
+    return CompletableFuture.completedFuture(RemoteWriteResult.success(partition));
+  }
+
+  @Override
+  public RemoteWriteResult setOffset(final long offset) {
+    table.setOffset(partition, offset);
+    return RemoteWriteResult.success(partition);
+  }
+}

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoWriterFactory.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoWriterFactory.java
@@ -14,15 +14,18 @@
  * limitations under the License.
  */
 
-package dev.responsive.kafka.internal.db;
+package dev.responsive.kafka.internal.db.mongo;
 
+import dev.responsive.kafka.internal.db.RemoteTable;
+import dev.responsive.kafka.internal.db.RemoteWriter;
+import dev.responsive.kafka.internal.db.WriterFactory;
 import dev.responsive.kafka.internal.utils.SharedClients;
 
-public class FactWriterFactory<K> implements WriterFactory<K> {
+public class MongoWriterFactory<K> implements WriterFactory<K> {
 
   private final RemoteTable<K> table;
 
-  public FactWriterFactory(final RemoteTable<K> table) {
+  public MongoWriterFactory(final RemoteTable<K> table) {
     this.table = table;
   }
 
@@ -32,15 +35,7 @@ public class FactWriterFactory<K> implements WriterFactory<K> {
       final int partition,
       final int batchSize
   ) {
-    return new FactSchemaWriter<>(
-        client.cassandraClient(),
-        table,
-        partition
-    );
+    return new MongoWriter<>(table, partition);
   }
 
-  @Override
-  public String toString() {
-    return "FactWriterFactory{}";
-  }
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/ResponsiveMongoClient.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/ResponsiveMongoClient.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.kafka.internal.db.mongo;
+
+import com.mongodb.client.MongoClient;
+import dev.responsive.kafka.internal.db.RemoteKVTable;
+import dev.responsive.kafka.internal.db.TableCache;
+import dev.responsive.kafka.internal.db.spec.BaseTableSpec;
+import java.util.concurrent.TimeoutException;
+
+public class ResponsiveMongoClient {
+
+  private final TableCache<RemoteKVTable> cache;
+  private final MongoClient client;
+
+  public ResponsiveMongoClient(final MongoClient client) {
+    this.client = client;
+    cache = new TableCache<>(spec -> new MongoKVTable(client, spec.tableName()));
+  }
+
+  public RemoteKVTable kvTable(final String name) throws InterruptedException, TimeoutException {
+    return cache.create(new BaseTableSpec(name));
+  }
+
+  public void close() {
+    client.close();
+  }
+}

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/CommitBuffer.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/CommitBuffer.java
@@ -19,7 +19,6 @@ package dev.responsive.kafka.internal.stores;
 import static org.apache.kafka.clients.admin.RecordsToDelete.beforeOffset;
 
 import dev.responsive.kafka.api.config.ResponsiveConfig;
-import dev.responsive.kafka.internal.db.CassandraClient;
 import dev.responsive.kafka.internal.db.KeySpec;
 import dev.responsive.kafka.internal.db.MetadataRow;
 import dev.responsive.kafka.internal.db.RemoteTable;
@@ -65,7 +64,7 @@ class CommitBuffer<K, S extends RemoteTable<K>>
   private final String logPrefix;
 
   private final SizeTrackingBuffer<K> buffer;
-  private final CassandraClient client;
+  private final SharedClients client;
   private final Admin admin;
   private final TopicPartition changelog;
   private final S table;
@@ -93,11 +92,10 @@ class CommitBuffer<K, S extends RemoteTable<K>>
       final SubPartitioner partitioner,
       final ResponsiveConfig config
   ) {
-    final var admin = clients.admin;
-    final var cassandraClient = clients.cassandraClient;
+    final var admin = clients.admin();
 
     return new CommitBuffer<>(
-        cassandraClient,
+        clients,
         changelog,
         admin,
         schema,
@@ -110,7 +108,7 @@ class CommitBuffer<K, S extends RemoteTable<K>>
   }
 
   CommitBuffer(
-      final CassandraClient client,
+      final SharedClients client,
       final TopicPartition changelog,
       final Admin admin,
       final S schema,
@@ -136,7 +134,7 @@ class CommitBuffer<K, S extends RemoteTable<K>>
   }
 
   CommitBuffer(
-      final CassandraClient client,
+      final SharedClients client,
       final TopicPartition changelog,
       final Admin admin,
       final S table,

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/GlobalOperations.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/GlobalOperations.java
@@ -16,10 +16,11 @@
 
 package dev.responsive.kafka.internal.stores;
 
+import dev.responsive.kafka.api.stores.ResponsiveKeyValueParams;
 import dev.responsive.kafka.internal.db.CassandraClient;
+import dev.responsive.kafka.internal.db.CassandraTableSpecFactory;
 import dev.responsive.kafka.internal.db.RemoteKVTable;
 import dev.responsive.kafka.internal.db.partitioning.SubPartitioner;
-import dev.responsive.kafka.internal.db.spec.CassandraTableSpec;
 import dev.responsive.kafka.internal.utils.SharedClients;
 import java.util.Collection;
 import java.util.concurrent.TimeoutException;
@@ -40,11 +41,12 @@ public class GlobalOperations implements KeyValueOperations {
 
   public static GlobalOperations create(
       final StateStoreContext storeContext,
-      final CassandraTableSpec spec
+      final ResponsiveKeyValueParams params
   ) throws InterruptedException, TimeoutException {
     final var context = (GlobalProcessorContextImpl) storeContext;
     final SharedClients sharedClients = SharedClients.loadSharedClients(context.appConfigs());
-    final var client = sharedClients.cassandraClient;
+    final var client = sharedClients.cassandraClient();
+    final var spec = CassandraTableSpecFactory.globalSpec(params);
     final var table = client.globalFactory().create(spec);
 
     table.init(SubPartitioner.NO_SUBPARTITIONS, IGNORED_PARTITION);

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveWindowStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveWindowStore.java
@@ -126,14 +126,14 @@ public class ResponsiveWindowStore implements WindowStore<Bytes, byte[]> {
 
       final ResponsiveConfig config = responsiveConfig(storeContext.appConfigs());
       final SharedClients sharedClients = loadSharedClients(storeContext.appConfigs());
-      final CassandraClient client = sharedClients.cassandraClient;
+      final CassandraClient client = sharedClients.cassandraClient();
 
       storeRegistry = InternalConfigs.loadStoreRegistry(context.appConfigs());
       partition =  new TopicPartition(
           changelogFor(storeContext, name.kafkaName(), false),
           context.taskId().partition()
       );
-      partitioner = config.getSubPartitioner(sharedClients.admin, name, partition.topic());
+      partitioner = config.getSubPartitioner(sharedClients.admin(), name, partition.topic());
 
       switch (params.schemaType()) {
         case WINDOW:
@@ -145,7 +145,7 @@ public class ResponsiveWindowStore implements WindowStore<Bytes, byte[]> {
           throw new IllegalArgumentException(params.schemaType().name());
       }
 
-      log.info("Remote table {} is available for querying.", name.cassandraName());
+      log.info("Remote table {} is available for querying.", name.remoteName());
 
       buffer = CommitBuffer.from(
           sharedClients,

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/utils/SharedClients.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/utils/SharedClients.java
@@ -1,32 +1,86 @@
 package dev.responsive.kafka.internal.utils;
 
+import dev.responsive.kafka.api.config.StorageBackend;
 import dev.responsive.kafka.internal.config.InternalConfigs;
 import dev.responsive.kafka.internal.db.CassandraClient;
+import dev.responsive.kafka.internal.db.mongo.ResponsiveMongoClient;
 import java.util.Map;
+import java.util.Optional;
 import org.apache.kafka.clients.admin.Admin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Basic container class for session clients and other shared resources that should only
  * be closed when the app itself is shutdown
  */
 public class SharedClients {
-  public final CassandraClient cassandraClient;
-  public final Admin admin;
+
+  private final Optional<ResponsiveMongoClient> mongoClient;
+  private final Optional<CassandraClient> cassandraClient;
+  private final Admin admin;
+
+  private static final Logger LOG = LoggerFactory.getLogger(SharedClients.class);
 
   public static SharedClients loadSharedClients(final Map<String, Object> configs) {
     return new SharedClients(
+        InternalConfigs.loadMongoClient(configs),
         InternalConfigs.loadCassandraClient(configs),
         InternalConfigs.loadKafkaAdmin(configs)
     );
   }
 
-  public SharedClients(final CassandraClient cassandraClient, final Admin admin) {
+  public SharedClients(
+      final Optional<ResponsiveMongoClient> mongoClient,
+      final Optional<CassandraClient> cassandraClient,
+      final Admin admin
+  ) {
+    this.mongoClient = mongoClient;
     this.cassandraClient = cassandraClient;
     this.admin = admin;
+
+
   }
 
   public void closeAll() {
-    cassandraClient.shutdown();
-    admin.close();
+    cassandraClient.ifPresent(CassandraClient::shutdown);
+    mongoClient.ifPresent(ResponsiveMongoClient::close);
+    admin().close();
+  }
+
+  public StorageBackend storageBackend() {
+    if (mongoClient.isPresent()) {
+      return StorageBackend.MONGO_DB;
+    } else if (cassandraClient.isPresent()) {
+      return StorageBackend.CASSANDRA;
+    } else {
+      throw new IllegalArgumentException("Invalid Shared Clients Configuration");
+    }
+  }
+
+  public ResponsiveMongoClient mongoClient() {
+    if (mongoClient.isEmpty()) {
+      final IllegalStateException fatalException =
+          new IllegalStateException("MongoDB client was missing");
+      LOG.error(fatalException.getMessage(), fatalException);
+      throw fatalException;
+    }
+
+    return mongoClient.get();
+  }
+
+  public CassandraClient cassandraClient() {
+    if (cassandraClient.isEmpty()) {
+      final IllegalStateException fatalException =
+          new IllegalStateException("Cassandra client was missing");
+      LOG.error(fatalException.getMessage(), fatalException);
+      throw fatalException;
+    }
+
+    return cassandraClient.get();
+  }
+
+  public Admin admin() {
+    return admin;
   }
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/utils/TableName.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/utils/TableName.java
@@ -32,12 +32,12 @@ public class TableName {
       Pattern.compile("[^a-zA-Z0-9_]");
 
   private final String kafkaName;
-  private final String cassandraName;
+  private final String remoteName;
 
   public TableName(final String kafkaName) {
     this.kafkaName = kafkaName;
     final var escaped = kafkaName.replaceAll("_", "__"); // escape existing underscores
-    cassandraName = INVALID_CASSANDRA_CHARS
+    remoteName = INVALID_CASSANDRA_CHARS
         .matcher(escaped)
         .replaceAll("_")
         .toLowerCase();
@@ -47,8 +47,8 @@ public class TableName {
     return kafkaName;
   }
 
-  public String cassandraName() {
-    return cassandraName;
+  public String remoteName() {
+    return remoteName;
   }
 
   @Override
@@ -61,16 +61,16 @@ public class TableName {
     }
     final TableName tableName = (TableName) o;
     return Objects.equals(kafkaName, tableName.kafkaName)
-        && Objects.equals(cassandraName, tableName.cassandraName);
+        && Objects.equals(remoteName, tableName.remoteName);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(kafkaName, cassandraName);
+    return Objects.hash(kafkaName, remoteName);
   }
 
   @Override
   public String toString() {
-    return kafkaName + "(" + cassandraName + ")";
+    return kafkaName + "(" + remoteName + ")";
   }
 }

--- a/kafka-client/src/test/java/dev/responsive/kafka/integration/MinimalIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/integration/MinimalIntegrationTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.kafka.integration;
+
+import static dev.responsive.kafka.testutils.IntegrationTestUtils.createTopicsAndWait;
+import static dev.responsive.kafka.testutils.IntegrationTestUtils.pipeInput;
+import static dev.responsive.kafka.testutils.IntegrationTestUtils.readOutput;
+import static dev.responsive.kafka.testutils.IntegrationTestUtils.startAppAndAwaitRunning;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.APPLICATION_ID_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.NUM_STREAM_THREADS_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.consumerPrefix;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItems;
+
+import dev.responsive.kafka.api.ResponsiveKafkaStreams;
+import dev.responsive.kafka.api.config.StorageBackend;
+import dev.responsive.kafka.api.stores.ResponsiveKeyValueParams;
+import dev.responsive.kafka.api.stores.ResponsiveStores;
+import dev.responsive.kafka.testutils.ResponsiveConfigParam;
+import dev.responsive.kafka.testutils.ResponsiveExtension;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.common.serialization.LongDeserializer;
+import org.apache.kafka.common.serialization.LongSerializer;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.kstream.KStream;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+/**
+ * This class tests the most minimal Kafka Streams application that uses
+ * a Responsive state store. It's mostly intended to be used as part of
+ * the development workflow, and therefore is disabled by default (to speed
+ * up test time).
+ */
+@Disabled
+public class MinimalIntegrationTest {
+
+  @RegisterExtension
+  static ResponsiveExtension EXTENSION = new ResponsiveExtension(StorageBackend.MONGO_DB);
+
+  private static final String INPUT_TOPIC = "input";
+  private static final String OUTPUT_TOPIC = "output";
+
+  private final Map<String, Object> responsiveProps = new HashMap<>();
+
+  private String name;
+  private Admin admin;
+
+  @BeforeEach
+  public void before(
+      final TestInfo info,
+      final Admin admin,
+      @ResponsiveConfigParam final Map<String, Object> responsiveProps
+  ) {
+    // add displayName to name to account for parameterized tests
+    name = info.getDisplayName().replace("()", "");
+    ScheduledExecutorService executor = new ScheduledThreadPoolExecutor(2);
+
+    this.responsiveProps.putAll(responsiveProps);
+
+    this.admin = admin;
+    createTopicsAndWait(admin, Map.of(inputTopic(), 2, outputTopic(), 1));
+  }
+
+  @AfterEach
+  public void after() {
+    admin.deleteTopics(List.of(inputTopic(), outputTopic()));
+  }
+
+  private String inputTopic() {
+    return name + "." + INPUT_TOPIC;
+  }
+
+  private String outputTopic() {
+    return name + "." + OUTPUT_TOPIC;
+  }
+
+  @Test
+  public void test() throws Exception {
+    // Given:
+    final Map<String, Object> properties = getMutableProperties();
+    final KafkaProducer<Long, Long> producer = new KafkaProducer<>(properties);
+    try (final ResponsiveKafkaStreams streams = buildStreams(properties)) {
+      startAppAndAwaitRunning(Duration.ofSeconds(10), streams);
+      pipeInput(inputTopic(), 2, producer, System::currentTimeMillis, 0, 10, 0, 1);
+
+      final var kvs = readOutput(outputTopic(), 0, 20, true, properties);
+      assertThat(
+          kvs,
+          hasItems(new KeyValue<>(0L, 10L), new KeyValue<>(1L, 10L)));
+    }
+  }
+
+  private ResponsiveKafkaStreams buildStreams(final Map<String, Object> properties) {
+    final StreamsBuilder builder = new StreamsBuilder();
+
+    final KStream<Long, Long> input = builder.stream(inputTopic());
+    input
+        .groupByKey()
+        .count(ResponsiveStores.materialized(ResponsiveKeyValueParams.keyValue("countStore")))
+        .toStream()
+        .to(outputTopic());
+
+    return new ResponsiveKafkaStreams(builder.build(), properties);
+  }
+
+  private Map<String, Object> getMutableProperties() {
+    final Map<String, Object> properties = new HashMap<>(responsiveProps);
+
+    properties.put(KEY_SERIALIZER_CLASS_CONFIG, LongSerializer.class);
+    properties.put(VALUE_SERIALIZER_CLASS_CONFIG, LongSerializer.class);
+    properties.put(KEY_DESERIALIZER_CLASS_CONFIG, LongDeserializer.class);
+    properties.put(VALUE_DESERIALIZER_CLASS_CONFIG, LongDeserializer.class);
+
+    properties.put(APPLICATION_ID_CONFIG, name);
+    properties.put(DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.LongSerde.class.getName());
+    properties.put(DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.LongSerde.class.getName());
+    properties.put(NUM_STREAM_THREADS_CONFIG, 1);
+    properties.put(STATESTORE_CACHE_MAX_BYTES_CONFIG, 0);
+
+    properties.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 1);
+    properties.put(consumerPrefix(ConsumerConfig.METADATA_MAX_AGE_CONFIG), "1000");
+    properties.put(consumerPrefix(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG), "earliest");
+
+    return properties;
+  }
+
+}

--- a/kafka-client/src/test/java/dev/responsive/kafka/integration/SubPartitionIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/integration/SubPartitionIntegrationTest.java
@@ -163,7 +163,7 @@ public class SubPartitionIntegrationTest {
               .collect(Collectors.toSet()),
           true,
           properties);
-      final String cassandraName = new TableName(storeName).cassandraName();
+      final String cassandraName = new TableName(storeName).remoteName();
       final RemoteKVTable table = CassandraKeyValueTable.create(
           new BaseTableSpec(cassandraName), client);
 
@@ -219,7 +219,7 @@ public class SubPartitionIntegrationTest {
               .collect(Collectors.toSet()),
           true,
           properties);
-      final String cassandraName = new TableName(storeName).cassandraName();
+      final String cassandraName = new TableName(storeName).remoteName();
       final RemoteKVTable table = CassandraFactTable.create(
           new BaseTableSpec(cassandraName), client);
 

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/CassandraFactTableIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/CassandraFactTableIntegrationTest.java
@@ -70,7 +70,7 @@ class CassandraFactTableIntegrationTest {
   public void shouldInitializeWithCorrectMetadata() throws Exception {
     // Given:
     params = ResponsiveKeyValueParams.fact(storeName);
-    final String tableName = params.name().cassandraName();
+    final String tableName = params.name().remoteName();
     final RemoteKVTable schema = client
         .factFactory()
         .create(CassandraTableSpecFactory.fromKVParams(params));
@@ -104,7 +104,7 @@ class CassandraFactTableIntegrationTest {
     // Given:
     final var ttl = Duration.ofDays(30);
     params = ResponsiveKeyValueParams.fact(storeName).withTimeToLive(ttl);
-    final String tableName = params.name().cassandraName();
+    final String tableName = params.name().remoteName();
 
     // When:
     final RemoteKVTable schema = client
@@ -132,7 +132,7 @@ class CassandraFactTableIntegrationTest {
   public void shouldUseTwcsWithoutTtl() throws Exception {
     // Given:
     params = ResponsiveKeyValueParams.fact(storeName);
-    final String tableName = params.name().cassandraName();
+    final String tableName = params.name().remoteName();
 
     // When:
     client.factFactory()
@@ -177,7 +177,7 @@ class CassandraFactTableIntegrationTest {
   public void shouldRespectSemanticTTL() throws Exception {
     // Given:
     params = ResponsiveKeyValueParams.fact(storeName);
-    final String tableName = params.name().cassandraName();
+    final String tableName = params.name().remoteName();
 
     final RemoteKVTable table = client
         .factFactory()

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/LwtWriterTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/LwtWriterTest.java
@@ -53,7 +53,7 @@ class LwtWriterTest {
   private static final long CURRENT_TS = 100L;
 
   @Mock
-  private WriterFactory<Bytes> writerFactory;
+  private WriterFactory<?> writerFactory;
   @Mock
   private CassandraClient client;
   @Mock

--- a/kafka-client/src/test/java/dev/responsive/kafka/testutils/IntegrationTestUtils.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/testutils/IntegrationTestUtils.java
@@ -3,8 +3,6 @@ package dev.responsive.kafka.testutils;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.ISOLATION_LEVEL_CONFIG;
 
 import dev.responsive.kafka.api.ResponsiveKafkaStreams;
-import dev.responsive.kafka.api.config.ResponsiveConfig;
-import dev.responsive.kafka.internal.config.ResponsiveStreamsConfig;
 import dev.responsive.kafka.internal.db.CassandraClientFactory;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -31,7 +29,6 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.KafkaClientSupplier;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KafkaStreams.State;
@@ -54,12 +51,10 @@ public final class IntegrationTestUtils {
         final CassandraClientFactory clientFactory
     ) {
       super(
-          topology,
-          ResponsiveConfig.responsiveConfig(config),
-          ResponsiveStreamsConfig.streamsConfig(config),
-          clientSupplier,
-          Time.SYSTEM,
-          clientFactory
+          new Params(topology, config)
+              .withClientSupplier(clientSupplier)
+              .withCassandraClientFactory(clientFactory)
+              .build()
       );
     }
   }

--- a/kafka-client/src/test/java/dev/responsive/kafka/testutils/TestConstants.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/testutils/TestConstants.java
@@ -22,5 +22,6 @@ public class TestConstants {
 
   public static final DockerImageName CASSANDRA = DockerImageName.parse("cassandra:4.1.0");
   public static final DockerImageName KAFKA = DockerImageName.parse("confluentinc/cp-kafka:7.3.2");
+  public static final DockerImageName MONGODB = DockerImageName.parse("mongo:7.0.2");
 
 }

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/internal/clients/TTDCassandraClient.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/internal/clients/TTDCassandraClient.java
@@ -26,7 +26,7 @@ import com.datastax.oss.driver.api.core.cql.Statement;
 import dev.responsive.kafka.internal.db.CassandraClient;
 import dev.responsive.kafka.internal.db.RemoteKVTable;
 import dev.responsive.kafka.internal.db.RemoteWindowedTable;
-import dev.responsive.kafka.internal.db.TableFactory;
+import dev.responsive.kafka.internal.db.TableCache;
 import dev.responsive.kafka.internal.stores.ResponsiveStoreRegistry;
 import dev.responsive.kafka.internal.stores.TTDKeyValueTable;
 import dev.responsive.kafka.internal.stores.TTDWindowedTable;
@@ -42,16 +42,16 @@ public class TTDCassandraClient extends CassandraClient {
   private final ResponsiveStoreRegistry storeRegistry = new ResponsiveStoreRegistry();
   private final TTDMockAdmin admin;
 
-  private final TableFactory<RemoteKVTable> kvFactory;
-  private final TableFactory<RemoteWindowedTable> windowedFactory;
+  private final TableCache<RemoteKVTable> kvFactory;
+  private final TableCache<RemoteWindowedTable> windowedFactory;
 
   public TTDCassandraClient(final TTDMockAdmin admin, final Time time) {
     super(loggedConfig(admin.props()));
     this.time = time;
     this.admin = admin;
 
-    kvFactory = new TableFactory<>(this, TTDKeyValueTable::create);
-    windowedFactory = new TableFactory<>(this, TTDWindowedTable::create);
+    kvFactory = new TableCache<>(spec -> TTDKeyValueTable.create(spec, this));
+    windowedFactory = new TableCache<>(spec -> TTDWindowedTable.create(spec, this));
   }
 
   public Time time() {
@@ -115,22 +115,22 @@ public class TTDCassandraClient extends CassandraClient {
   }
 
   @Override
-  public TableFactory<RemoteKVTable> globalFactory() {
+  public TableCache<RemoteKVTable> globalFactory() {
     return kvFactory;
   }
 
   @Override
-  public TableFactory<RemoteKVTable> kvFactory() {
+  public TableCache<RemoteKVTable> kvFactory() {
     return kvFactory;
   }
 
   @Override
-  public TableFactory<RemoteKVTable> factFactory() {
+  public TableCache<RemoteKVTable> factFactory() {
     return kvFactory;
   }
 
   @Override
-  public TableFactory<RemoteWindowedTable> windowedFactory() {
+  public TableCache<RemoteWindowedTable> windowedFactory() {
     return windowedFactory;
   }
 }

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/internal/stores/TTDTable.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/internal/stores/TTDTable.java
@@ -18,7 +18,6 @@ package dev.responsive.kafka.internal.stores;
 
 import com.datastax.oss.driver.api.core.cql.BoundStatement;
 import dev.responsive.kafka.internal.clients.TTDCassandraClient;
-import dev.responsive.kafka.internal.db.CassandraClient;
 import dev.responsive.kafka.internal.db.MetadataRow;
 import dev.responsive.kafka.internal.db.RemoteTable;
 import dev.responsive.kafka.internal.db.RemoteWriter;
@@ -49,7 +48,7 @@ public abstract class TTDTable<K> implements RemoteTable<K> {
       final SubPartitioner partitioner,
       final int kafkaPartition
   ) {
-    return (client, partition, batchSize) -> new TTDWriter<K>(this, partition);
+    return (client, partition, batchSize) -> new TTDWriter<>(this, partition);
   }
 
   @Override
@@ -63,8 +62,8 @@ public abstract class TTDTable<K> implements RemoteTable<K> {
   }
 
   @Override
-  public CassandraClient cassandraClient() {
-    return client;
+  public long approximateNumEntries(final int partition) {
+    return client.count(name(), partition);
   }
 
   private static class TTDWriter<K> implements RemoteWriter<K> {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -51,6 +51,7 @@ dependencyResolutionManagement {
             version("protobuf-java", "3.22.3")
             version("slf4j", "1.7.5")
             version("log4j2", "2.20.0")
+            version("mongoDB", "4.10.2")
 
             library("jackson", "com.fasterxml.jackson.datatype", "jackson-datatype-jdk8").versionRef("jackson")
 
@@ -62,6 +63,8 @@ dependencyResolutionManagement {
             library("scylla-query-builder", "com.scylladb", "java-driver-query-builder").versionRef("scylla")
             library("scylla-mapper-runtime", "com.scylladb", "java-driver-mapper-runtime").versionRef("scylla")
             bundle("scylla", listOf("scylla-driver-core", "scylla-query-builder", "scylla-mapper-runtime"))
+
+            library("mongodb-driver-sync", "org.mongodb", "mongodb-driver-sync").versionRef("mongoDB")
 
             library("javaoperatorsdk", "io.javaoperatorsdk", "operator-framework").versionRef("javaoperatorsdk")
 
@@ -107,7 +110,15 @@ dependencyResolutionManagement {
             library("testcontainers-junit", "org.testcontainers", "junit-jupiter").versionRef("testcontainers")
             library("testcontainers-cassandra", "org.testcontainers", "cassandra").versionRef("testcontainers")
             library("testcontainers-kafka", "org.testcontainers", "kafka").versionRef("testcontainers")
-            bundle("testcontainers", listOf("testcontainers", "testcontainers-junit", "testcontainers-cassandra", "testcontainers-kafka"))
+            library("testcontainers-mongodb", "org.testcontainers", "mongodb").versionRef("testcontainers")
+            bundle("testcontainers",
+                    listOf(
+                            "testcontainers",
+                            "testcontainers-junit",
+                            "testcontainers-cassandra",
+                            "testcontainers-kafka",
+                            "testcontainers-mongodb"
+                    ))
 
             bundle("base", listOf("junit", "slf4j", "log4j-core", "hamcrest", "mockito", "mockito-jupiter"))
         }


### PR DESCRIPTION
This PR is the minimal set of changes I needed to make in order to comfortably support different backends. There are still some places (and I will point them out with inline comments on this PR) where it's awkward and doesn't totally fit our existing. Here's the general review guide:

1. I refactored the `ResponsiveKafkaStreams` chain of constructors into an internal builder to make it easier to modify
2. Added `BackendStorage` enum that signals which backend to use
3. Moved most C* specific things into the corresponding `RemoteTable` classes
4. Made the `ResponsiveExtension` for spinning up test containers smart about whether it should spin up a C* or Mongo container. You can see `MinimalIntegraionTest` as an example of the new usage.

Unfortunately this will mean that we need to package both Mongo/Scylla clients into our JAR. That's not ideal, but hopefully soon we can move all of this into a proxy.

**NOTE:** I haven't spent any time thinking about the MongoDB schema or optimizing it. All I did was the minimal amount of work to get some of the tests to pass (e.g. the restore integration test), I'll spend some time reading up on that later.