### PR TITLE
Persist stream-time for window stores

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraKeyValueTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraKeyValueTable.java
@@ -268,9 +268,9 @@ public class CassandraKeyValueTable
   public WriterFactory<Bytes, Integer> init(
       final int kafkaPartition
   ) {
-    partitioner.allTablePartitions(kafkaPartition).forEach(sub -> client.execute(
+    partitioner.allTablePartitions(kafkaPartition).forEach(tablePartition -> client.execute(
         QueryBuilder.insertInto(name)
-            .value(PARTITION_KEY.column(), PARTITION_KEY.literal(sub))
+            .value(PARTITION_KEY.column(), PARTITION_KEY.literal(tablePartition))
             .value(ROW_TYPE.column(), METADATA_ROW.literal())
             .value(DATA_KEY.column(), DATA_KEY.literal(METADATA_KEY))
             .value(TIMESTAMP.column(), TIMESTAMP.literal(METADATA_TS))

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraWindowedTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraWindowedTable.java
@@ -698,8 +698,7 @@ public class CassandraWindowedTable implements
         .bind()
         .setInt(PARTITION_KEY.bind(), metadataPartition.tablePartition)
         .setLong(SEGMENT_ID.bind(), metadataPartition.segmentId)
-        .setLong(STREAM_TIME.bind(), pendingFlush.pendingFlushStreamTime)
-        .setLong(EPOCH.bind(), epoch);
+        .setLong(STREAM_TIME.bind(), pendingFlush.pendingFlushStreamTime);
   }
 
   @Override

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraWindowedTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraWindowedTable.java
@@ -435,7 +435,7 @@ public class CassandraWindowedTable implements
 
     client.execute(
         QueryBuilder.insertInto(name)
-            .value(PARTITION_KEY.column(), PARTITION_KEY.literal(metadataPartition.partitionKey))
+            .value(PARTITION_KEY.column(), PARTITION_KEY.literal(metadataPartition.tablePartition))
             .value(SEGMENT_ID.column(), SEGMENT_ID.literal(metadataPartition.segmentId))
             .value(ROW_TYPE.column(), METADATA_ROW.literal())
             .value(DATA_KEY.column(), DATA_KEY.literal(METADATA_KEY))
@@ -489,7 +489,7 @@ public class CassandraWindowedTable implements
     client.execute(
         initSegment
             .bind()
-            .setInt(PARTITION_KEY.bind(), segmentToCreate.partitionKey)
+            .setInt(PARTITION_KEY.bind(), segmentToCreate.tablePartition)
             .setLong(SEGMENT_ID.bind(), segmentToCreate.segmentId)
             .setLong(EPOCH.bind(), epoch)
     );
@@ -499,7 +499,7 @@ public class CassandraWindowedTable implements
     client.execute(
         expireSegment
             .bind()
-            .setInt(PARTITION_KEY.bind(), segmentToDelete.partitionKey)
+            .setInt(PARTITION_KEY.bind(), segmentToDelete.tablePartition)
             .setLong(SEGMENT_ID.bind(), segmentToDelete.segmentId)
     );
   }
@@ -510,7 +510,7 @@ public class CassandraWindowedTable implements
     final List<Row> result = client.execute(
         fetchOffset
             .bind()
-            .setInt(PARTITION_KEY.bind(), metadataPartition.partitionKey)
+            .setInt(PARTITION_KEY.bind(), metadataPartition.tablePartition)
             .setLong(SEGMENT_ID.bind(), metadataPartition.segmentId))
         .all();
 
@@ -531,7 +531,7 @@ public class CassandraWindowedTable implements
     final SegmentPartition metadataPartition = partitioner.metadataTablePartition(kafkaPartition);
     return setOffset
         .bind()
-        .setInt(PARTITION_KEY.bind(), metadataPartition.partitionKey)
+        .setInt(PARTITION_KEY.bind(), metadataPartition.tablePartition)
         .setLong(SEGMENT_ID.bind(), metadataPartition.segmentId)
         .setLong(OFFSET.bind(), offset);
   }
@@ -541,7 +541,7 @@ public class CassandraWindowedTable implements
     final List<Row> result = client.execute(
             fetchEpoch
                 .bind()
-                .setInt(PARTITION_KEY.bind(), segmentPartition.partitionKey)
+                .setInt(PARTITION_KEY.bind(), segmentPartition.tablePartition)
                 .setLong(SEGMENT_ID.bind(), segmentPartition.segmentId))
         .all();
 
@@ -558,7 +558,7 @@ public class CassandraWindowedTable implements
   public BoundStatement reserveEpoch(final SegmentPartition segmentPartition, final long epoch) {
     return reserveEpoch
         .bind()
-        .setInt(PARTITION_KEY.bind(), segmentPartition.partitionKey)
+        .setInt(PARTITION_KEY.bind(), segmentPartition.tablePartition)
         .setLong(SEGMENT_ID.bind(), segmentPartition.segmentId)
         .setLong(EPOCH.bind(), epoch);
   }
@@ -567,7 +567,7 @@ public class CassandraWindowedTable implements
   public BoundStatement ensureEpoch(final SegmentPartition segmentPartition, final long epoch) {
     return ensureEpoch
         .bind()
-        .setInt(PARTITION_KEY.bind(), segmentPartition.partitionKey)
+        .setInt(PARTITION_KEY.bind(), segmentPartition.tablePartition)
         .setLong(SEGMENT_ID.bind(), segmentPartition.segmentId)
         .setLong(EPOCH.bind(), epoch);
   }
@@ -598,7 +598,7 @@ public class CassandraWindowedTable implements
     final SegmentPartition remotePartition = partitioner.tablePartition(kafkaPartition, key);
     return insert
         .bind()
-        .setInt(PARTITION_KEY.bind(), remotePartition.partitionKey)
+        .setInt(PARTITION_KEY.bind(), remotePartition.tablePartition)
         .setLong(SEGMENT_ID.bind(), remotePartition.segmentId)
         .setByteBuffer(DATA_KEY.bind(), ByteBuffer.wrap(key.key.get()))
         .setInstant(WINDOW_START.bind(), Instant.ofEpochMilli(key.stamp))
@@ -625,7 +625,7 @@ public class CassandraWindowedTable implements
     final SegmentPartition segmentPartition = partitioner.tablePartition(kafkaPartition, key);
     return delete
         .bind()
-        .setInt(PARTITION_KEY.bind(), segmentPartition.partitionKey)
+        .setInt(PARTITION_KEY.bind(), segmentPartition.tablePartition)
         .setLong(SEGMENT_ID.bind(), segmentPartition.segmentId)
         .setByteBuffer(DATA_KEY.bind(), ByteBuffer.wrap(key.key.get()))
         .setInstant(WINDOW_START.bind(), Instant.ofEpochMilli(key.stamp));
@@ -651,7 +651,7 @@ public class CassandraWindowedTable implements
 
     final BoundStatement get = fetchSingle
         .bind()
-        .setInt(PARTITION_KEY.bind(), segmentPartition.partitionKey)
+        .setInt(PARTITION_KEY.bind(), segmentPartition.tablePartition)
         .setLong(SEGMENT_ID.bind(), segmentPartition.segmentId)
         .setByteBuffer(DATA_KEY.bind(), ByteBuffer.wrap(key.get()))
         .setInstant(WINDOW_START.bind(), Instant.ofEpochMilli(windowStart));
@@ -688,7 +688,7 @@ public class CassandraWindowedTable implements
     for (final SegmentPartition partition : partitioner.range(kafkaPartition, timeFrom, timeTo)) {
       final BoundStatement get = fetch
           .bind()
-          .setInt(PARTITION_KEY.bind(), partition.partitionKey)
+          .setInt(PARTITION_KEY.bind(), partition.tablePartition)
           .setLong(SEGMENT_ID.bind(), partition.segmentId)
           .setByteBuffer(DATA_KEY.bind(), ByteBuffer.wrap(key.get()))
           .setInstant(WINDOW_FROM_BIND, Instant.ofEpochMilli(timeFrom))
@@ -723,7 +723,7 @@ public class CassandraWindowedTable implements
     for (final var partition : partitioner.reverseRange(kafkaPartition, timeFrom, timeTo)) {
       final BoundStatement get = backFetch
           .bind()
-          .setInt(PARTITION_KEY.bind(), partition.partitionKey)
+          .setInt(PARTITION_KEY.bind(), partition.tablePartition)
           .setLong(SEGMENT_ID.bind(), partition.segmentId)
           .setByteBuffer(DATA_KEY.bind(), ByteBuffer.wrap(key.get()))
           .setInstant(WINDOW_FROM_BIND, Instant.ofEpochMilli(timeFrom))
@@ -761,7 +761,7 @@ public class CassandraWindowedTable implements
     for (final SegmentPartition partition : partitioner.range(kafkaPartition, timeFrom, timeTo)) {
       final BoundStatement get = fetchRange
           .bind()
-          .setInt(PARTITION_KEY.bind(), partition.partitionKey)
+          .setInt(PARTITION_KEY.bind(), partition.tablePartition)
           .setLong(SEGMENT_ID.bind(), partition.segmentId)
           .setByteBuffer(KEY_FROM_BIND, ByteBuffer.wrap(fromKey.get()))
           .setByteBuffer(KEY_TO_BIND, ByteBuffer.wrap(toKey.get()));
@@ -801,7 +801,7 @@ public class CassandraWindowedTable implements
     for (final var partition : partitioner.reverseRange(kafkaPartition, timeFrom, timeTo)) {
       final BoundStatement get = backFetchRange
           .bind()
-          .setInt(PARTITION_KEY.bind(), partition.partitionKey)
+          .setInt(PARTITION_KEY.bind(), partition.tablePartition)
           .setLong(SEGMENT_ID.bind(), partition.segmentId)
           .setByteBuffer(KEY_FROM_BIND, ByteBuffer.wrap(fromKey.get()))
           .setByteBuffer(KEY_TO_BIND, ByteBuffer.wrap(toKey.get()));
@@ -836,7 +836,7 @@ public class CassandraWindowedTable implements
     for (final SegmentPartition partition : partitioner.range(kafkaPartition, timeFrom, timeTo)) {
       final BoundStatement get = fetchAll
           .bind()
-          .setInt(PARTITION_KEY.bind(), partition.partitionKey)
+          .setInt(PARTITION_KEY.bind(), partition.tablePartition)
           .setLong(SEGMENT_ID.bind(), partition.segmentId)
           .setInstant(KEY_FROM_BIND, Instant.ofEpochMilli(timeFrom))
           .setInstant(KEY_TO_BIND, Instant.ofEpochMilli(timeTo));
@@ -871,7 +871,7 @@ public class CassandraWindowedTable implements
     for (final var partition : partitioner.reverseRange(kafkaPartition, timeFrom, timeTo)) {
       final BoundStatement get = backFetchAll
           .bind()
-          .setInt(PARTITION_KEY.bind(), partition.partitionKey)
+          .setInt(PARTITION_KEY.bind(), partition.tablePartition)
           .setLong(SEGMENT_ID.bind(), partition.segmentId)
           .setInstant(KEY_FROM_BIND, Instant.ofEpochMilli(timeFrom))
           .setInstant(KEY_TO_BIND, Instant.ofEpochMilli(timeTo));

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/ColumnName.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/ColumnName.java
@@ -38,6 +38,7 @@ public enum ColumnName {
   DATA_VALUE("value", "value", b -> bytes((byte[]) b)),
   OFFSET("offset", "offset"),
   EPOCH("epoch", "epoch"),
+  STREAM_TIME("streamTime", "streamtime", ts -> timestamp((long) ts)),
   WINDOW_START("windowStart", "windowstart", ts -> timestamp((long) ts)),
   TIMESTAMP("ts", "ts", ts -> timestamp((long) ts));
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/ColumnName.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/ColumnName.java
@@ -38,7 +38,7 @@ public enum ColumnName {
   DATA_VALUE("value", "value", b -> bytes((byte[]) b)),
   OFFSET("offset", "offset"),
   EPOCH("epoch", "epoch"),
-  STREAM_TIME("streamTime", "streamtime", ts -> timestamp((long) ts)),
+  STREAM_TIME("streamTime", "streamtime"),
   WINDOW_START("windowStart", "windowstart", ts -> timestamp((long) ts)),
   TIMESTAMP("ts", "ts", ts -> timestamp((long) ts));
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/LwtWriterFactory.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/LwtWriterFactory.java
@@ -21,14 +21,8 @@ import com.datastax.oss.driver.api.core.cql.BatchType;
 import com.datastax.oss.driver.api.core.cql.BoundStatement;
 import dev.responsive.kafka.internal.db.partitioning.TablePartitioner;
 import dev.responsive.kafka.internal.stores.RemoteWriteResult;
-import java.util.List;
-import org.apache.kafka.streams.errors.TaskMigratedException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class LwtWriterFactory<K, P> extends WriterFactory<K, P> {
-
-  private static final Logger LOG = LoggerFactory.getLogger(LwtWriterFactory.class);
 
   private final RemoteTable<K, BoundStatement> table;
   private final TableMetadata<P> tableMetadata;

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/partitioning/SegmentPartitioner.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/partitioning/SegmentPartitioner.java
@@ -93,18 +93,18 @@ public class SegmentPartitioner implements TablePartitioner<Stamped<Bytes>, Segm
   private final long windowSizeMs;
 
   public static class SegmentPartition {
-    public final int partitionKey;
+    public final int tablePartition;
     public final long segmentId;
 
-    public SegmentPartition(final int partitionKey, final long segmentId) {
-      this.partitionKey = partitionKey;
+    public SegmentPartition(final int tablePartition, final long segmentId) {
+      this.tablePartition = tablePartition;
       this.segmentId = segmentId;
     }
 
     @Override
     public String toString() {
       return "SegmentPartition{"
-          + "partitionKey=" + partitionKey
+          + "partitionKey=" + tablePartition
           + ", segmentId=" + segmentId
           + '}';
     }
@@ -126,6 +126,8 @@ public class SegmentPartitioner implements TablePartitioner<Stamped<Bytes>, Segm
     this.retentionPeriodMs = retentionPeriodMs;
     this.segmentIntervalMs = segmentIntervalMs;
     this.windowSizeMs = windowSizeMs;
+    LOG.info("Created segment partitioner with retentionPeriod={}ms, segmentInterval={}ms,"
+                 + " and windowSize={}ms", retentionPeriodMs, segmentIntervalMs, windowSizeMs);
   }
 
   @Override
@@ -229,8 +231,8 @@ public class SegmentPartitioner implements TablePartitioner<Stamped<Bytes>, Segm
     }
   }
 
-  private int segmentId(final long windowTimestamp) {
-    return Integer.max(0, (int) (windowTimestamp / segmentIntervalMs));
+  private long segmentId(final long windowTimestamp) {
+    return Long.max(0, windowTimestamp / segmentIntervalMs);
   }
 
   public static class SegmentRoll {

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/partitioning/SegmentPartitioner.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/partitioning/SegmentPartitioner.java
@@ -136,7 +136,7 @@ public class SegmentPartitioner implements TablePartitioner<Stamped<Bytes>, Segm
                 retentionPeriodMs, segmentIntervalMs, windowSizeMs);
       throw new IllegalStateException("Segment partitioner received a negative or zero value");
     }
-    
+
     LOG.info("Created segment partitioner with retentionPeriod={}ms, segmentInterval={}ms,"
                  + " and windowSize={}ms", retentionPeriodMs, segmentIntervalMs, windowSizeMs);
   }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/utils/Stamped.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/utils/Stamped.java
@@ -28,9 +28,9 @@ public class Stamped<K> {
 
   @Override
   public String toString() {
-    return "Stamped{" +
-        "key=" + key +
-        ", windowStart=" + stamp +
-        '}';
+    return "Stamped{"
+        + "key=" + key
+        + ", windowStart=" + stamp
+        + '}';
   }
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/utils/Stamped.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/utils/Stamped.java
@@ -26,4 +26,11 @@ public class Stamped<K> {
     this.stamp = stamp;
   }
 
+  @Override
+  public String toString() {
+    return "Stamped{" +
+        "key=" + key +
+        ", windowStart=" + stamp +
+        '}';
+  }
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/utils/StoreUtil.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/utils/StoreUtil.java
@@ -48,7 +48,7 @@ public final class StoreUtil {
   }
 
   public static long computeSegmentInterval(final long retentionPeriod, final long numSegments) {
-    return retentionPeriod / numSegments;
+    return Math.max(1, retentionPeriod / numSegments);
   }
 
   public static void validateLogConfigs(

--- a/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveWindowStoreIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveWindowStoreIntegrationTest.java
@@ -52,7 +52,6 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 import org.apache.kafka.clients.admin.Admin;

--- a/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveWindowStoreIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveWindowStoreIntegrationTest.java
@@ -252,7 +252,8 @@ public class ResponsiveWindowStoreIntegrationTest {
       }
     }
   }
-
+  
+  //@Test
   public void shouldComputeWindowedJoinUsingRanges() throws InterruptedException {
     // Given:
     final Map<String, Object> properties = getMutableProperties();

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/CommitBufferTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/CommitBufferTest.java
@@ -318,9 +318,9 @@ public class CommitBufferTest {
     // Given:
     try (final CommitBuffer<Bytes, Integer> buffer = createCommitBuffer(false)) {
 
-      // reserve epoch for partition 8 to ensure it doesn't get flushed
-      // if it did it would get fenced
-      table.init(KAFKA_PARTITION);
+      // reserve epoch 2 for partition 9 to ensure the flush attempt fails
+      // to write for that partition
+      client.execute(table.reserveEpoch(9, 2));
 
       final Bytes k1 = Bytes.wrap(new byte[]{1});
       final Bytes k2 = Bytes.wrap(new byte[]{2});
@@ -329,7 +329,7 @@ public class CommitBufferTest {
       buffer.put(k1, VALUE, CURRENT_TS); // insert into subpartition 9
       buffer.put(k2, VALUE, CURRENT_TS); // insert into subpartition 10
 
-      // flush with partial epoch fencing: only subpartition 8 and 9 have been bumped
+      // flush with partial epoch fencing: only subpartition 9 has been bumped
       // so the offset update and k1 write will fail but k2 write will get through
       try {
         buffer.flush(100L);
@@ -341,7 +341,7 @@ public class CommitBufferTest {
       assertThat(table.get(changelog.partition(), k1, MIN_VALID_TS), nullValue());
       assertThat(table.get(changelog.partition(), k2, MIN_VALID_TS), is(VALUE));
 
-      assertThat(table.fetchEpoch(8), is(2L));
+      assertThat(table.fetchEpoch(8), is(1L));
       assertThat(table.fetchEpoch(9), is(2L));
       assertThat(table.fetchEpoch(10), is(1L));
       assertThat(table.fetchOffset(changelog.partition()), is(-1L));

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/CommitBufferTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/CommitBufferTest.java
@@ -321,8 +321,7 @@ public class CommitBufferTest {
 
       // reserve epoch for partition 8 to ensure it doesn't get flushed
       // if it did it would get fenced
-      LwtWriterFactory.initialize(
-          table, table, client, partitioner, changelog.partition(), List.of(8, 9));
+      table.init(KAFKA_PARTITION);
 
       final Bytes k1 = Bytes.wrap(new byte[]{1});
       final Bytes k2 = Bytes.wrap(new byte[]{2});

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/CommitBufferTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/CommitBufferTest.java
@@ -55,7 +55,6 @@ import dev.responsive.kafka.internal.db.BytesKeySpec;
 import dev.responsive.kafka.internal.db.CassandraClient;
 import dev.responsive.kafka.internal.db.CassandraKeyValueTable;
 import dev.responsive.kafka.internal.db.KeySpec;
-import dev.responsive.kafka.internal.db.LwtWriterFactory;
 import dev.responsive.kafka.internal.db.partitioning.SubPartitioner;
 import dev.responsive.kafka.internal.db.spec.BaseTableSpec;
 import dev.responsive.kafka.internal.metrics.ClientVersionMetadata;


### PR DESCRIPTION
- The main change here is to start preserving the stream-time across restarts by persisting it in the metadata segment, along with the offset. 
- Also fixes some arithmetic/edge case errors in the SegmentPartitioner.
- With the above, we can re-enable the ResponsiveWindowStoreIntegrationTest