### PR TITLE
Export all kafka-streams dependencies in Responsive api

### DIFF
--- a/responsive-test-utils/build.gradle.kts
+++ b/responsive-test-utils/build.gradle.kts
@@ -22,12 +22,13 @@ version = project(":kafka-client").version
 
 dependencies {
     implementation(project(":kafka-client"))
+    api(libs.kafka.streams.test.utils)
 
-    implementation(libs.bundles.scylla)
-    implementation(libs.kafka.streams.test.utils)
     implementation(variantOf(libs.kafka.clients) {
         classifier("test")
     })
+
+    implementation(libs.bundles.scylla)
 
     testImplementation(testlibs.bundles.base)
     testImplementation(libs.bundles.logging)


### PR DESCRIPTION
One-line change to how we declare one of the kafka related dependencies in the responsive client module group, specifically the responsive-test-utils module. We switch the `kafka-streams-test-utils` dependency from `implementation` to `api` so that it will be exported as part of the `responsive-test-utils` artifact, the same way we export the `kafka-streams` dependency with the `kafka-client` module

With this, users should be able to remove all explicit kafka dependencies from their maven/gradle build file and access everything through the responsive `kafka-client` and `responsive-test-utils`. Without this change, users will generally always need to explicitly pull in the `kafka-streams-test-utils` artifact to make use of the TopologyTestDriver features like `TestInputTopic`/`TestOutputTopic`.

This should make it clear to users that we are controlling the version of kafka/streams and hopefully avoid any unpleasant surprises down the line.

Note: some users might leverage the plain clients in their Streams application or test code, but neither they nor us need to explicitly import the `kafka-clients` artifact (much less export it through the api) as I believe the `kafka-streams` module already does this for us. Thus the change in this PR is sufficient to remove all explicit user dependencies and we can recommend they pull in only the responsive artifacts to ensure consistent versioning