### PR TITLE
support metrics-only mode in ResponsiveKafkaStreams

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/api/config/CompatibilityMode.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/config/CompatibilityMode.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.kafka.api.config;
+
+import java.util.Arrays;
+
+public enum CompatibilityMode {
+
+  FULL,
+  METRICS_ONLY;
+
+  public static String[] names() {
+    return Arrays.stream(values()).map(Enum::name).toArray(String[]::new);
+  }
+
+}

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
@@ -37,6 +37,11 @@ public class ResponsiveConfig extends AbstractConfig {
 
   // ------------------ connection configurations -----------------------------
 
+  public static final String COMPATIBILITY_MODE_CONFIG = "responsive.compatibility.mode";
+  private static final String COMPATIBILITY_MODE_DOC = "This configuration enables running Responsive "
+      + "in compatibility mode, disabling certain features.";
+  private static final CompatibilityMode COMPATIBILITY_MODE_DEFAULT = CompatibilityMode.FULL;
+
   public static final String STORAGE_HOSTNAME_CONFIG = "responsive.storage.hostname";
   private static final String STORAGE_HOSTNAME_DOC = "The hostname of the storage server.";
 
@@ -138,6 +143,14 @@ public class ResponsiveConfig extends AbstractConfig {
   public static final String TASK_ASSIGNOR_CLASS_OVERRIDE = StickyTaskAssignor.class.getName();
 
   private static final ConfigDef CONFIG_DEF = new ConfigDef()
+      .define(
+          COMPATIBILITY_MODE_CONFIG,
+          Type.STRING,
+          COMPATIBILITY_MODE_DEFAULT.name(),
+          ConfigDef.CaseInsensitiveValidString.in(CompatibilityMode.names()),
+          Importance.MEDIUM,
+          COMPATIBILITY_MODE_DOC
+      )
       .define(
           STORAGE_HOSTNAME_CONFIG,
           Type.STRING,

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/ResponsiveKafkaClientSupplier.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/ResponsiveKafkaClientSupplier.java
@@ -354,7 +354,7 @@ public final class ResponsiveKafkaClientSupplier implements KafkaClientSupplier 
         final ResponsiveMetrics metrics,
         final KafkaClientSupplier clientSupplier
     ) {
-      return new EndOffsetsPoller(config, metrics, clientSupplier);
+      return new EndOffsetsPoller(config, metrics, clientSupplier::getAdmin);
     }
 
     default <K, V> ResponsiveProducer<K, V> createResponsiveProducer(

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/ResponsiveKafkaClientSupplier.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/ResponsiveKafkaClientSupplier.java
@@ -74,7 +74,7 @@ public final class ResponsiveKafkaClientSupplier implements KafkaClientSupplier 
       final ResponsiveStoreRegistry storeRegistry,
       final ResponsiveMetrics metrics,
       final CompatibilityMode compatibilityMode
-      ) {
+  ) {
     this(new Factories() {}, clientSupplier, configs, storeRegistry, metrics, compatibilityMode);
   }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/config/ConfigUtils.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/config/ConfigUtils.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.kafka.internal.config;
+
+import dev.responsive.kafka.api.config.CompatibilityMode;
+import dev.responsive.kafka.api.config.ResponsiveConfig;
+import dev.responsive.kafka.api.config.StorageBackend;
+import java.util.Locale;
+
+/**
+ * Internal utility to make it easier to extract some values from {@link ResponsiveConfig}
+ * without making those methods part of our public API.
+ *
+ * @implNote please keep this in the {@code .internal} package
+ */
+public class ConfigUtils {
+
+  private ConfigUtils() {
+    /* Empty constructor for public class */
+  }
+
+  public static StorageBackend storageBackend(final ResponsiveConfig config) {
+    final var backend = config
+        .getString(ResponsiveConfig.STORAGE_BACKEND_TYPE_CONFIG)
+        .toUpperCase(Locale.ROOT);
+
+    return StorageBackend.valueOf(backend);
+  }
+
+  public static CompatibilityMode compatibilityMode(final ResponsiveConfig config) {
+    final var backend = config
+        .getString(ResponsiveConfig.COMPATIBILITY_MODE_CONFIG)
+        .toUpperCase(Locale.ROOT);
+
+    return CompatibilityMode.valueOf(backend);
+  }
+
+}

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/metrics/EndOffsetsPoller.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/metrics/EndOffsetsPoller.java
@@ -65,7 +65,7 @@ public class EndOffsetsPoller {
   public EndOffsetsPoller(
       final Map<String, ?> configs,
       final ResponsiveMetrics metrics,
-      final KafkaClientSupplier clientSupplier
+      final Factories factories
   ) {
     this(
         configs,
@@ -76,12 +76,7 @@ public class EndOffsetsPoller {
           t.setName("responsive-end-offsets-poller");
           return t;
         }),
-        new Factories() {
-          @Override
-          public Admin createAdminClient(final Map<String, Object> configs) {
-            return clientSupplier.getAdmin(configs);
-          }
-        }
+        factories
     );
   }
 
@@ -275,9 +270,8 @@ public class EndOffsetsPoller {
     }
   }
 
+  @FunctionalInterface
   public interface Factories {
-    default Admin createAdminClient(final Map<String, Object> configs) {
-      return Admin.create(configs);
-    }
+    Admin createAdminClient(final Map<String, Object> configs);
   }
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/metrics/EndOffsetsPoller.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/metrics/EndOffsetsPoller.java
@@ -41,6 +41,7 @@ import org.apache.kafka.clients.admin.OffsetSpec;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.metrics.Gauge;
+import org.apache.kafka.streams.KafkaClientSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,8 +64,9 @@ public class EndOffsetsPoller {
 
   public EndOffsetsPoller(
       final Map<String, ?> configs,
-      final ResponsiveMetrics metrics
-  ) {
+      final ResponsiveMetrics metrics,
+      final KafkaClientSupplier clientSupplier
+      ) {
     this(
         configs,
         metrics,
@@ -74,7 +76,12 @@ public class EndOffsetsPoller {
           t.setName("responsive-end-offsets-poller");
           return t;
         }),
-        new Factories() {}
+        new Factories() {
+          @Override
+          public Admin createAdminClient(final Map<String, Object> configs) {
+            return clientSupplier.getAdmin(configs);
+          }
+        }
     );
   }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/metrics/EndOffsetsPoller.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/metrics/EndOffsetsPoller.java
@@ -66,7 +66,7 @@ public class EndOffsetsPoller {
       final Map<String, ?> configs,
       final ResponsiveMetrics metrics,
       final KafkaClientSupplier clientSupplier
-      ) {
+  ) {
     this(
         configs,
         metrics,

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/metrics/EndOffsetsPoller.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/metrics/EndOffsetsPoller.java
@@ -41,7 +41,6 @@ import org.apache.kafka.clients.admin.OffsetSpec;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.metrics.Gauge;
-import org.apache.kafka.streams.KafkaClientSupplier;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/utils/SessionClients.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/utils/SessionClients.java
@@ -16,6 +16,8 @@
 
 package dev.responsive.kafka.internal.utils;
 
+import dev.responsive.kafka.api.config.CompatibilityMode;
+import dev.responsive.kafka.api.config.ResponsiveConfig;
 import dev.responsive.kafka.api.config.StorageBackend;
 import dev.responsive.kafka.internal.db.CassandraClient;
 import dev.responsive.kafka.internal.db.mongo.ResponsiveMongoClient;
@@ -71,7 +73,11 @@ public class SessionClients {
     } else if (cassandraClient.isPresent()) {
       return StorageBackend.CASSANDRA;
     } else {
-      throw new IllegalArgumentException("Invalid Shared Clients Configuration");
+      throw new IllegalArgumentException("Invalid Shared Clients Configuration. "
+          + "If you have configured " + ResponsiveConfig.COMPATIBILITY_MODE_CONFIG
+          + "=" + CompatibilityMode.METRICS_ONLY + " you cannot use Responsive storage. "
+          + "See https://docs.responsive.dev/getting-started/quickstart for a how-to guide for "
+          + "getting started with Responsive stores.");
     }
   }
 

--- a/kafka-client/src/test/java/dev/responsive/kafka/api/ResponsiveKafkaStreamsTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/api/ResponsiveKafkaStreamsTest.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.kafka.api;
+
+import static dev.responsive.kafka.api.config.ResponsiveConfig.TENANT_ID_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.APPLICATION_ID_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.BOOTSTRAP_SERVERS_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.NUM_STANDBY_REPLICAS_CONFIG;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.typesafe.config.ConfigException;
+import dev.responsive.kafka.api.config.CompatibilityMode;
+import dev.responsive.kafka.api.config.ResponsiveConfig;
+import dev.responsive.kafka.internal.db.CassandraClient;
+import dev.responsive.kafka.internal.db.CassandraClientFactory;
+import dev.responsive.kafka.testutils.IntegrationTestUtils;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.common.serialization.LongDeserializer;
+import org.apache.kafka.common.serialization.LongSerializer;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.KafkaClientSupplier;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.errors.StreamsException;
+import org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ResponsiveKafkaStreamsTest {
+
+  private final KafkaClientSupplier supplier = new DefaultKafkaClientSupplier() {
+    @Override
+    public Admin getAdmin(final Map<String, Object> config) {
+      return admin;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Producer<byte[], byte[]> getProducer(final Map<String, Object> config) {
+      return Mockito.mock(Producer.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Consumer<byte[], byte[]> getConsumer(final Map<String, Object> config) {
+      final var mock = Mockito.mock(Consumer.class);
+      when(mock.groupMetadata()).thenReturn(new ConsumerGroupMetadata("group.id"));
+      return mock;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Consumer<byte[], byte[]> getRestoreConsumer(final Map<String, Object> config) {
+      return Mockito.mock(Consumer.class);
+    }
+  };
+
+  private final CassandraClientFactory mockCassandryFactory = new CassandraClientFactory() {
+    @Override
+    public CqlSession createCqlSession(final ResponsiveConfig config) {
+      return Mockito.mock(CqlSession.class);
+    }
+
+    @Override
+    public CassandraClient createClient(final CqlSession session, final ResponsiveConfig config) {
+      return Mockito.mock(CassandraClient.class);
+    }
+  };
+
+  @Mock
+  private Admin admin;
+  private Map<String, Object> properties;
+
+  @BeforeEach
+  public void setUp() {
+    properties = new HashMap<>();
+    properties.putAll(IntegrationTestUtils.dummyConfig().originals());
+    properties.put(BOOTSTRAP_SERVERS_CONFIG, "foo:8082");
+
+    properties.put(KEY_SERIALIZER_CLASS_CONFIG, LongSerializer.class);
+    properties.put(VALUE_SERIALIZER_CLASS_CONFIG, LongSerializer.class);
+    properties.put(KEY_DESERIALIZER_CLASS_CONFIG, LongDeserializer.class);
+    properties.put(VALUE_DESERIALIZER_CLASS_CONFIG, LongDeserializer.class);
+
+    properties.put(APPLICATION_ID_CONFIG, "kafka-streams-test");
+    properties.put(DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.LongSerde.class.getName());
+    properties.put(DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.LongSerde.class.getName());
+
+    properties.put(TENANT_ID_CONFIG, "test");
+  }
+
+  @SuppressWarnings("resource")
+  @Test
+  public void shouldInvalidateBadConfigs() {
+    // Given:
+    properties.put(NUM_STANDBY_REPLICAS_CONFIG, 2); // a config that would cause failure
+
+    // When:
+    final StreamsBuilder builder = new StreamsBuilder();
+    builder.stream("foo").to("bar");
+
+    // Then:
+    final StreamsException e = assertThrows(
+        StreamsException.class,
+        () -> new IntegrationTestUtils.MockResponsiveKafkaStreams(
+            builder.build(),
+            properties,
+            supplier,
+            mockCassandryFactory
+        )
+    );
+    assertThat(
+        e.getCause().getMessage(),
+        Matchers.containsString("Invalid Streams configuration value for 'num.standby.replicas'")
+    );
+  }
+
+  @Test
+  public void shouldCreateResponsiveKafkaStreamsInMetricsOnlyModeWithUnverifiedConfigs() {
+    // Given:
+    properties.put(ResponsiveConfig.COMPATIBILITY_MODE_CONFIG, CompatibilityMode.METRICS_ONLY.name());
+    properties.put(NUM_STANDBY_REPLICAS_CONFIG, 2); // a config that would cause failure
+
+    // When:
+    final StreamsBuilder builder = new StreamsBuilder();
+    builder.stream("foo").to("bar");
+
+    final var ks = new ResponsiveKafkaStreams(builder.build(), properties, supplier);
+
+    // Then:
+    // no error is thrown
+    ks.close();
+  }
+
+}

--- a/kafka-client/src/test/java/dev/responsive/kafka/api/ResponsiveKafkaStreamsTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/api/ResponsiveKafkaStreamsTest.java
@@ -16,6 +16,7 @@
 
 package dev.responsive.kafka.api;
 
+import static dev.responsive.kafka.api.config.ResponsiveConfig.COMPATIBILITY_MODE_CONFIG;
 import static dev.responsive.kafka.api.config.ResponsiveConfig.TENANT_ID_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
@@ -31,7 +32,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 import com.datastax.oss.driver.api.core.CqlSession;
-import com.typesafe.config.ConfigException;
 import dev.responsive.kafka.api.config.CompatibilityMode;
 import dev.responsive.kafka.api.config.ResponsiveConfig;
 import dev.responsive.kafka.internal.db.CassandraClient;
@@ -151,7 +151,7 @@ class ResponsiveKafkaStreamsTest {
   @Test
   public void shouldCreateResponsiveKafkaStreamsInMetricsOnlyModeWithUnverifiedConfigs() {
     // Given:
-    properties.put(ResponsiveConfig.COMPATIBILITY_MODE_CONFIG, CompatibilityMode.METRICS_ONLY.name());
+    properties.put(COMPATIBILITY_MODE_CONFIG, CompatibilityMode.METRICS_ONLY.name());
     properties.put(NUM_STANDBY_REPLICAS_CONFIG, 2); // a config that would cause failure
 
     // When:

--- a/kafka-client/src/test/java/dev/responsive/kafka/integration/MinimalIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/integration/MinimalIntegrationTest.java
@@ -16,7 +16,6 @@
 
 package dev.responsive.kafka.integration;
 
-import static dev.responsive.kafka.api.config.ResponsiveConfig.COMPATIBILITY_MODE_CONFIG;
 import static dev.responsive.kafka.api.config.ResponsiveConfig.STORE_FLUSH_RECORDS_TRIGGER_CONFIG;
 import static dev.responsive.kafka.testutils.IntegrationTestUtils.createTopicsAndWait;
 import static dev.responsive.kafka.testutils.IntegrationTestUtils.pipeInput;
@@ -37,7 +36,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
 
 import dev.responsive.kafka.api.ResponsiveKafkaStreams;
-import dev.responsive.kafka.api.config.CompatibilityMode;
 import dev.responsive.kafka.api.config.StorageBackend;
 import dev.responsive.kafka.api.stores.ResponsiveKeyValueParams;
 import dev.responsive.kafka.api.stores.ResponsiveStores;

--- a/kafka-client/src/test/java/dev/responsive/kafka/integration/MinimalIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/integration/MinimalIntegrationTest.java
@@ -16,6 +16,7 @@
 
 package dev.responsive.kafka.integration;
 
+import static dev.responsive.kafka.api.config.ResponsiveConfig.COMPATIBILITY_MODE_CONFIG;
 import static dev.responsive.kafka.api.config.ResponsiveConfig.STORE_FLUSH_RECORDS_TRIGGER_CONFIG;
 import static dev.responsive.kafka.testutils.IntegrationTestUtils.createTopicsAndWait;
 import static dev.responsive.kafka.testutils.IntegrationTestUtils.pipeInput;
@@ -36,6 +37,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
 
 import dev.responsive.kafka.api.ResponsiveKafkaStreams;
+import dev.responsive.kafka.api.config.CompatibilityMode;
 import dev.responsive.kafka.api.config.StorageBackend;
 import dev.responsive.kafka.api.stores.ResponsiveKeyValueParams;
 import dev.responsive.kafka.api.stores.ResponsiveStores;

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/clients/ResponsiveKafkaClientSupplierTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/clients/ResponsiveKafkaClientSupplierTest.java
@@ -265,7 +265,10 @@ class ResponsiveKafkaClientSupplierTest {
   }
 
   @NotNull
-  private ResponsiveKafkaClientSupplier supplier(final Map<String, Object> configs, final CompatibilityMode compat) {
+  private ResponsiveKafkaClientSupplier supplier(
+      final Map<String, Object> configs,
+      final CompatibilityMode compat
+  ) {
     return new ResponsiveKafkaClientSupplier(
         factories,
         wrapped,


### PR DESCRIPTION
the new config (`responsive.compatibility.mode = METRICS_ONLY`) effectively disables the following:
- config validation
- responsive restore consumer
- responsive global consumer
- connecting to responsive storage