### PR TITLE
Remove generic <K> from Stamped and clean up Comparator logic

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/BytesKeySpec.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/BytesKeySpec.java
@@ -16,7 +16,6 @@
 
 package dev.responsive.kafka.internal.db;
 
-import java.util.Objects;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.utils.Bytes;
 
@@ -30,11 +29,6 @@ public class BytesKeySpec implements KeySpec<Bytes> {
   @Override
   public int sizeInBytes(final Bytes key) {
     return key.get().length;
-  }
-
-  @Override
-  public int compare(final Bytes o1, final Bytes o2) {
-    return Objects.compare(o1, o2, Bytes::compareTo);
   }
 
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraTableSpecFactory.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraTableSpecFactory.java
@@ -66,7 +66,7 @@ public class CassandraTableSpecFactory {
 
   public static CassandraTableSpec fromWindowParams(
       final ResponsiveWindowParams params,
-      final TablePartitioner<Stamped<Bytes>, SegmentPartition> partitioner
+      final TablePartitioner<Stamped, SegmentPartition> partitioner
   ) {
     return new BaseTableSpec(params.name().remoteName(), partitioner);
   }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/KeySpec.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/KeySpec.java
@@ -16,10 +16,9 @@
 
 package dev.responsive.kafka.internal.db;
 
-import java.util.Comparator;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 
-public interface KeySpec<K> extends Comparator<K> {
+public interface KeySpec<K extends Comparable<K>> {
 
   K keyFromRecord(final ConsumerRecord<byte[], byte[]> record);
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/RemoteWindowedTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/RemoteWindowedTable.java
@@ -20,53 +20,52 @@ import dev.responsive.kafka.internal.utils.Stamped;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.state.KeyValueIterator;
 
-public interface RemoteWindowedTable<S> extends RemoteTable<Stamped<Bytes>, S> {
+public interface RemoteWindowedTable<S> extends RemoteTable<Stamped, S> {
 
   byte[] fetch(
-      int kafkaPartition,
+      int partition,
       Bytes key,
       long windowStart
   );
 
-  KeyValueIterator<Stamped<Bytes>, byte[]> fetch(
-      int kafkaPartition,
+  KeyValueIterator<Stamped, byte[]> fetch(
+      int partition,
       Bytes key,
       long timeFrom,
       long timeTo
   );
 
-  KeyValueIterator<Stamped<Bytes>, byte[]> fetchRange(
-      int kafkaPartition,
+  KeyValueIterator<Stamped, byte[]> backFetch(
+      int partition,
+      Bytes key,
+      long timeFrom,
+      long timeTo
+  );
+
+  KeyValueIterator<Stamped, byte[]> fetchRange(
+      int partition,
       Bytes fromKey,
       Bytes toKey,
       long timeFrom,
       long timeTo
   );
 
-  KeyValueIterator<Stamped<Bytes>, byte[]> fetchAll(
-      int kafkaPartition,
-      long timeFrom,
-      long timeTo
-  );
-
-
-  KeyValueIterator<Stamped<Bytes>, byte[]> backFetch(
-      int kafkaPartition,
-      Bytes key,
-      long timeFrom,
-      long timeTo
-  );
-
-  KeyValueIterator<Stamped<Bytes>, byte[]> backFetchRange(
-      int kafkaPartition,
+  KeyValueIterator<Stamped, byte[]> backFetchRange(
+      int partition,
       Bytes fromKey,
       Bytes toKey,
       long timeFrom,
       long timeTo
   );
 
-  KeyValueIterator<Stamped<Bytes>, byte[]> backFetchAll(
-      int kafkaPartition,
+  KeyValueIterator<Stamped, byte[]> fetchAll(
+      int partition,
+      long timeFrom,
+      long timeTo
+  );
+
+  KeyValueIterator<Stamped, byte[]> backFetchAll(
+      int partition,
       long timeFrom,
       long timeTo
   );

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/partitioning/SegmentPartitioner.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/partitioning/SegmentPartitioner.java
@@ -26,7 +26,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
-import org.apache.kafka.common.utils.Bytes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -81,7 +80,7 @@ import org.slf4j.LoggerFactory;
  * For the time being, we simply recommend that users configure the number of segments
  * similarly to how they would configure the number of sub-partitions for a key-value store.
  */
-public class SegmentPartitioner implements TablePartitioner<Stamped<Bytes>, SegmentPartition> {
+public class SegmentPartitioner implements TablePartitioner<Stamped, SegmentPartition> {
 
   private static final Logger LOG = LoggerFactory.getLogger(SegmentPartitioner.class);
 
@@ -142,8 +141,8 @@ public class SegmentPartitioner implements TablePartitioner<Stamped<Bytes>, Segm
   }
 
   @Override
-  public SegmentPartition tablePartition(final int kafkaPartition, final Stamped<Bytes> key) {
-    return new SegmentPartition(kafkaPartition, segmentId(key.stamp));
+  public SegmentPartition tablePartition(final int kafkaPartition, final Stamped key) {
+    return new SegmentPartition(kafkaPartition, segmentId(key.timestamp));
   }
 
   @Override

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/CommitBuffer.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/CommitBuffer.java
@@ -79,7 +79,7 @@ import org.apache.kafka.streams.processor.internals.RecordBatchingStateRestoreCa
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.slf4j.Logger;
 
-public class CommitBuffer<K, P>
+public class CommitBuffer<K extends Comparable<K>, P>
     implements RecordBatchingStateRestoreCallback, Closeable {
 
   public static final int MAX_BATCH_SIZE = 1000;
@@ -116,7 +116,7 @@ public class CommitBuffer<K, P>
 
   private Instant lastFlush;
 
-  static <K, P> CommitBuffer<K, P> from(
+  static <K extends Comparable<K>, P> CommitBuffer<K, P> from(
       final WriterFactory<K, P> writerFactory,
       final SessionClients clients,
       final TopicPartition changelog,

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/PartitionedOperations.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/PartitionedOperations.java
@@ -54,7 +54,6 @@ public class PartitionedOperations implements KeyValueOperations {
   private final InternalProcessorContext context;
   private final ResponsiveKeyValueParams params;
   private final RemoteKVTable<?> table;
-  private final BytesKeySpec keySpec;
   private final CommitBuffer<Bytes, ?> buffer;
   private final TopicPartition changelog;
 
@@ -126,7 +125,6 @@ public class PartitionedOperations implements KeyValueOperations {
         context,
         params,
         table,
-        keySpec,
         buffer,
         changelog,
         storeRegistry,
@@ -184,7 +182,6 @@ public class PartitionedOperations implements KeyValueOperations {
       final InternalProcessorContext context,
       final ResponsiveKeyValueParams params,
       final RemoteKVTable<?> table,
-      final BytesKeySpec keySpec,
       final CommitBuffer<Bytes, ?> buffer,
       final TopicPartition changelog,
       final ResponsiveStoreRegistry storeRegistry,
@@ -195,7 +192,6 @@ public class PartitionedOperations implements KeyValueOperations {
     this.context = context;
     this.params = params;
     this.table = table;
-    this.keySpec = keySpec;
     this.buffer = buffer;
     this.changelog = changelog;
     this.storeRegistry = storeRegistry;
@@ -254,8 +250,7 @@ public class PartitionedOperations implements KeyValueOperations {
 
     return new LocalRemoteKvIterator<>(
         buffer.range(from, to),
-        table.range(changelog.partition(), from, to, minValidTimestamp()),
-        keySpec
+        table.range(changelog.partition(), from, to, minValidTimestamp())
     );
   }
 
@@ -269,8 +264,7 @@ public class PartitionedOperations implements KeyValueOperations {
   public KeyValueIterator<Bytes, byte[]> all() {
     return new LocalRemoteKvIterator<>(
         buffer.all(),
-        table.all(changelog.partition(), minValidTimestamp()),
-        keySpec
+        table.all(changelog.partition(), minValidTimestamp())
     );
   }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveWindowStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveWindowStore.java
@@ -86,7 +86,7 @@ public class ResponsiveWindowStore implements WindowStore<Bytes, byte[]> {
           name,
           storeContext,
           params,
-          window -> window.stamp >= minValidTimestamp()
+          window -> window.timestamp >= minValidTimestamp()
       );
 
       log.info("Completed initializing state store");

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/SizeTrackingBuffer.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/SizeTrackingBuffer.java
@@ -7,7 +7,7 @@ import java.util.NavigableMap;
 import java.util.Objects;
 import java.util.TreeMap;
 
-public class SizeTrackingBuffer<K> {
+public class SizeTrackingBuffer<K extends Comparable<K>> {
   private final NavigableMap<K, Result<K>> buffer;
   private final NavigableMap<K, Result<K>> reader;
   private final KeySpec<K> extractor;
@@ -15,7 +15,7 @@ public class SizeTrackingBuffer<K> {
 
   public SizeTrackingBuffer(final KeySpec<K> extractor) {
     this.extractor = Objects.requireNonNull(extractor);
-    buffer = new TreeMap<>(extractor);
+    buffer = new TreeMap<>();
     reader = Collections.unmodifiableNavigableMap(buffer);
   }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/utils/Result.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/utils/Result.java
@@ -18,22 +18,29 @@ package dev.responsive.kafka.internal.utils;
 
 import dev.responsive.kafka.internal.db.KeySpec;
 
-public class Result<K> {
+public class Result<K extends Comparable<K>> {
 
   public final K key;
   public final byte[] value;
   public final boolean isTombstone;
   public final long timestamp;
 
-  public static <K> Result<K> value(final K key, final byte[] value, long timestamp) {
+  public static <K extends Comparable<K>> Result<K> value(
+      final K key,
+      final byte[] value,
+      final long timestamp
+  ) {
     return new Result<>(key, value, false, timestamp);
   }
 
-  public static <K> Result<K> tombstone(final K key, long timestamp) {
+  public static <K extends Comparable<K>> Result<K> tombstone(
+      final K key,
+      final long timestamp
+  ) {
     return new Result<>(key, null, true, timestamp);
   }
 
-  private Result(final K key, final byte[] value, final boolean isTombstone, long timestamp) {
+  private Result(final K key, final byte[] value, final boolean isTombstone, final long timestamp) {
     this.key = key;
     this.value = value;
     this.isTombstone = isTombstone;

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/utils/Stamped.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/utils/Stamped.java
@@ -16,21 +16,33 @@
 
 package dev.responsive.kafka.internal.utils;
 
-public class Stamped<K> {
+import org.apache.kafka.common.utils.Bytes;
 
-  public final K key;
-  public final long stamp;
+public class Stamped implements Comparable<Stamped> {
 
-  public Stamped(final K key, final long stamp) {
+  public final Bytes key;
+  public final long timestamp;
+
+  public Stamped(final Bytes key, final long timestamp) {
     this.key = key;
-    this.stamp = stamp;
+    this.timestamp = timestamp;
   }
 
   @Override
   public String toString() {
     return "Stamped{"
         + "key=" + key
-        + ", windowStart=" + stamp
+        + ", windowStart=" + timestamp
         + '}';
+  }
+
+  @Override
+  public int compareTo(final Stamped o) {
+    final int compareKeys = this.key.compareTo(o.key);
+    if (compareKeys != 0) {
+      return compareKeys;
+    } else {
+      return Long.compare(this.timestamp, o.timestamp);
+    }
   }
 }

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/LocalRemoteKvIteratorTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/LocalRemoteKvIteratorTest.java
@@ -50,7 +50,7 @@ public class LocalRemoteKvIteratorTest {
 
     // When:
     final List<Bytes> flushed = new ArrayList<>();
-    new LocalRemoteKvIterator<>(buffered, remote, Bytes::compareTo)
+    new LocalRemoteKvIterator<>(buffered, remote)
         .forEachRemaining(kv -> flushed.add(kv.key));
 
     // Then:
@@ -78,7 +78,7 @@ public class LocalRemoteKvIteratorTest {
 
     // When:
     final List<byte[]> flushed = new ArrayList<>();
-    new LocalRemoteKvIterator<>(buffered, remote, Bytes::compareTo)
+    new LocalRemoteKvIterator<>(buffered, remote)
         .forEachRemaining(kv -> flushed.add(kv.value));
 
     // Then:
@@ -105,7 +105,7 @@ public class LocalRemoteKvIteratorTest {
 
     // When:
     final List<Bytes> flushed = new ArrayList<>();
-    new LocalRemoteKvIterator<>(buffered, remote, Bytes::compareTo)
+    new LocalRemoteKvIterator<>(buffered, remote)
         .forEachRemaining(kv -> flushed.add(kv.key));
 
     // Then:
@@ -132,7 +132,7 @@ public class LocalRemoteKvIteratorTest {
 
     // When:
     final List<Bytes> flushed = new ArrayList<>();
-    new LocalRemoteKvIterator<>(buffered, remote, Bytes::compareTo)
+    new LocalRemoteKvIterator<>(buffered, remote)
         .forEachRemaining(kv -> flushed.add(kv.key));
 
     // Then:
@@ -159,7 +159,7 @@ public class LocalRemoteKvIteratorTest {
 
     // When:
     final List<Bytes> flushed = new ArrayList<>();
-    new LocalRemoteKvIterator<>(buffered, remote, Bytes::compareTo)
+    new LocalRemoteKvIterator<>(buffered, remote)
         .forEachRemaining(kv -> flushed.add(kv.key));
 
     // Then:
@@ -183,7 +183,7 @@ public class LocalRemoteKvIteratorTest {
 
     // When:
     final List<Bytes> flushed = new ArrayList<>();
-    new LocalRemoteKvIterator<>(buffered, remote, Bytes::compareTo)
+    new LocalRemoteKvIterator<>(buffered, remote)
         .forEachRemaining(kv -> flushed.add(kv.key));
 
     // Then:

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/SizeTrackingBufferTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/SizeTrackingBufferTest.java
@@ -3,10 +3,9 @@ package dev.responsive.kafka.internal.stores;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-import dev.responsive.kafka.internal.db.KeySpec;
+import dev.responsive.kafka.internal.db.BytesKeySpec;
 import dev.responsive.kafka.internal.utils.Result;
 import java.util.List;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.utils.Bytes;
 import org.junit.jupiter.api.Test;
 
@@ -14,22 +13,7 @@ class SizeTrackingBufferTest {
 
   private static final long TIMESTAMP = 100L;
 
-  private final SizeTrackingBuffer<Bytes> buffer = new SizeTrackingBuffer<>(new KeySpec<>() {
-    @Override
-    public Bytes keyFromRecord(final ConsumerRecord<byte[], byte[]> record) {
-      return Bytes.wrap(record.key());
-    }
-
-    @Override
-    public int sizeInBytes(final Bytes key) {
-      return key.get().length;
-    }
-
-    @Override
-    public int compare(final Bytes o1, final Bytes o2) {
-      return o1.compareTo(o2);
-    }
-  });
+  private final SizeTrackingBuffer<Bytes> buffer = new SizeTrackingBuffer<>(new BytesKeySpec());
 
   @Test
   public void shouldReturnSizeZeroOnEmptyBuffer() {

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/internal/db/TTDWindowedTable.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/internal/db/TTDWindowedTable.java
@@ -24,7 +24,7 @@ import dev.responsive.kafka.internal.utils.Stamped;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.state.KeyValueIterator;
 
-public class TTDWindowedTable extends TTDTable<Stamped<Bytes>>
+public class TTDWindowedTable extends TTDTable<Stamped>
     implements RemoteWindowedTable<BoundStatement>  {
 
   private final String name;
@@ -51,7 +51,7 @@ public class TTDWindowedTable extends TTDTable<Stamped<Bytes>>
   @Override
   public BoundStatement insert(
       final int kafkaPartition,
-      final Stamped<Bytes> key,
+      final Stamped key,
       final byte[] value,
       final long epochMillis
   ) {
@@ -62,7 +62,7 @@ public class TTDWindowedTable extends TTDTable<Stamped<Bytes>>
   @Override
   public BoundStatement delete(
       final int kafkaPartition,
-      final Stamped<Bytes> key
+      final Stamped key
   ) {
     stub.delete(key);
     return null;
@@ -78,7 +78,7 @@ public class TTDWindowedTable extends TTDTable<Stamped<Bytes>>
   }
 
   @Override
-  public KeyValueIterator<Stamped<Bytes>, byte[]> fetch(
+  public KeyValueIterator<Stamped, byte[]> fetch(
       final int kafkaPartition,
       final Bytes key,
       final long timeFrom,
@@ -88,7 +88,7 @@ public class TTDWindowedTable extends TTDTable<Stamped<Bytes>>
   }
 
   @Override
-  public KeyValueIterator<Stamped<Bytes>, byte[]> backFetch(
+  public KeyValueIterator<Stamped, byte[]> backFetch(
       final int kafkaPartition,
       final Bytes key,
       final long timeFrom,
@@ -98,7 +98,7 @@ public class TTDWindowedTable extends TTDTable<Stamped<Bytes>>
   }
 
   @Override
-  public KeyValueIterator<Stamped<Bytes>, byte[]> fetchRange(
+  public KeyValueIterator<Stamped, byte[]> fetchRange(
       final int kafkaPartition,
       final Bytes fromKey,
       final Bytes toKey,
@@ -109,7 +109,7 @@ public class TTDWindowedTable extends TTDTable<Stamped<Bytes>>
   }
 
   @Override
-  public KeyValueIterator<Stamped<Bytes>, byte[]> backFetchRange(
+  public KeyValueIterator<Stamped, byte[]> backFetchRange(
       final int kafkaPartition,
       final Bytes fromKey,
       final Bytes toKey,
@@ -120,7 +120,7 @@ public class TTDWindowedTable extends TTDTable<Stamped<Bytes>>
   }
 
   @Override
-  public KeyValueIterator<Stamped<Bytes>, byte[]> fetchAll(
+  public KeyValueIterator<Stamped, byte[]> fetchAll(
       final int kafkaPartition,
       final long timeFrom,
       final long timeTo
@@ -129,7 +129,7 @@ public class TTDWindowedTable extends TTDTable<Stamped<Bytes>>
   }
 
   @Override
-  public KeyValueIterator<Stamped<Bytes>, byte[]> backFetchAll(
+  public KeyValueIterator<Stamped, byte[]> backFetchAll(
       final int kafkaPartition,
       final long timeFrom,
       final long timeTo

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/internal/stores/WindowStoreStub.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/internal/stores/WindowStoreStub.java
@@ -24,10 +24,10 @@ import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.state.KeyValueIterator;
 
 public class WindowStoreStub {
-  final Comparator<Stamped<Bytes>> keyComparator = Comparator.comparing(k -> k.key);
+  final Comparator<Stamped> keyComparator = Comparator.comparing(k -> k.key);
 
-  private final NavigableMap<Stamped<Bytes>, byte[]> records =
-      new TreeMap<>(keyComparator.thenComparingLong(k -> k.stamp));
+  private final NavigableMap<Stamped, byte[]> records =
+      new TreeMap<>(keyComparator.thenComparingLong(k -> k.timestamp));
 
   private final long retentionPeriod;
   private long observedStreamTime = 0L;
@@ -37,13 +37,13 @@ public class WindowStoreStub {
     this.retentionPeriod = 15L;
   }
 
-  public void put(final Stamped<Bytes> key, final byte[] value) {
-    observedStreamTime = Math.max(observedStreamTime, key.stamp);
+  public void put(final Stamped key, final byte[] value) {
+    observedStreamTime = Math.max(observedStreamTime, key.timestamp);
     records.put(key, value);
   }
 
-  public void delete(final Stamped<Bytes> key) {
-    observedStreamTime = Math.max(observedStreamTime, key.stamp);
+  public void delete(final Stamped key) {
+    observedStreamTime = Math.max(observedStreamTime, key.timestamp);
     records.remove(key);
   }
 
@@ -51,7 +51,7 @@ public class WindowStoreStub {
       final Bytes key,
       final long windowStart
   ) {
-    final Stamped<Bytes> windowedKey = new Stamped<>(key, windowStart);
+    final Stamped windowedKey = new Stamped(key, windowStart);
     if (windowStart < minValidTimestamp() && records.containsKey(windowedKey)) {
       return records.get(windowedKey);
     } else {
@@ -59,7 +59,7 @@ public class WindowStoreStub {
     }
   }
 
-  public KeyValueIterator<Stamped<Bytes>, byte[]> fetch(
+  public KeyValueIterator<Stamped, byte[]> fetch(
       final Bytes key,
       long timeFrom,
       final long timeTo
@@ -67,7 +67,7 @@ public class WindowStoreStub {
     throw new UnsupportedOperationException("Not yet implemented.");
   }
 
-  public KeyValueIterator<Stamped<Bytes>, byte[]> backFetch(
+  public KeyValueIterator<Stamped, byte[]> backFetch(
       final Bytes key,
       final long timeFrom,
       final long timeTo
@@ -75,7 +75,7 @@ public class WindowStoreStub {
     throw new UnsupportedOperationException("Not yet implemented.");
   }
 
-  public KeyValueIterator<Stamped<Bytes>, byte[]> fetchRange(
+  public KeyValueIterator<Stamped, byte[]> fetchRange(
       final Bytes fromKey,
       final Bytes toKey,
       final long timeFrom,
@@ -84,7 +84,7 @@ public class WindowStoreStub {
     throw new UnsupportedOperationException("Not yet implemented.");
   }
 
-  public KeyValueIterator<Stamped<Bytes>, byte[]> backFetchRange(
+  public KeyValueIterator<Stamped, byte[]> backFetchRange(
       final Bytes fromKey,
       final Bytes toKey,
       final long timeFrom,
@@ -93,14 +93,14 @@ public class WindowStoreStub {
     throw new UnsupportedOperationException("Not yet implemented.");
   }
 
-  public KeyValueIterator<Stamped<Bytes>, byte[]> fetchAll(
+  public KeyValueIterator<Stamped, byte[]> fetchAll(
       final long timeFrom,
       final long timeTo
   ) {
     throw new UnsupportedOperationException("Not yet implemented.");
   }
 
-  public KeyValueIterator<Stamped<Bytes>, byte[]> backFetchAll(
+  public KeyValueIterator<Stamped, byte[]> backFetchAll(
       final long timeFrom,
       final long timeTo
   ) {


### PR DESCRIPTION
Main change here is to remove the generic <K> from the Stamped class and hard-code it to Bytes.

The rest of this PR is all the clean up that's enabled from this one change, mainly around removing generics from window store related iterators and from making the actual key generic <K> extend Comparable<K> instead of using the KeySpec class as a Comparator