### PR TITLE
[mongo] insert in bulk to avoid network roundtrips

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoWriterFactory.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoWriterFactory.java
@@ -16,17 +16,25 @@
 
 package dev.responsive.kafka.internal.db.mongo;
 
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.WriteModel;
 import dev.responsive.kafka.internal.db.RemoteTable;
 import dev.responsive.kafka.internal.db.RemoteWriter;
 import dev.responsive.kafka.internal.db.WriterFactory;
 import dev.responsive.kafka.internal.utils.SessionClients;
+import org.bson.Document;
 
 public class MongoWriterFactory<K> implements WriterFactory<K> {
 
-  private final RemoteTable<K, Void> table;
+  private final RemoteTable<K, WriteModel<Document>> table;
+  private final MongoCollection<Document> genericCollection;
 
-  public MongoWriterFactory(final RemoteTable<K, Void> table) {
+  public MongoWriterFactory(
+      final RemoteTable<K, WriteModel<Document>> table,
+      final MongoCollection<Document> genericCollection
+  ) {
     this.table = table;
+    this.genericCollection = genericCollection;
   }
 
   @Override
@@ -35,7 +43,7 @@ public class MongoWriterFactory<K> implements WriterFactory<K> {
       final int partition,
       final int batchSize
   ) {
-    return new MongoWriter<>(table, partition);
+    return new MongoWriter<>(table, partition, genericCollection);
   }
 
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/ResponsiveMongoClient.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/ResponsiveMongoClient.java
@@ -17,14 +17,16 @@
 package dev.responsive.kafka.internal.db.mongo;
 
 import com.mongodb.client.MongoClient;
+import com.mongodb.client.model.WriteModel;
 import dev.responsive.kafka.internal.db.RemoteKVTable;
 import dev.responsive.kafka.internal.db.TableCache;
 import dev.responsive.kafka.internal.db.spec.BaseTableSpec;
 import java.util.concurrent.TimeoutException;
+import org.bson.Document;
 
 public class ResponsiveMongoClient {
 
-  private final TableCache<RemoteKVTable<Void>> cache;
+  private final TableCache<RemoteKVTable<WriteModel<Document>>> cache;
   private final MongoClient client;
 
   public ResponsiveMongoClient(final MongoClient client) {
@@ -32,7 +34,7 @@ public class ResponsiveMongoClient {
     cache = new TableCache<>(spec -> new MongoKVTable(client, spec.tableName()));
   }
 
-  public RemoteKVTable<Void> kvTable(final String name)
+  public RemoteKVTable<WriteModel<Document>> kvTable(final String name)
       throws InterruptedException, TimeoutException {
     return cache.create(new BaseTableSpec(name));
   }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/CommitBuffer.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/CommitBuffer.java
@@ -523,7 +523,7 @@ class CommitBuffer<K, S extends RemoteTable<K, ?>>
     flushSensor.record(1, endMs);
     flushLatencySensor.record(flushLatencyMs, endMs);
 
-    log.debug("Flushed {} records to remote in {}ms (offset={}, writer={}, numSubPartitions={})",
+    log.info("Flushed {} records to remote in {}ms (offset={}, writer={}, numSubPartitions={})",
         buffer.getReader().size(),
         flushLatencyMs,
         consumedOffset,


### PR DESCRIPTION
Note that batches in mongo are _not_ atomic so it's possible that any number of writes within a batch will fail. That's OK because newer writers will succeed in overwriting anything with older epochs (not yet implemented, that's in the next PR that has EOS).

When I have Mongo fully implemented I'll add a suite of unit/integration tests. 