### PR TITLE
Add WindowOperations and SegmentedOperations

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
@@ -271,6 +271,15 @@ public class ResponsiveConfig extends AbstractConfig {
     super(CONFIG_DEF, originals, doLog);
   }
 
+  // TODO: encapsulate the SubPartitioner in the RemoteTable class
+  public SubPartitioner getSegmentedSubPartitioner(
+      final Admin admin,
+      final TableName name,
+      final String changelogTopicName
+  ) {
+    throw new UnsupportedOperationException("TODO -- follow up PR");
+  }
+
   public SubPartitioner getSubPartitioner(
       final Admin admin,
       final TableName name,

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/StampedKeySpec.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/StampedKeySpec.java
@@ -18,7 +18,6 @@ package dev.responsive.kafka.internal.db;
 
 import static org.apache.kafka.streams.state.StateSerdes.TIMESTAMP_SIZE;
 
-import dev.responsive.kafka.internal.stores.ResponsiveWindowStore;
 import dev.responsive.kafka.internal.utils.Stamped;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -58,6 +57,16 @@ public class StampedKeySpec implements KeySpec<Stamped<Bytes>> {
 
   @Override
   public int compare(final Stamped<Bytes> o1, final Stamped<Bytes> o2) {
-    return ResponsiveWindowStore.compareKeys(o1, o2);
+    return compareKeys(o1, o2);
+  }
+
+  // TODO remove generic from Stamped<> and just implement Comparable
+  public static int compareKeys(final Stamped<Bytes> o1, final Stamped<Bytes> o2) {
+    final int key = o1.key.compareTo(o2.key);
+    if (key != 0) {
+      return key;
+    }
+
+    return Long.compare(o1.stamp, o2.stamp);
   }
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/GlobalOperations.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/GlobalOperations.java
@@ -92,16 +92,6 @@ public class GlobalOperations implements KeyValueOperations {
   }
 
   @Override
-  public void register(final ResponsiveStoreRegistry storeRegistry) {
-    // we don't do anything with global tables
-  }
-
-  @Override
-  public void deregister(final ResponsiveStoreRegistry storeRegistry) {
-    // we don't do anything with global tables
-  }
-
-  @Override
   public void put(final Bytes key, final byte[] value) {
     put(key, value, context.partition(), context.offset(), context.timestamp());
   }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/KeyValueOperations.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/KeyValueOperations.java
@@ -23,10 +23,6 @@ import org.apache.kafka.streams.state.KeyValueIterator;
 
 public interface KeyValueOperations extends Closeable, RecordBatchingStateRestoreCallback {
 
-  void register(ResponsiveStoreRegistry storeRegistry);
-
-  void deregister(ResponsiveStoreRegistry storeRegistry);
-
   void put(final Bytes key, final byte[] value);
 
   byte[] delete(final Bytes key);

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/SegmentedOperations.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/SegmentedOperations.java
@@ -1,0 +1,306 @@
+/*
+ *
+ *  * Copyright 2023 Responsive Computing, Inc.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package dev.responsive.kafka.internal.stores;
+
+import static dev.responsive.kafka.internal.config.InternalSessionConfigs.loadSessionClients;
+import static dev.responsive.kafka.internal.config.InternalSessionConfigs.loadStoreRegistry;
+import static org.apache.kafka.streams.processor.internals.ProcessorContextUtils.asInternalProcessorContext;
+import static org.apache.kafka.streams.processor.internals.ProcessorContextUtils.changelogFor;
+
+import dev.responsive.kafka.api.config.ResponsiveConfig;
+import dev.responsive.kafka.api.stores.ResponsiveWindowParams;
+import dev.responsive.kafka.internal.db.CassandraTableSpecFactory;
+import dev.responsive.kafka.internal.db.RemoteWindowedTable;
+import dev.responsive.kafka.internal.db.StampedKeySpec;
+import dev.responsive.kafka.internal.db.partitioning.SubPartitioner;
+import dev.responsive.kafka.internal.metrics.ResponsiveRestoreListener;
+import dev.responsive.kafka.internal.utils.Iterators;
+import dev.responsive.kafka.internal.utils.Result;
+import dev.responsive.kafka.internal.utils.SessionClients;
+import dev.responsive.kafka.internal.utils.Stamped;
+import dev.responsive.kafka.internal.utils.TableName;
+import java.util.Collection;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Predicate;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.common.utils.LogContext;
+import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.processor.StateStoreContext;
+import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.WindowStoreIterator;
+
+public class SegmentedOperations implements WindowOperations {
+
+  @SuppressWarnings("rawtypes")
+  private final InternalProcessorContext context;
+  private final ResponsiveWindowParams params;
+  private final StampedKeySpec keySpec;
+  private final RemoteWindowedTable<?> table;
+  private final CommitBuffer<Stamped<Bytes>, RemoteWindowedTable<?>> buffer;
+  private final SubPartitioner partitioner;
+  private final TopicPartition changelog;
+
+  private final ResponsiveStoreRegistry storeRegistry;
+  private final ResponsiveStoreRegistration registration;
+  private final ResponsiveRestoreListener restoreListener;
+
+  public static SegmentedOperations create(
+      final TableName name,
+      final StateStoreContext storeContext,
+      final ResponsiveWindowParams params,
+      final Predicate<Stamped<Bytes>> withinRetention
+  ) throws InterruptedException, TimeoutException {
+
+    final var log = new LogContext(
+        String.format("store [%s] ", name.kafkaName())
+    ).logger(SegmentedOperations.class);
+    final var context = asInternalProcessorContext(storeContext);
+
+    // Save this so we don't have to rebuild the config map on every access
+    final var appConfigs = storeContext.appConfigs();
+
+    final ResponsiveConfig config = ResponsiveConfig.responsiveConfig(appConfigs);
+    final SessionClients sessionClients = loadSessionClients(appConfigs);
+    final ResponsiveStoreRegistry storeRegistry = loadStoreRegistry(appConfigs);
+
+    final TopicPartition changelog = new TopicPartition(
+        changelogFor(storeContext, name.kafkaName(), false),
+        context.taskId().partition()
+    );
+    final var partitioner = config.getSegmentedSubPartitioner(
+        sessionClients.admin(), 
+        name, 
+        changelog.topic()
+    );
+
+    final RemoteWindowedTable<?> table;
+    switch (sessionClients.storageBackend()) {
+      case CASSANDRA:
+        table = createCassandra(params, sessionClients);
+        break;
+      case MONGO_DB:
+        throw new UnsupportedOperationException("Window stores are not yet compatible with Mongo");
+      default:
+        throw new IllegalStateException("Unexpected value: " + sessionClients.storageBackend());
+    }
+
+    log.info("Remote table {} is available for querying.", name.remoteName());
+
+    final StampedKeySpec keySpec = new StampedKeySpec(withinRetention);
+    final CommitBuffer<Stamped<Bytes>, RemoteWindowedTable<?>> buffer = CommitBuffer.from(
+        sessionClients,
+        changelog,
+        table,
+        keySpec,
+        params.truncateChangelog(),
+        params.name().kafkaName(),
+        partitioner,
+        config
+    );
+    buffer.init();
+
+    final long offset = buffer.offset();
+    final var registration = new ResponsiveStoreRegistration(
+        name.kafkaName(),
+        changelog,
+        offset == -1 ? 0 : offset,
+        buffer::flush
+    );
+    storeRegistry.registerStore(registration);
+
+    return new SegmentedOperations(
+        params,
+        keySpec,
+        table,
+        buffer,
+        partitioner,
+        changelog,
+        context,
+        storeRegistry,
+        registration,
+        sessionClients.restoreListener()
+    );
+  }
+
+  private static RemoteWindowedTable<?> createCassandra(
+      final ResponsiveWindowParams params,
+      final SessionClients clients
+  ) throws InterruptedException, TimeoutException {
+    final var client = clients.cassandraClient();
+    final var spec = CassandraTableSpecFactory.fromWindowParams(params);
+    switch (params.schemaType()) {
+      case WINDOW:
+        return client.windowedFactory().create(spec);
+      case STREAM:
+        throw new UnsupportedOperationException("Not yet implemented");
+      default:
+        throw new IllegalArgumentException(params.schemaType().name());
+    }
+  }
+
+  @SuppressWarnings("rawtypes")
+  public SegmentedOperations(
+      final ResponsiveWindowParams params,
+      final StampedKeySpec keySpec,
+      final RemoteWindowedTable table,
+      final CommitBuffer<Stamped<Bytes>, RemoteWindowedTable<?>> buffer,
+      final SubPartitioner partitioner,
+      final TopicPartition changelog,
+      final InternalProcessorContext context,
+      final ResponsiveStoreRegistry storeRegistry,
+      final ResponsiveStoreRegistration registration,
+      final ResponsiveRestoreListener restoreListener
+  ) {
+    this.params = params;
+    this.keySpec = keySpec;
+    this.table = table;
+    this.buffer = buffer;
+    this.partitioner = partitioner;
+    this.changelog = changelog;
+    this.context = context;
+    this.storeRegistry = storeRegistry;
+    this.registration = registration;
+    this.restoreListener = restoreListener;
+  }
+  
+  @Override
+  public void put(final Stamped<Bytes> windowedKey, final byte[] value) {
+    buffer.put(windowedKey, value, context.timestamp());
+  }
+
+  @Override
+  public void delete(final Stamped<Bytes> windowedKey) {
+    buffer.tombstone(windowedKey, context.timestamp());
+  }
+
+  @Override
+  public byte[] fetch(final Bytes key, final long windowStartTime) {
+    final Result<Stamped<Bytes>> localResult = buffer.get(new Stamped<>(key, windowStartTime));
+    if (localResult != null)  {
+      return localResult.isTombstone ? null : localResult.value;
+    }
+
+    return table.fetch(
+        partitioner.partition(changelog.partition(), key),
+        key,
+        windowStartTime
+    );
+  }
+
+  @Override
+  public WindowStoreIterator<byte[]> fetch(
+      final Bytes key,
+      final long timeFrom,
+      final long timeTo
+  ) {
+    final Stamped<Bytes> from = new Stamped<>(key, timeFrom);
+    final Stamped<Bytes> to = new Stamped<>(key, timeTo);
+
+    final int subPartition = partitioner.partition(changelog.partition(), key);
+    return Iterators.windowed(
+        new LocalRemoteKvIterator<>(
+            buffer.range(from, to),
+            table.fetch(subPartition, key, timeFrom, timeTo),
+            keySpec
+        )
+    );
+  }
+
+  @Override
+  public KeyValueIterator<Windowed<Bytes>, byte[]> fetch(
+      final Bytes keyFrom,
+      final Bytes keyTo,
+      final long timeFrom,
+      final long timeTo
+  ) {
+    throw new UnsupportedOperationException("Not yet implemented.");
+  }
+
+  @Override
+  public KeyValueIterator<Windowed<Bytes>, byte[]> fetchAll(
+      final long timeFrom,
+      final long timeTo
+  ) {
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  @Override
+  public KeyValueIterator<Windowed<Bytes>, byte[]> all() {
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  @Override
+  public WindowStoreIterator<byte[]> backwardFetch(
+      final Bytes key,
+      final long timeFrom,
+      final long timeTo
+  ) {
+    final Stamped<Bytes> from = new Stamped<>(key, timeFrom);
+    final Stamped<Bytes> to = new Stamped<>(key, timeTo);
+
+    final int subPartition = partitioner.partition(changelog.partition(), key);
+    return Iterators.windowed(
+        new LocalRemoteKvIterator<>(
+            buffer.backRange(from, to),
+            table.backFetch(subPartition, key, timeFrom, timeTo),
+            keySpec
+        )
+    );
+  }
+
+  @Override
+  public KeyValueIterator<Windowed<Bytes>, byte[]> backwardFetch(
+      final Bytes keyFrom,
+      final Bytes keyTo,
+      final long timeFrom,
+      final long timeTo
+  ) {
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  @Override
+  public KeyValueIterator<Windowed<Bytes>, byte[]> backwardFetchAll(
+      final long timeFrom,
+      final long timeTo
+  ) {
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  @Override
+  public KeyValueIterator<Windowed<Bytes>, byte[]> backwardAll() {
+    throw new UnsupportedOperationException("Not yet implemented");
+  }
+
+  @Override
+  public void close() {
+    // no need to flush the buffer here, will happen through the kafka client commit as usual
+    buffer.close();
+    restoreListener.onStoreClosed(changelog, params.name().kafkaName());
+    storeRegistry.deregisterStore(registration);
+  }
+
+  @Override
+  public void restoreBatch(final Collection<ConsumerRecord<byte[], byte[]>> records) {
+    buffer.restoreBatch(records);
+  }
+
+}

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/WindowOperations.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/WindowOperations.java
@@ -1,0 +1,79 @@
+/*
+ *
+ *  * Copyright 2023 Responsive Computing, Inc.
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     http://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *
+ */
+
+package dev.responsive.kafka.internal.stores;
+
+import dev.responsive.kafka.internal.utils.Stamped;
+import java.io.Closeable;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.kstream.Windowed;
+import org.apache.kafka.streams.processor.internals.RecordBatchingStateRestoreCallback;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.WindowStoreIterator;
+
+public interface WindowOperations extends Closeable, RecordBatchingStateRestoreCallback {
+
+  void put(final Stamped<Bytes> windowedKey, final byte[] value);
+
+  void delete(final Stamped<Bytes> windowedKey);
+
+  byte[] fetch(final Bytes key, final long windowStartTime);
+
+  WindowStoreIterator<byte[]> fetch(
+      final Bytes key,
+      final long timeFrom,
+      final long timeTo
+  );
+
+  KeyValueIterator<Windowed<Bytes>, byte[]> fetch(
+      final Bytes keyFrom,
+      final Bytes keyTo,
+      final long timeFrom,
+      final long timeTo
+  );
+
+  KeyValueIterator<Windowed<Bytes>, byte[]> fetchAll(
+      final long timeFrom,
+      final long timeTo
+  );
+
+  KeyValueIterator<Windowed<Bytes>, byte[]> all();
+
+  WindowStoreIterator<byte[]> backwardFetch(
+      final Bytes key,
+      final long timeFrom,
+      final long timeTo
+  );
+
+  KeyValueIterator<Windowed<Bytes>, byte[]> backwardFetch(
+      final Bytes keyFrom,
+      final Bytes keyTo,
+      final long timeFrom,
+      final long timeTo
+  );
+
+  KeyValueIterator<Windowed<Bytes>, byte[]> backwardFetchAll(
+      final long timeFrom,
+      final long timeTo
+  );
+
+  KeyValueIterator<Windowed<Bytes>, byte[]> backwardAll();
+
+  @Override
+  void close();
+}

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/ResponsiveKeyValueStoreTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/ResponsiveKeyValueStoreTest.java
@@ -46,8 +46,7 @@ class ResponsiveKeyValueStoreTest {
     // Given:
     final var store = new ResponsiveKeyValueStore(
         ResponsiveKeyValueParams.keyValue("test"),
-        (params, context, type) -> ops,
-        config -> null
+        (params, context, type) -> ops
     );
     store.init((StateStoreContext) context, root);
     when(ops.get(any())).thenReturn(null);
@@ -64,8 +63,7 @@ class ResponsiveKeyValueStoreTest {
     // Given:
     final var store = new ResponsiveKeyValueStore(
         ResponsiveKeyValueParams.keyValue("test"),
-        (params, context, type) -> ops,
-        config -> null
+        (params, context, type) -> ops
     );
     store.init((StateStoreContext) context, root);
     when(ops.get(any())).thenReturn(new byte[]{125});


### PR DESCRIPTION
Just a minor step in the window store implementation, most of the interesting stuff will be in the followup with the subpartitioner (which for now is just a TODO)

This PRs adds a WindowOperations interface with just the single SegmentedOperations implementation for now. Although there's only the one implementation of this, it's still nice to break up everything that's currently stuffed into the `ResponsiveWindowStore` implementation.

With this, all of the Streams/WindowStore semantics and logic stays in the ResponsiveWindowStore class while the actual storage engine/implementation details will go in the SegmentedOperations