### PR TITLE
make the Table API generic to backend storage

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraClient.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraClient.java
@@ -20,6 +20,7 @@ import static dev.responsive.kafka.internal.db.ColumnName.PARTITION_KEY;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
 import com.datastax.oss.driver.api.core.cql.PreparedStatement;
 import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.datastax.oss.driver.api.core.cql.SimpleStatement;
@@ -46,10 +47,10 @@ public class CassandraClient {
   private final CqlSession session;
 
   private final ResponsiveConfig config;
-  private final TableCache<RemoteKVTable> kvFactory;
-  private final TableCache<RemoteKVTable> factFactory;
-  private final TableCache<RemoteWindowedTable> windowedFactory;
-  private final TableCache<RemoteKVTable> globalFactory;
+  private final TableCache<RemoteKVTable<BoundStatement>> kvFactory;
+  private final TableCache<RemoteKVTable<BoundStatement>> factFactory;
+  private final TableCache<RemoteWindowedTable<BoundStatement>> windowedFactory;
+  private final TableCache<RemoteKVTable<BoundStatement>> globalFactory;
 
   /**
    * @param session the Cassandra session, expected to be initialized
@@ -151,19 +152,19 @@ public class CassandraClient {
     session.close();
   }
 
-  public TableCache<RemoteKVTable> globalFactory() {
+  public TableCache<RemoteKVTable<BoundStatement>> globalFactory() {
     return globalFactory;
   }
 
-  public TableCache<RemoteKVTable> kvFactory() {
+  public TableCache<RemoteKVTable<BoundStatement>> kvFactory() {
     return kvFactory;
   }
 
-  public TableCache<RemoteKVTable> factFactory() {
+  public TableCache<RemoteKVTable<BoundStatement>> factFactory() {
     return factFactory;
   }
 
-  public TableCache<RemoteWindowedTable> windowedFactory() {
+  public TableCache<RemoteWindowedTable<BoundStatement>> windowedFactory() {
     return windowedFactory;
   }
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraFactTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraFactTable.java
@@ -44,7 +44,7 @@ import org.apache.kafka.streams.state.KeyValueIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class CassandraFactTable implements RemoteKVTable {
+public class CassandraFactTable implements RemoteKVTable<BoundStatement> {
 
   private static final Logger LOG = LoggerFactory.getLogger(
       CassandraFactTable.class);

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraKeyValueTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraKeyValueTable.java
@@ -53,7 +53,7 @@ import org.apache.kafka.streams.state.KeyValueIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class CassandraKeyValueTable implements RemoteKVTable {
+public class CassandraKeyValueTable implements RemoteKVTable<BoundStatement> {
 
   private static final Logger LOG = LoggerFactory.getLogger(CassandraKeyValueTable.class);
   private static final String FROM_BIND = "fk";

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraWindowedTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraWindowedTable.java
@@ -55,7 +55,7 @@ import org.apache.kafka.streams.state.KeyValueIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class CassandraWindowedTable implements RemoteWindowedTable {
+public class CassandraWindowedTable implements RemoteWindowedTable<BoundStatement> {
 
   private static final Logger LOG = LoggerFactory.getLogger(CassandraWindowedTable.class);
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/FactSchemaWriter.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/FactSchemaWriter.java
@@ -16,6 +16,7 @@
 
 package dev.responsive.kafka.internal.db;
 
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
 import com.datastax.oss.driver.api.core.cql.Statement;
 import dev.responsive.kafka.internal.stores.RemoteWriteResult;
 import java.util.ArrayList;
@@ -27,14 +28,14 @@ import java.util.stream.Collectors;
 public class FactSchemaWriter<K> implements RemoteWriter<K> {
 
   private final CassandraClient client;
-  private final RemoteTable<K> table;
+  private final RemoteTable<K, BoundStatement> table;
   private final int partition;
 
   private final List<Statement<?>> statements;
 
   public FactSchemaWriter(
       final CassandraClient client,
-      final RemoteTable<K> table,
+      final RemoteTable<K, BoundStatement> table,
       final int partition
   ) {
     this.client = client;

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/FactWriterFactory.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/FactWriterFactory.java
@@ -16,13 +16,14 @@
 
 package dev.responsive.kafka.internal.db;
 
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
 import dev.responsive.kafka.internal.utils.SessionClients;
 
 public class FactWriterFactory<K> implements WriterFactory<K> {
 
-  private final RemoteTable<K> table;
+  private final RemoteTable<K, BoundStatement> table;
 
-  public FactWriterFactory(final RemoteTable<K> table) {
+  public FactWriterFactory(final RemoteTable<K, BoundStatement> table) {
     this.table = table;
   }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/LwtWriter.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/LwtWriter.java
@@ -19,6 +19,7 @@ package dev.responsive.kafka.internal.db;
 import com.datastax.oss.driver.api.core.cql.BatchStatementBuilder;
 import com.datastax.oss.driver.api.core.cql.BatchType;
 import com.datastax.oss.driver.api.core.cql.BatchableStatement;
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
 import com.datastax.oss.driver.api.core.cql.Statement;
 import dev.responsive.kafka.internal.stores.RemoteWriteResult;
 import java.util.ArrayList;
@@ -31,7 +32,7 @@ public class LwtWriter<K> implements RemoteWriter<K> {
 
   private final CassandraClient client;
   private final Supplier<BatchableStatement<?>> fencingStatementFactory;
-  private final RemoteTable<K> table;
+  private final RemoteTable<K, BoundStatement> table;
   private final int partition;
   private final int batchSize;
 
@@ -40,7 +41,7 @@ public class LwtWriter<K> implements RemoteWriter<K> {
   public LwtWriter(
       final CassandraClient client,
       final Supplier<BatchableStatement<?>> fencingStatementFactory,
-      final RemoteTable<K> table,
+      final RemoteTable<K, BoundStatement> table,
       final int partition,
       final int batchSize
   ) {

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/LwtWriterFactory.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/LwtWriterFactory.java
@@ -25,6 +25,7 @@ import static dev.responsive.kafka.internal.db.ColumnName.ROW_TYPE;
 import static dev.responsive.kafka.internal.db.ColumnName.WINDOW_START;
 import static dev.responsive.kafka.internal.db.RowType.METADATA_ROW;
 
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
 import com.datastax.oss.driver.api.core.cql.PreparedStatement;
 import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.datastax.oss.driver.api.querybuilder.QueryBuilder;
@@ -40,10 +41,10 @@ public class LwtWriterFactory<K> implements WriterFactory<K> {
 
   private final long epoch;
   private final PreparedStatement ensureEpoch;
-  private final RemoteTable<K> table;
+  private final RemoteTable<K, BoundStatement> table;
 
   public static <K> LwtWriterFactory<K> reserveWindowed(
-      final RemoteTable<K> table,
+      final RemoteTable<K, BoundStatement> table,
       final CassandraClient client,
       final SubPartitioner partitioner,
       final int kafkaPartition
@@ -52,7 +53,7 @@ public class LwtWriterFactory<K> implements WriterFactory<K> {
   }
 
   public static <K> LwtWriterFactory<K> reserve(
-      final RemoteTable<K> table,
+      final RemoteTable<K, BoundStatement> table,
       final CassandraClient client,
       final SubPartitioner partitioner,
       final int kafkaPartition
@@ -61,7 +62,7 @@ public class LwtWriterFactory<K> implements WriterFactory<K> {
   }
 
   private static <K> LwtWriterFactory<K> reserve(
-      final RemoteTable<K> table,
+      final RemoteTable<K, BoundStatement> table,
       final CassandraClient client,
       final SubPartitioner partitioner,
       final int kafkaPartition,
@@ -84,7 +85,7 @@ public class LwtWriterFactory<K> implements WriterFactory<K> {
 
   // Visible for Testing
   public static <K> LwtWriterFactory<K> reserve(
-      final RemoteTable<K> table,
+      final RemoteTable<K, BoundStatement> table,
       final CassandraClient client,
       final int[] partitions,
       final int kafkaPartition,
@@ -123,7 +124,7 @@ public class LwtWriterFactory<K> implements WriterFactory<K> {
   }
 
   public LwtWriterFactory(
-      final RemoteTable<K> table,
+      final RemoteTable<K, BoundStatement> table,
       final long epoch,
       final PreparedStatement ensureEpoch
   ) {
@@ -155,7 +156,7 @@ public class LwtWriterFactory<K> implements WriterFactory<K> {
   }
 
   private static ResultSet reserveEpoch(
-      final RemoteTable<?> table,
+      final RemoteTable<?, BoundStatement> table,
       final CassandraClient client,
       final int partition,
       final long epoch
@@ -172,7 +173,7 @@ public class LwtWriterFactory<K> implements WriterFactory<K> {
   }
 
   private static ResultSet reserveEpochWindowed(
-      final RemoteTable<?> table,
+      final RemoteTable<?, BoundStatement> table,
       final CassandraClient client,
       final int partition,
       final long epoch
@@ -190,7 +191,7 @@ public class LwtWriterFactory<K> implements WriterFactory<K> {
   }
 
   private static PreparedStatement ensureEpoch(
-      final RemoteTable<?> table,
+      final RemoteTable<?, BoundStatement> table,
       final CassandraClient client,
       final long epoch
   ) {
@@ -206,7 +207,7 @@ public class LwtWriterFactory<K> implements WriterFactory<K> {
   }
 
   private static PreparedStatement ensureEpochWindowed(
-      final RemoteTable<?> table,
+      final RemoteTable<?, BoundStatement> table,
       final CassandraClient client,
       final long epoch
   ) {

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/RemoteKVTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/RemoteKVTable.java
@@ -19,7 +19,7 @@ package dev.responsive.kafka.internal.db;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.state.KeyValueIterator;
 
-public interface RemoteKVTable extends RemoteTable<Bytes> {
+public interface RemoteKVTable<S> extends RemoteTable<Bytes, S> {
 
   /**
    * Retrieves the value of the given {@code partitionKey} and {@code key}

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/RemoteTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/RemoteTable.java
@@ -16,11 +16,10 @@
 
 package dev.responsive.kafka.internal.db;
 
-import com.datastax.oss.driver.api.core.cql.BoundStatement;
 import dev.responsive.kafka.internal.db.partitioning.SubPartitioner;
 import javax.annotation.CheckReturnValue;
 
-public interface RemoteTable<K> {
+public interface RemoteTable<K, S> {
 
   String name();
 
@@ -51,7 +50,7 @@ public interface RemoteTable<K> {
    * {@code table} with value {@code value}
    */
   @CheckReturnValue
-  BoundStatement insert(
+  S insert(
       final int partitionKey,
       final K key,
       final byte[] value,
@@ -67,7 +66,7 @@ public interface RemoteTable<K> {
    *         {@code table}
    */
   @CheckReturnValue
-  BoundStatement delete(
+  S delete(
       final int partitionKey,
       final K key
   );
@@ -85,7 +84,7 @@ public interface RemoteTable<K> {
    * in the metadata row of {@code table}.
    */
   @CheckReturnValue
-  BoundStatement setOffset(
+  S setOffset(
       final int partition,
       final long offset
   );

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/RemoteWindowedTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/RemoteWindowedTable.java
@@ -20,7 +20,7 @@ import dev.responsive.kafka.internal.utils.Stamped;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.state.KeyValueIterator;
 
-public interface RemoteWindowedTable extends RemoteTable<Stamped<Bytes>> {
+public interface RemoteWindowedTable<S> extends RemoteTable<Stamped<Bytes>, S> {
 
   byte[] fetch(
       int partition,

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/TableCache.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/TableCache.java
@@ -28,7 +28,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * table are only prepared once during the lifetime of the application.
  */
 @ThreadSafe
-public class TableCache<T extends RemoteTable<?>> {
+public class TableCache<T extends RemoteTable<?, ?>> {
 
   @FunctionalInterface
   public interface Factory<T> {

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoKVTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoKVTable.java
@@ -21,7 +21,6 @@ import static dev.responsive.kafka.internal.stores.ResponsiveStoreRegistration.N
 import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
 import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
 
-import com.datastax.oss.driver.api.core.cql.BoundStatement;
 import com.mongodb.client.MongoClient;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoDatabase;
@@ -42,7 +41,7 @@ import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.codecs.pojo.PojoCodecProvider;
 import org.bson.types.ObjectId;
 
-public class MongoKVTable implements RemoteKVTable {
+public class MongoKVTable implements RemoteKVTable<Void> {
 
   private final String name;
   private final MongoCollection<KVDoc> collection;
@@ -112,7 +111,7 @@ public class MongoKVTable implements RemoteKVTable {
   }
 
   @Override
-  public BoundStatement insert(
+  public Void insert(
       final int partitionKey,
       final Bytes key,
       final byte[] value,
@@ -126,7 +125,7 @@ public class MongoKVTable implements RemoteKVTable {
   }
 
   @Override
-  public BoundStatement delete(final int partitionKey, final Bytes key) {
+  public Void delete(final int partitionKey, final Bytes key) {
     collection.deleteOne(Filters.eq("key", key));
     return null;
   }
@@ -143,8 +142,8 @@ public class MongoKVTable implements RemoteKVTable {
   }
 
   @Override
-  public BoundStatement setOffset(final int partition, final long offset) {
-    final UpdateResult modifiedCount = metadata.updateOne(
+  public Void setOffset(final int partition, final long offset) {
+    metadata.updateOne(
         Filters.eq("_id", metadataRows.get(partition)),
         Updates.set("offset", offset)
     );

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoWriter.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoWriter.java
@@ -24,10 +24,10 @@ import java.util.concurrent.CompletionStage;
 
 public class MongoWriter<K> implements RemoteWriter<K> {
 
-  private final RemoteTable<K> table;
+  private final RemoteTable<K, Void> table;
   private final int partition;
 
-  public MongoWriter(final RemoteTable<K> table, final int partition) {
+  public MongoWriter(final RemoteTable<K, Void> table, final int partition) {
     this.table = table;
     this.partition = partition;
   }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoWriterFactory.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoWriterFactory.java
@@ -23,9 +23,9 @@ import dev.responsive.kafka.internal.utils.SessionClients;
 
 public class MongoWriterFactory<K> implements WriterFactory<K> {
 
-  private final RemoteTable<K> table;
+  private final RemoteTable<K, Void> table;
 
-  public MongoWriterFactory(final RemoteTable<K> table) {
+  public MongoWriterFactory(final RemoteTable<K, Void> table) {
     this.table = table;
   }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/ResponsiveMongoClient.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/ResponsiveMongoClient.java
@@ -24,7 +24,7 @@ import java.util.concurrent.TimeoutException;
 
 public class ResponsiveMongoClient {
 
-  private final TableCache<RemoteKVTable> cache;
+  private final TableCache<RemoteKVTable<Void>> cache;
   private final MongoClient client;
 
   public ResponsiveMongoClient(final MongoClient client) {
@@ -32,7 +32,7 @@ public class ResponsiveMongoClient {
     cache = new TableCache<>(spec -> new MongoKVTable(client, spec.tableName()));
   }
 
-  public RemoteKVTable kvTable(final String name) throws InterruptedException, TimeoutException {
+  public RemoteKVTable<Void> kvTable(final String name) throws InterruptedException, TimeoutException {
     return cache.create(new BaseTableSpec(name));
   }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/ResponsiveMongoClient.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/ResponsiveMongoClient.java
@@ -32,7 +32,8 @@ public class ResponsiveMongoClient {
     cache = new TableCache<>(spec -> new MongoKVTable(client, spec.tableName()));
   }
 
-  public RemoteKVTable<Void> kvTable(final String name) throws InterruptedException, TimeoutException {
+  public RemoteKVTable<Void> kvTable(final String name)
+      throws InterruptedException, TimeoutException {
     return cache.create(new BaseTableSpec(name));
   }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/CommitBuffer.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/CommitBuffer.java
@@ -85,7 +85,7 @@ import org.apache.kafka.streams.processor.internals.RecordBatchingStateRestoreCa
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.slf4j.Logger;
 
-class CommitBuffer<K, S extends RemoteTable<K>>
+class CommitBuffer<K, S extends RemoteTable<K, ?>>
     implements RecordBatchingStateRestoreCallback, Closeable {
 
   public static final int MAX_BATCH_SIZE = 1000;
@@ -125,7 +125,7 @@ class CommitBuffer<K, S extends RemoteTable<K>>
   private Instant lastFlush;
   private WriterFactory<K> writerFactory;
 
-  static <K, S extends RemoteTable<K>> CommitBuffer<K, S> from(
+  static <K, S extends RemoteTable<K, ?>> CommitBuffer<K, S> from(
       final SessionClients clients,
       final TopicPartition changelog,
       final S schema,

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/GlobalOperations.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/GlobalOperations.java
@@ -18,6 +18,7 @@ package dev.responsive.kafka.internal.stores;
 
 import static dev.responsive.kafka.internal.config.InternalSessionConfigs.loadSessionClients;
 
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
 import dev.responsive.kafka.api.stores.ResponsiveKeyValueParams;
 import dev.responsive.kafka.internal.db.CassandraClient;
 import dev.responsive.kafka.internal.db.CassandraTableSpecFactory;
@@ -45,7 +46,7 @@ public class GlobalOperations implements KeyValueOperations {
 
   private final GlobalProcessorContextImpl context;
   private final CassandraClient client;
-  private final RemoteKVTable table;
+  private final RemoteKVTable<BoundStatement> table;
 
   public static GlobalOperations create(
       final StateStoreContext storeContext,
@@ -80,7 +81,7 @@ public class GlobalOperations implements KeyValueOperations {
       final ResponsiveRestoreListener restoreListener,
       final GlobalProcessorContextImpl context,
       final CassandraClient client,
-      final RemoteKVTable table
+      final RemoteKVTable<BoundStatement> table
   ) {
     this.storeName = storeName;
     this.changelog = changelog;

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/PartitionedOperations.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/PartitionedOperations.java
@@ -43,8 +43,8 @@ import org.apache.kafka.streams.state.KeyValueIterator;
 public class PartitionedOperations implements KeyValueOperations {
 
   private final ResponsiveKeyValueParams params;
-  private final RemoteKVTable table;
-  private final CommitBuffer<Bytes, RemoteKVTable> buffer;
+  private final RemoteKVTable<?> table;
+  private final CommitBuffer<Bytes, RemoteKVTable<?>> buffer;
   private final SubPartitioner partitioner;
   private final TopicPartition changelog;
   @SuppressWarnings("rawtypes")
@@ -77,7 +77,7 @@ public class PartitionedOperations implements KeyValueOperations {
         ? SubPartitioner.NO_SUBPARTITIONS
         : config.getSubPartitioner(sessionClients.admin(), name, changelog.topic());
 
-    final RemoteKVTable table;
+    final RemoteKVTable<?> table;
     switch (sessionClients.storageBackend()) {
       case CASSANDRA:
         table = createCassandra(params, sessionClients);
@@ -91,7 +91,7 @@ public class PartitionedOperations implements KeyValueOperations {
 
     log.info("Remote table {} is available for querying.", name.remoteName());
 
-    final var buffer = CommitBuffer.from(
+    final CommitBuffer<Bytes, RemoteKVTable<?>> buffer = CommitBuffer.from(
         sessionClients,
         changelog,
         table,
@@ -122,7 +122,7 @@ public class PartitionedOperations implements KeyValueOperations {
     );
   }
 
-  private static RemoteKVTable createCassandra(
+  private static RemoteKVTable<?> createCassandra(
       final ResponsiveKeyValueParams params,
       final SessionClients clients
   ) throws InterruptedException, TimeoutException {
@@ -138,7 +138,7 @@ public class PartitionedOperations implements KeyValueOperations {
     }
   }
 
-  private static RemoteKVTable createMongo(
+  private static RemoteKVTable<?> createMongo(
       final ResponsiveKeyValueParams params,
       final SessionClients sessionClients
   ) throws InterruptedException, TimeoutException {
@@ -149,7 +149,7 @@ public class PartitionedOperations implements KeyValueOperations {
   public PartitionedOperations(
       final ResponsiveKeyValueParams params,
       final RemoteKVTable table,
-      final CommitBuffer<Bytes, RemoteKVTable> buffer,
+      final CommitBuffer<Bytes, RemoteKVTable<?>> buffer,
       final SubPartitioner partitioner,
       final TopicPartition changelog,
       final InternalProcessorContext context,

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveWindowStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveWindowStore.java
@@ -73,8 +73,8 @@ public class ResponsiveWindowStore implements WindowStore<Bytes, byte[]> {
   private InternalProcessorContext context;
   private TopicPartition changelog;
 
-  private CommitBuffer<Stamped<Bytes>, RemoteWindowedTable> buffer;
-  private RemoteWindowedTable table;
+  private CommitBuffer<Stamped<Bytes>, RemoteWindowedTable<?>> buffer;
+  private RemoteWindowedTable<?> table;
   private ResponsiveStoreRegistry storeRegistry;
   private ResponsiveStoreRegistration registration;
   private ResponsiveRestoreListener restoreListener;

--- a/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveKeyValueStoreRestoreIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveKeyValueStoreRestoreIntegrationTest.java
@@ -183,7 +183,7 @@ public class ResponsiveKeyValueStoreRestoreIntegrationTest {
 
       // Make sure changelog is even w/ cassandra
       final ResponsiveConfig config = ResponsiveConfig.responsiveConfig(properties);
-      final RemoteKVTable table = remoteKVTable(type, defaultFactory, config);
+      final RemoteKVTable<?> table = remoteKVTable(type, defaultFactory, config);
 
       final long cassandraOffset = table.metadata(0).offset;
       assertThat(cassandraOffset, greaterThan(0L));
@@ -238,7 +238,7 @@ public class ResponsiveKeyValueStoreRestoreIntegrationTest {
 
     // Make sure changelog is ahead of remote
     final ResponsiveConfig config = ResponsiveConfig.responsiveConfig(properties);
-    final RemoteKVTable table;
+    final RemoteKVTable<?> table;
 
     table = remoteKVTable(type, defaultFactory, config);
 
@@ -279,11 +279,11 @@ public class ResponsiveKeyValueStoreRestoreIntegrationTest {
     assertThat(firstOffset(changelog), greaterThan(0L));
   }
 
-  private RemoteKVTable remoteKVTable(final KVSchema type,
+  private RemoteKVTable<?> remoteKVTable(final KVSchema type,
                                       final CassandraClientFactory defaultFactory,
                                       final ResponsiveConfig config)
       throws InterruptedException, TimeoutException {
-    final RemoteKVTable table;
+    final RemoteKVTable<?> table;
     if (EXTENSION.backend == StorageBackend.CASSANDRA) {
       final CassandraClient cassandraClient = defaultFactory.createClient(
           defaultFactory.createCqlSession(config),

--- a/kafka-client/src/test/java/dev/responsive/kafka/integration/SubPartitionIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/integration/SubPartitionIntegrationTest.java
@@ -43,7 +43,6 @@ import dev.responsive.kafka.api.stores.ResponsiveStores;
 import dev.responsive.kafka.internal.db.CassandraClient;
 import dev.responsive.kafka.internal.db.CassandraFactTable;
 import dev.responsive.kafka.internal.db.CassandraKeyValueTable;
-import dev.responsive.kafka.internal.db.RemoteKVTable;
 import dev.responsive.kafka.internal.db.partitioning.Hasher;
 import dev.responsive.kafka.internal.db.partitioning.SubPartitioner;
 import dev.responsive.kafka.internal.db.spec.BaseTableSpec;
@@ -164,7 +163,7 @@ public class SubPartitionIntegrationTest {
           true,
           properties);
       final String cassandraName = new TableName(storeName).remoteName();
-      final RemoteKVTable table = CassandraKeyValueTable.create(
+      final CassandraKeyValueTable table = CassandraKeyValueTable.create(
           new BaseTableSpec(cassandraName), client);
 
       assertThat(client.numPartitions(cassandraName), is(OptionalInt.of(32)));
@@ -220,7 +219,7 @@ public class SubPartitionIntegrationTest {
           true,
           properties);
       final String cassandraName = new TableName(storeName).remoteName();
-      final RemoteKVTable table = CassandraFactTable.create(
+      final CassandraFactTable table = CassandraFactTable.create(
           new BaseTableSpec(cassandraName), client);
 
       final var meta0 = table.metadata(0);

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/CassandraFactTableIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/CassandraFactTableIntegrationTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 
 import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
 import dev.responsive.kafka.api.config.ResponsiveConfig;
 import dev.responsive.kafka.api.stores.ResponsiveKeyValueParams;
 import dev.responsive.kafka.internal.db.partitioning.SubPartitioner;
@@ -71,7 +72,7 @@ class CassandraFactTableIntegrationTest {
     // Given:
     params = ResponsiveKeyValueParams.fact(storeName);
     final String tableName = params.name().remoteName();
-    final RemoteKVTable schema = client
+    final RemoteKVTable<BoundStatement> schema = client
         .factFactory()
         .create(CassandraTableSpecFactory.fromKVParams(params));
 
@@ -107,8 +108,7 @@ class CassandraFactTableIntegrationTest {
     final String tableName = params.name().remoteName();
 
     // When:
-    final RemoteKVTable schema = client
-        .factFactory()
+    client.factFactory()
         .create(CassandraTableSpecFactory.fromKVParams(params));
 
     // Then:
@@ -153,7 +153,7 @@ class CassandraFactTableIntegrationTest {
   public void shouldInsertAndDelete() throws Exception {
     // Given:
     params = ResponsiveKeyValueParams.fact(storeName);
-    final RemoteKVTable table = client
+    final RemoteKVTable<BoundStatement> table = client
         .factFactory()
         .create(CassandraTableSpecFactory.fromKVParams(params));
 
@@ -179,7 +179,7 @@ class CassandraFactTableIntegrationTest {
     params = ResponsiveKeyValueParams.fact(storeName);
     final String tableName = params.name().remoteName();
 
-    final RemoteKVTable table = client
+    final RemoteKVTable<BoundStatement> table = client
         .factFactory()
         .create(CassandraTableSpecFactory.fromKVParams(params));
 

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/CassandraKVTableIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/CassandraKVTableIntegrationTest.java
@@ -41,7 +41,7 @@ public class CassandraKVTableIntegrationTest {
   private static final long CURRENT_TS = 100L;
   private static final long MIN_VALID_TS = 0L;
 
-  private RemoteKVTable table;
+  private RemoteKVTable<BoundStatement> table;
   private String name;
   private CassandraClient client;
 

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/FactSchemaWriterTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/FactSchemaWriterTest.java
@@ -49,7 +49,7 @@ class FactSchemaWriterTest {
   private static final long CURRENT_TS = 100L;
 
   @Mock private CassandraClient client;
-  @Mock private RemoteTable<Bytes> table;
+  @Mock private RemoteTable<Bytes, BoundStatement> table;
   @Mock private AsyncResultSet result;
 
   private final ArgumentCaptor<Statement<?>> statementCaptor =

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/internal/clients/TTDCassandraClient.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/internal/clients/TTDCassandraClient.java
@@ -19,6 +19,7 @@ package dev.responsive.kafka.internal.clients;
 import static dev.responsive.kafka.api.config.ResponsiveConfig.loggedConfig;
 
 import com.datastax.oss.driver.api.core.cql.AsyncResultSet;
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
 import com.datastax.oss.driver.api.core.cql.PreparedStatement;
 import com.datastax.oss.driver.api.core.cql.ResultSet;
 import com.datastax.oss.driver.api.core.cql.SimpleStatement;
@@ -42,8 +43,8 @@ public class TTDCassandraClient extends CassandraClient {
   private final ResponsiveStoreRegistry storeRegistry = new ResponsiveStoreRegistry();
   private final TTDMockAdmin admin;
 
-  private final TableCache<RemoteKVTable> kvFactory;
-  private final TableCache<RemoteWindowedTable> windowedFactory;
+  private final TableCache<RemoteKVTable<BoundStatement>> kvFactory;
+  private final TableCache<RemoteWindowedTable<BoundStatement>> windowedFactory;
 
   public TTDCassandraClient(final TTDMockAdmin admin, final Time time) {
     super(loggedConfig(admin.props()));
@@ -115,22 +116,22 @@ public class TTDCassandraClient extends CassandraClient {
   }
 
   @Override
-  public TableCache<RemoteKVTable> globalFactory() {
+  public TableCache<RemoteKVTable<BoundStatement>> globalFactory() {
     return kvFactory;
   }
 
   @Override
-  public TableCache<RemoteKVTable> kvFactory() {
+  public TableCache<RemoteKVTable<BoundStatement>> kvFactory() {
     return kvFactory;
   }
 
   @Override
-  public TableCache<RemoteKVTable> factFactory() {
+  public TableCache<RemoteKVTable<BoundStatement>> factFactory() {
     return kvFactory;
   }
 
   @Override
-  public TableCache<RemoteWindowedTable> windowedFactory() {
+  public TableCache<RemoteWindowedTable<BoundStatement>> windowedFactory() {
     return windowedFactory;
   }
 }

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/internal/stores/TTDKeyValueTable.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/internal/stores/TTDKeyValueTable.java
@@ -27,7 +27,7 @@ import java.time.Duration;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.state.KeyValueIterator;
 
-public class TTDKeyValueTable extends TTDTable<Bytes> implements RemoteKVTable {
+public class TTDKeyValueTable extends TTDTable<Bytes> implements RemoteKVTable<BoundStatement> {
 
   private final String name;
   private final KVStoreStub stub;

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/internal/stores/TTDTable.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/internal/stores/TTDTable.java
@@ -27,7 +27,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import org.apache.kafka.common.utils.Time;
 
-public abstract class TTDTable<K> implements RemoteTable<K> {
+public abstract class TTDTable<K> implements RemoteTable<K, BoundStatement> {
 
   private final TTDCassandraClient client;
   protected final Time time;

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/internal/stores/TTDWindowedTable.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/internal/stores/TTDWindowedTable.java
@@ -25,7 +25,8 @@ import dev.responsive.kafka.internal.utils.Stamped;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.state.KeyValueIterator;
 
-public class TTDWindowedTable extends TTDTable<Stamped<Bytes>> implements RemoteWindowedTable  {
+public class TTDWindowedTable extends TTDTable<Stamped<Bytes>>
+    implements RemoteWindowedTable<BoundStatement>  {
 
   private final String name;
   private final WindowStoreStub stub;


### PR DESCRIPTION
Before this PR the `RemoteTable` API assumed Cassandra and therefore encoded `BoundStatement` in it. This sets the stage for returning something different for different backend implementations.