### PR TITLE
[mongo] eos support with epoch based fencing

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/KVDoc.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/KVDoc.java
@@ -16,36 +16,39 @@
 
 package dev.responsive.kafka.internal.db.mongo;
 
+import java.util.Arrays;
+import java.util.Date;
+import java.util.Objects;
 import org.bson.codecs.pojo.annotations.BsonId;
-import org.bson.types.ObjectId;
 
 public class KVDoc {
 
+  // TODO(agavra): figure out if we can use @BsonProperty to set the names explicitly
+  public static final String ID = "_id";
+  public static final String VALUE = "value";
+  public static final String EPOCH = "epoch";
+  public static final String TOMBSTONE_TS = "tombstoneTs";
+
   @BsonId
-  ObjectId id;
-  byte[] key;
+  byte[] id;
   byte[] value;
   long epoch;
+  Date tombstoneTs;
 
   public KVDoc() {
   }
 
   public KVDoc(final byte[] key, final byte[] value, final long epoch) {
-    this.key = key;
     this.value = value;
     this.epoch = epoch;
   }
 
-  public ObjectId getId() {
+  public byte[] getKey() {
     return id;
   }
 
-  public void setId(final ObjectId id) {
+  public void setKey(final byte[] id) {
     this.id = id;
-  }
-
-  public void setKey(final byte[] key) {
-    this.key = key;
   }
 
   public void setValue(final byte[] value) {
@@ -56,15 +59,51 @@ public class KVDoc {
     this.epoch = epoch;
   }
 
-  public byte[] getKey() {
-    return key;
-  }
-
   public byte[] getValue() {
     return value;
   }
 
   public long getEpoch() {
     return epoch;
+  }
+
+  public Date getTombstoneTs() {
+    return tombstoneTs;
+  }
+
+  public void setTombstoneTs(final Date tombstoneTs) {
+    this.tombstoneTs = tombstoneTs;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final KVDoc kvDoc = (KVDoc) o;
+    return epoch == kvDoc.epoch
+        && Arrays.equals(id, kvDoc.id)
+        && Arrays.equals(value, kvDoc.value)
+        && Objects.equals(tombstoneTs, kvDoc.tombstoneTs);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = Objects.hash(id, epoch, tombstoneTs);
+    result = 31 * result + Arrays.hashCode(value);
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "KVDoc{"
+        + "id=" + Arrays.toString(id)
+        + ", value=" + Arrays.toString(value)
+        + ", epoch=" + epoch
+        + ", tombstoneTs=" + tombstoneTs
+        + '}';
   }
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MetadataDoc.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MetadataDoc.java
@@ -16,15 +16,22 @@
 
 package dev.responsive.kafka.internal.db.mongo;
 
+import java.util.Objects;
 import org.bson.codecs.pojo.annotations.BsonId;
 import org.bson.types.ObjectId;
 
 public class MetadataDoc {
 
+  public static final String ID = "_id";
+  public static final String PARTITION = "partition";
+  public static final String OFFSET = "offset";
+  public static final String EPOCH = "epoch";
+
   @BsonId
   ObjectId id;
   int partition;
   long offset;
+  long epoch;
 
   public MetadataDoc() {
   }
@@ -51,5 +58,44 @@ public class MetadataDoc {
 
   public void setOffset(final long offset) {
     this.offset = offset;
+  }
+
+  public long epoch() {
+    return epoch;
+  }
+
+  public void setEpoch(final long epoch) {
+    this.epoch = epoch;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    final MetadataDoc that = (MetadataDoc) o;
+    return partition == that.partition
+        && offset == that.offset
+        && epoch == that.epoch
+        && Objects.equals(id, that.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, partition, epoch, offset);
+  }
+
+  @Override
+  public String toString() {
+    return "MetadataDoc{"
+        + "id=" + id
+        + ", partition=" + partition
+        + ", offset=" + offset
+        + ", epoch=" + epoch
+        + '}';
+
   }
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoWriterFactory.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoWriterFactory.java
@@ -30,18 +30,21 @@ import org.bson.Document;
 public class MongoWriterFactory<K> extends WriterFactory<K, Integer> {
 
   private final RemoteTable<K, WriteModel<Document>> table;
-  private final MongoCollection<Document> genericCollection;
+  private final MongoCollection<Document> genericDocs;
+  private final MongoCollection<Document> genericMetadata;
   private final TablePartitioner<K, Integer> partitioner;
   private final int kafkaPartition;
 
   public MongoWriterFactory(
       final RemoteTable<K, WriteModel<Document>> table,
-      final MongoCollection<Document> genericCollection,
+      final MongoCollection<Document> genericDocs,
+      final MongoCollection<Document> genericMetadata,
       final int kafkaPartition
   ) {
     super(String.format("MongoWriterFactory [%s-%d] ", table.name(), kafkaPartition));
     this.table = table;
-    this.genericCollection = genericCollection;
+    this.genericDocs = genericDocs;
+    this.genericMetadata = genericMetadata;
     this.partitioner = new DefaultPartitioner<>();
     this.kafkaPartition = kafkaPartition;
   }
@@ -50,7 +53,7 @@ public class MongoWriterFactory<K> extends WriterFactory<K, Integer> {
   public RemoteWriter<K, Integer> createWriter(
       final Integer tablePartition
   ) {
-    return new MongoWriter<>(table, kafkaPartition, genericCollection);
+    return new MongoWriter<>(table, kafkaPartition, genericDocs);
   }
 
   @Override
@@ -65,7 +68,7 @@ public class MongoWriterFactory<K> extends WriterFactory<K, Integer> {
 
   @Override
   public RemoteWriteResult<Integer> setOffset(final long consumedOffset) {
-    genericCollection.bulkWrite(List.of(table.setOffset(kafkaPartition, consumedOffset)));
+    genericMetadata.bulkWrite(List.of(table.setOffset(kafkaPartition, consumedOffset)));
     return RemoteWriteResult.success(kafkaPartition);
   }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/utils/SessionUtil.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/utils/SessionUtil.java
@@ -90,8 +90,11 @@ public final class SessionUtil {
   ) {
     final String connectionString;
     if (clientId != null && clientSecret != null) {
+      // TODO(agavra): consider allowing configuration of the read consideration
+      // some situations (such as non-EOS) could benefit from performance of non-majority
+      // reads if they're ok with the risks
       connectionString = String.format(
-          "mongodb+srv://%s:%s@%s/?retryWrites=true&w=majority",
+          "mongodb+srv://%s:%s@%s/?retryWrites=true&w=majority&r=majority",
           clientId,
           clientSecret,
           hostname

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/mongo/MongoKVTableTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/mongo/MongoKVTableTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.kafka.internal.db.mongo;
+
+import static dev.responsive.kafka.api.config.ResponsiveConfig.STORAGE_HOSTNAME_CONFIG;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.mongodb.client.MongoClient;
+import dev.responsive.kafka.api.config.StorageBackend;
+import dev.responsive.kafka.internal.stores.RemoteWriteResult;
+import dev.responsive.kafka.internal.utils.SessionUtil;
+import dev.responsive.kafka.testutils.ResponsiveConfigParam;
+import dev.responsive.kafka.testutils.ResponsiveExtension;
+import java.util.Map;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ExecutionException;
+import org.apache.kafka.common.utils.Bytes;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class MongoKVTableTest {
+
+  @RegisterExtension
+  public static final ResponsiveExtension EXT = new ResponsiveExtension(StorageBackend.MONGO_DB);
+
+  private String name;
+  private MongoClient client;
+
+  @BeforeEach
+  public void before(
+      final TestInfo info,
+      @ResponsiveConfigParam final Map<String, Object> props
+  ) {
+    name = info.getDisplayName().replace("()", "");
+
+    final String mongoConnection = (String) props.get(STORAGE_HOSTNAME_CONFIG);
+    client = SessionUtil.connect(mongoConnection, null, null);
+  }
+
+  @Test
+  public void shouldSucceedWriterWithSameEpoch() throws ExecutionException, InterruptedException {
+    // Given:
+    final MongoKVTable table = new MongoKVTable(client, name);
+
+    var writerFactory = table.init(0);
+    var writer = writerFactory.createWriter(0);
+    writer.insert(Bytes.wrap(new byte[] {1}), new byte[] {1}, 100);
+    writer.flush();
+
+    // When:
+    // use the same writer, which should have the same epoch
+    writer.insert(Bytes.wrap(new byte[] {1}), new byte[] {1}, 101);
+    final CompletionStage<RemoteWriteResult<Integer>> flush = writer.flush();
+
+    // Then:
+    assertThat(flush.toCompletableFuture().get().wasApplied(), is(true));
+  }
+
+  @Test
+  public void shouldSucceedWriterWithLargerEpoch() throws ExecutionException, InterruptedException {
+    // Given:
+    var table = new MongoKVTable(client, name);
+    var writerFactory = table.init(0);
+    var writer = writerFactory.createWriter(0);
+    writer.insert(Bytes.wrap(new byte[] {1}), new byte[] {1}, 100);
+    writer.flush();
+
+    // When:
+    // initialize new writer with higher epoch
+    table = new MongoKVTable(client, name);
+    writerFactory = table.init(0);
+    writer = writerFactory.createWriter(0);
+    writer.insert(Bytes.wrap(new byte[] {1}), new byte[] {1}, 101);
+    final CompletionStage<RemoteWriteResult<Integer>> flush = writer.flush();
+
+    // Then:
+    assertThat(flush.toCompletableFuture().get().wasApplied(), is(true));
+  }
+
+  @Test
+  public void shouldFenceWriterSmallerEpoch() throws ExecutionException, InterruptedException {
+    // Given:
+    var table0 = new MongoKVTable(client, name);
+    var writerFactory0 = table0.init(0);
+    var writer0 = writerFactory0.createWriter(0);
+
+    var table1 = new MongoKVTable(client, name);
+    var writerFactory1 = table1.init(0);
+    var writer1 = writerFactory1.createWriter(0);
+
+    writer1.insert(Bytes.wrap(new byte[] {1}), new byte[] {1}, 100);
+    writer1.flush();
+
+    // When:
+    // initialize new writer with higher epoch
+    writer0.insert(Bytes.wrap(new byte[] {1}), new byte[] {1}, 101);
+    final CompletionStage<RemoteWriteResult<Integer>> flush = writer0.flush();
+
+    // Then:
+    assertThat(flush.toCompletableFuture().get().wasApplied(), is(false));
+  }
+
+}


### PR DESCRIPTION
### Review Guide

There are basically two changes:

1. pipe `epoch` through to where it's necessary
2. Changes in `MongoKVTable` to support EOS

You really only need to review the second to get a sense of whats' going on.

I tested it by running the EOS test against MongoDB, though I'll follow up this PR with a more significant testing suite for MongoDB stores in general.

#### Implementing Epoch-Based Fencing

MongoDB supports atomic updates on individual documents via the [findAndModify](https://www.mongodb.com/docs/manual/reference/method/db.collection.findAndModify/#std-label-findAndModify-upsert-example) upsert operation of the form:

```jsx
db.example.findAndModify({
    query: { key: "0xDEADBEEF", epoch: { $lte: local_epoch } },
    update: { $set: { key: "0xDEADBEEF", value: "0xCAFED00D", epoch: local_epoch } },
    upsert: true
})
```

The `$lte: local_epoch` ensures that the document will not be retrieved at all if the current document has been written by a writer that has a higher epoch. So long as processing deterministically updates the same keys, this should be a safe operation (which is a requirement for EOS in Kafka Streams anyway).

****************************************Managing Tombstones.**************************************** Deletes are more complicated to handle since it is possible that a future writer *deleted* a document. If we were to simply remove those documents from the database, a zombie would be able to revive the document because it would consider it would successfully upsert. 

To handle this, we'll insert a special timestamp field *only for deleted documents* that includes the time in which it was deleted and build a [TTL index](https://www.mongodb.com/docs/manual/core/index-ttl/) on top of it to automatically expire it after some grace period (this is very similar to Cassandra's `gc_grace_seconds` and Kafka's `delete.retention.ms` configurations):

```jsx
db.example.createIndex( { "tombstoneTs": 1 }, {expireAfterSeconds: 86400 } )
db.example.findAndModify({
    query: { key: "0xDEADBEEF", epoch: { $lte: local_epoch } },
    update: { $set: { key: "0xDEADBEEF", value: null, epoch: local_epoch, tombstoneTs: now() } },
})
```

Note that we will have to add `{ $unset: tombstoneTs }` to the normal inserts to ensure we don't accidentally remove a document if it is intentionally revived.