### PR TITLE
revert back to kafka.streams.topic.consumed.total

### DIFF
--- a/etc/otel-jmx.config.yaml
+++ b/etc/otel-jmx.config.yaml
@@ -221,7 +221,7 @@ rules:
      topic: param(topic)
    mapping:
      records-consumed-total:
-       metric: kafka.streams.topic.records.consumed.total
+       metric: kafka.streams.topic.consumed.total
        type: gauge
        desc: the total records consumed
        unit: '{records}'


### PR DESCRIPTION
Changes kafka.streams.topic.records.consumed.total back to kafka.streams.topic.consumed.total so as not to break apps using the rate based policy.