### PR TITLE
Support for agent-free metrics reporting

### DIFF
--- a/kafka-client/build.gradle.kts
+++ b/kafka-client/build.gradle.kts
@@ -69,6 +69,7 @@ dependencies {
 
     implementation(libs.bundles.scylla)
     implementation(libs.mongodb.driver.sync)
+    implementation(libs.bundles.otel)
 
     testImplementation(libs.kafka.clients) {
         artifact {

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveKafkaStreams.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveKafkaStreams.java
@@ -21,7 +21,10 @@ import static dev.responsive.kafka.api.config.ResponsiveConfig.CLIENT_SECRET_CON
 import static dev.responsive.kafka.api.config.ResponsiveConfig.STORAGE_HOSTNAME_CONFIG;
 import static dev.responsive.kafka.api.config.ResponsiveConfig.TASK_ASSIGNOR_CLASS_OVERRIDE;
 import static dev.responsive.kafka.internal.metrics.ResponsiveMetrics.RESPONSIVE_METRICS_NAMESPACE;
-import static org.apache.kafka.streams.StreamsConfig.*;
+import static org.apache.kafka.streams.StreamsConfig.APPLICATION_ID_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.METRICS_NUM_SAMPLES_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.METRICS_RECORDING_LEVEL_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.METRICS_SAMPLE_WINDOW_MS_CONFIG;
 
 import dev.responsive.kafka.api.config.CompatibilityMode;
 import dev.responsive.kafka.api.config.ResponsiveConfig;
@@ -220,7 +223,7 @@ public class ResponsiveKafkaStreams extends KafkaStreams {
   ) {
     final OtelMetricsService otel;
     if (responsiveConfig.getBoolean(ResponsiveConfig.METRICS_ENABLED_CONFIG)) {
-       otel = OtelMetricsService.create(streamsConfig, responsiveConfig);
+      otel = OtelMetricsService.create(streamsConfig, responsiveConfig);
     } else {
       otel = OtelMetricsService.noop();
     }
@@ -240,7 +243,8 @@ public class ResponsiveKafkaStreams extends KafkaStreams {
         Time.SYSTEM,
         new KafkaMetricsContext(
             RESPONSIVE_METRICS_NAMESPACE,
-            streamsConfig.originalsWithPrefix(CommonClientConfigs.METRICS_CONTEXT_PREFIX))
+            streamsConfig.originalsWithPrefix(CommonClientConfigs.METRICS_CONTEXT_PREFIX)
+        )
     ), otel);
   }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
@@ -70,6 +70,28 @@ public class ResponsiveConfig extends AbstractConfig {
   private static final String STORAGE_BACKEND_TYPE_DOC = "The storage backend";
   private static final StorageBackend STORAGE_BACKEND_TYPE_DEFAULT = StorageBackend.CASSANDRA;
 
+  // ------------------ metrics configurations --------------------------------
+
+  public static final String RESPONSIVE_APPLICATION_ID_CONFIG = "responsive.application.id";
+  private static final String RESPONSIVE_APPLICATION_ID_DOC = "The application ID that uniquely "
+      + "identifies this application with Responsive. This defaults to the configured Kafka "
+      + "Streams application.id but can be overridden in the case you have multiple applications "
+      + "with the same application.id configured to run in the same responsive.tenant.id";
+
+  public static final String METRICS_ENABLED_CONFIG = "responsive.metrics.enabled";
+  private static final String METRICS_ENABLED_DOC = "Whether or not metrics should be sent to Responsive Cloud";
+
+  public static final String CONTROLLER_ENDPOINT_CONFIG = "responsive.controller.endpoint";
+  private static final String CONTROLLER_ENDPOINT_DOC = "The endpoint of the running responsive "
+      + "cloud controller. If enabled, metrics will be sent to this endpoint.";
+
+  // TODO(agavra): we should consolidate API keys, but for now it's OK to use different ones
+  public static final String METRICS_API_KEY_CONFIG = "responsive.metrics.api.key";
+  private static final String METRICS_API_KEY_DOC = "The API Key provided for Metrics access.";
+
+  public static final String METRICS_SECRET_CONFIG = "responsive.metrics.secret";
+  private static final String METRICS_SECRET_DOC = "The Secret provided for Metrics access.";
+
   // ------------------ request configurations --------------------------------
 
   public static final String REQUEST_TIMEOUT_MS_CONFIG = "responsive.request.timeout.ms";
@@ -204,6 +226,36 @@ public class ResponsiveConfig extends AbstractConfig {
           ConfigDef.CaseInsensitiveValidString.in(StorageBackend.names()),
           Importance.HIGH,
           STORAGE_BACKEND_TYPE_DOC
+      ).define(
+          RESPONSIVE_APPLICATION_ID_CONFIG,
+          Type.STRING,
+          "",
+          Importance.MEDIUM,
+          RESPONSIVE_APPLICATION_ID_DOC
+      ).define(
+          METRICS_ENABLED_CONFIG,
+          Type.BOOLEAN,
+          false,
+          Importance.MEDIUM,
+          METRICS_ENABLED_DOC
+      ).define(
+          CONTROLLER_ENDPOINT_CONFIG,
+          Type.STRING,
+          "",
+          Importance.HIGH,
+          CONTROLLER_ENDPOINT_DOC
+      ). define(
+          METRICS_API_KEY_CONFIG,
+          Type.STRING,
+          "",
+          Importance.HIGH,
+          METRICS_API_KEY_DOC
+      ).define(
+          METRICS_SECRET_CONFIG,
+          Type.PASSWORD,
+          "",
+          Importance.HIGH,
+          METRICS_SECRET_DOC
       ).define(
           REQUEST_TIMEOUT_MS_CONFIG,
           Type.LONG,

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/config/ConfigUtils.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/config/ConfigUtils.java
@@ -16,10 +16,13 @@
 
 package dev.responsive.kafka.internal.config;
 
+import static dev.responsive.kafka.api.config.ResponsiveConfig.RESPONSIVE_APPLICATION_ID_CONFIG;
+
 import dev.responsive.kafka.api.config.CompatibilityMode;
 import dev.responsive.kafka.api.config.ResponsiveConfig;
 import dev.responsive.kafka.api.config.StorageBackend;
 import java.util.Locale;
+import org.apache.kafka.streams.StreamsConfig;
 
 /**
  * Internal utility to make it easier to extract some values from {@link ResponsiveConfig}
@@ -47,6 +50,17 @@ public class ConfigUtils {
         .toUpperCase(Locale.ROOT);
 
     return CompatibilityMode.valueOf(backend);
+  }
+
+  public static String responsiveAppId(
+      final StreamsConfig streamsConfig,
+      final ResponsiveConfig responsiveConfig
+  ) {
+    if (responsiveConfig.originals().containsKey(RESPONSIVE_APPLICATION_ID_CONFIG)) {
+      return responsiveConfig.getString(RESPONSIVE_APPLICATION_ID_CONFIG);
+    }
+
+    return streamsConfig.getString(StreamsConfig.APPLICATION_ID_CONFIG);
   }
 
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/metrics/OtelMetricsService.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/metrics/OtelMetricsService.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.kafka.internal.metrics;
+
+import dev.responsive.kafka.api.config.ResponsiveConfig;
+import dev.responsive.kafka.internal.config.ConfigUtils;
+import io.opentelemetry.api.OpenTelemetry;
+import io.opentelemetry.api.baggage.propagation.W3CBaggagePropagator;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.propagation.W3CTraceContextPropagator;
+import io.opentelemetry.context.propagation.ContextPropagators;
+import io.opentelemetry.context.propagation.TextMapPropagator;
+import io.opentelemetry.exporter.otlp.metrics.OtlpGrpcMetricExporter;
+import io.opentelemetry.instrumentation.jmx.engine.JmxMetricInsight;
+import io.opentelemetry.instrumentation.jmx.engine.MetricConfiguration;
+import io.opentelemetry.instrumentation.jmx.yaml.RuleParser;
+import io.opentelemetry.sdk.OpenTelemetrySdk;
+import io.opentelemetry.sdk.metrics.SdkMeterProvider;
+import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
+import io.opentelemetry.sdk.resources.Resource;
+import java.io.Closeable;
+import java.time.Duration;
+import org.apache.kafka.streams.StreamsConfig;
+
+public class OtelMetricsService implements Closeable {
+
+  private final JmxMetricInsight metricInsight;
+  private final Runnable onClose;
+
+  public static OtelMetricsService create(
+      final StreamsConfig streamsConfig,
+      final ResponsiveConfig config
+  ) {
+    final var exporter = OtlpGrpcMetricExporter
+        .builder()
+        .addHeader("api-key", config.getString(ResponsiveConfig.METRICS_API_KEY_CONFIG))
+        .addHeader("secret", config.getString(ResponsiveConfig.METRICS_API_KEY_CONFIG))
+        .setEndpoint(config.getString(ResponsiveConfig.CONTROLLER_ENDPOINT_CONFIG))
+        .build();
+
+    final var metricReader = PeriodicMetricReader
+        .builder(exporter)
+        .setInterval(Duration.ofSeconds(10))
+        .build();
+
+    final var appId = ConfigUtils.responsiveAppId(streamsConfig, config);
+    final var attributes = Attributes
+        .builder()
+        .put("service.name", appId + "-otel")
+        .put("responsiveApplicationId", appId)
+        .build();
+
+    final var meterProvider = SdkMeterProvider
+        .builder()
+        .setResource(Resource.create(attributes))
+        .registerMetricReader(metricReader)
+        .build();
+
+    final OpenTelemetrySdk otel = OpenTelemetrySdk
+        .builder()
+        .setMeterProvider(meterProvider)
+        .setPropagators(ContextPropagators.create(TextMapPropagator.composite(
+            W3CTraceContextPropagator.getInstance(),
+            W3CBaggagePropagator.getInstance()
+        )))
+        .build();
+
+    return new OtelMetricsService(otel, otel::close);
+  }
+
+  public static OtelMetricsService noop() {
+    return new OtelMetricsService(OpenTelemetry.noop(), () -> {});
+  }
+
+  private OtelMetricsService(final OpenTelemetry otel, final Runnable onClose) {
+    this.onClose = onClose;
+    this.metricInsight = JmxMetricInsight.createService(otel, 0);
+  }
+
+  public void start() {
+    this.metricInsight.start(buildMetricConfiguration());
+  }
+
+  @Override
+  public void close() {
+    onClose.run();
+  }
+
+  private static void buildFromUserRules(MetricConfiguration conf) {
+    RuleParser parserInstance = RuleParser.get();
+    final ClassLoader loader = OtelMetricsService.class.getClassLoader();
+
+    // TODO(agavra): instead of including otel-jmx.config.yaml as a resource we should
+    // fetch it from the Responsive controller on start-up
+    try (final var is = loader.getResourceAsStream("otel-jmx.config.yaml")) {
+      parserInstance.addMetricDefsTo(conf, is, "responsive builtin config");
+    } catch (Exception e) {
+      // yaml parsing errors are caught and logged inside addMetricDefsTo
+      // only file access related exceptions are expected here
+      JmxMetricInsight.getLogger().warning(e.toString());
+    }
+  }
+
+  private static MetricConfiguration buildMetricConfiguration() {
+    MetricConfiguration metricConfiguration = new MetricConfiguration();
+    buildFromUserRules(metricConfiguration);
+    return metricConfiguration;
+  }
+}

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/metrics/ResponsiveMetrics.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/metrics/ResponsiveMetrics.java
@@ -48,10 +48,12 @@ public class ResponsiveMetrics implements Closeable {
   private static final Pattern GLOBAL_THREAD_REGEX = Pattern.compile(".*-(GlobalStreamThread+)");
 
   private OrderedTagsSupplier orderedTagsSupplier;
+  private final OtelMetricsService otelService;
   private final Metrics metrics;
 
-  public ResponsiveMetrics(final Metrics metrics) {
+  public ResponsiveMetrics(final Metrics metrics, final OtelMetricsService otelService) {
     this.metrics = metrics;
+    this.otelService = otelService;
   }
 
   /**
@@ -176,5 +178,6 @@ public class ResponsiveMetrics implements Closeable {
       LOG.warn("Not all metrics were cleaned up before close: {}", metrics().keySet());
     }
     metrics.close();
+    otelService.close();
   }
 }

--- a/kafka-client/src/main/resources/otel-jmx.config.yaml
+++ b/kafka-client/src/main/resources/otel-jmx.config.yaml
@@ -1,0 +1,334 @@
+---
+rules:
+
+#### Responsive Metrics ####
+
+ # Responsive application metrics
+ - bean: dev.responsive:type=application-metrics,responsive-version=*,responsive-commit-id=*,streams-version=*,streams-commit-id=*,consumer-group=*,streams-application-id=*,streams-client-id=*
+   metricAttribute:
+     responsiveVersion: param(responsive-version)
+     responsiveCommitId: param(responsive-commit-id)
+     streamsVersion: param(streams-version)
+     streamsCommitId: param(streams-commit-id)
+     consumerGroup: param(consumer-group)
+     streamsApplicationId: param(streams-application-id)
+     streamsClientId: param(streams-client-id)
+   mapping:
+     streams-state:
+       metric: responsive.kafka.streams.state
+       type: gauge
+       desc: the current state of this Kafka Streams client
+       unit: '{KafkaStreams.State}'
+     num-restoring-changelogs:
+       metric: responsive.kafka.streams.num.restoring.changelogs
+       type: gauge
+       desc: the number of state stores currently being restored from a changelog
+       unit: '{stores}'
+     num-interrupted-changelogs:
+       metric: responsive.kafka.streams.num.interrupted.changelogs
+       desc: the number of state stores that were interrupted before finishing restoration
+       unit: '{stores}'
+
+ # Responsive topic metrics
+ - bean: dev.responsive:type=topic-metrics,responsive-version=*,responsive-commit-id=*,streams-version=*,streams-commit-id=*,consumer-group=*,streams-application-id=*,streams-client-id=*,thread-id=*,topic=*,partition=*
+   metricAttribute:
+     responsiveVersion: param(responsive-version)
+     responsiveCommitId: param(responsive-commit-id)
+     streamsVersion: param(streams-version)
+     streamsCommitId: param(streams-commit-id)
+     consumerGroup: param(consumer-group)
+     streamsApplicationId: param(streams-application-id)
+     streamsClientId: param(streams-client-id)
+     thread: param(thread-id)
+     partition: param(partition)
+     topic: param(topic)
+   mapping:
+     end-offset:
+       metric: responsive.kafka.streams.source.offset.end
+       type: gauge
+       desc: the current end offset of the partition
+       unit: '{offset}'
+     committed-offset:
+       metric: responsive.kafka.streams.source.offset.committed
+       type: gauge
+       desc: the current committed offset of the partition
+       unit: '{offset}'
+
+ # Responsive store metrics
+ - bean: dev.responsive:type=store-metrics,responsive-version=*,responsive-commit-id=*,streams-version=*,streams-commit-id=*,consumer-group=*,streams-application-id=*,streams-client-id=*,thread-id=*,topic=*,partition=*,store=*
+   metricAttribute:
+     responsiveVersion: param(responsive-version)
+     responsiveCommitId: param(responsive-commit-id)
+     streamsVersion: param(streams-version)
+     streamsCommitId: param(streams-commit-id)
+     consumerGroup: param(consumer-group)
+     streamsApplicationId: param(streams-application-id)
+     streamsClientId: param(streams-client-id)
+     thread: param(thread-id)
+     partition: param(partition)
+     topic: param(topic)
+     store: param(store)
+   mapping:
+     time-restoring:
+       metric: responsive.kafka.streams.time.restoring
+       type: gauge
+       desc: the amount of time since this state store started restoration
+       unit: '{milliseconds}'
+     time-since-last-flush:
+       metric: responsive.kafka.streams.time.since.last.flush
+       type: gauge
+       desc: the amount of time since the last successful flush
+       unit: '{milliseconds}'
+     flush-rate:
+       metric: responsive.kafka.streams.flush.rate
+       desc: the rate of commit buffer flushes
+       unit: '{flushes/s}'
+     flush-total:
+       metric: responsive.kafka.streams.flush.total
+       desc: the total number of commit buffer flushes
+       unit: '{flushes}'
+     flush-latency-avg:
+       metric: responsive.kafka.streams.flush.latency.avg
+       desc: the average time it took to flush the commit buffer
+       unit: '{milliseconds}'
+     flush-latency-max:
+       metric: responsive.kafka.streams.flush.latency.max
+       desc: the maximum time it took to flush the commit buffer
+       unit: '{milliseconds}'
+     flush-errors-rate:
+       metric: responsive.kafka.streams.flush.errors.rate
+       desc: the rate of commit buffer flushes that failed
+       unit: '{flushes/s}'
+     flush-errors-total:
+       metric: responsive.kafka.streams.flush.errors.total
+       desc: the total number of commit buffer flushes that failed
+       unit: '{flushes}'
+     failed-truncations-rate:
+       metric: responsive.kafka.streams.failed.truncations.rate
+       desc: the rate of changelog truncation attempts that failed
+       unit: '{deletes/s}'
+     failed-truncations-total:
+       metric: responsive.kafka.streams.failed.truncations.total
+       desc: the total number of changelog truncation attempts that failed
+       unit: '{deletes}'
+
+
+ #### Apache Kafka Metrics ####
+
+ # Consumer Client metrics
+ - bean: kafka.consumer:type=consumer-fetch-manager-metrics,partition=*,topic=*,client-id=*
+   metricAttribute:
+     partition: param(partition)
+     topic: param(topic)
+     clientId: param(client-id)
+   mapping:
+     records-lag:
+       metric: kafka.streams.records.lag
+       type: gauge
+       desc: the current lag of the partition
+       unit: '{records}'
+ - bean: kafka.consumer:type=consumer-fetch-manager-metrics,client-id=*
+   metricAttribute:
+     clientId: param(client-id)
+   mapping:
+     records-lag-max:
+       metric: kafka.streams.records.lag.max
+       type: gauge
+       desc: the max lag of all partitions
+       unit: '{records}'
+ - bean: kafka.consumer:type=consumer-coordinator-metrics,client-id=*
+   metricAttribute:
+     clientId: param(client-id)
+   mapping:
+     assigned-partitions:
+       metric: kafka.streams.assigned.partitions
+       type: gauge
+       desc: the number of assigned partitions
+       unit: '{partitions}'
+     rebalance-rate-per-hour:
+       metric: kafka.streams.rebalance.rate
+       type: gauge
+       desc: the rate of rebalances
+       unit: '{rebalances-per-hour}'
+     failed-rebalance-rate-per-hour:
+       metric: kafka.streams.failed.rebalance.rate
+       type: gauge
+       desc: the rate of failed rebalances
+       unit: '{rebalances-per-hour}'
+
+ - bean: kafka.consumer:type=consumer-metrics,client-id=*
+   metricAttribute:
+     clientid: param(client-id)
+   mapping:
+     io-wait-time-ns-total:
+       metric: kafka.consumer.io.wait.time.ns.total
+       type: gauge
+       desc: the total time waiting for new records from kafka
+       unit: '{nanoseconds}'
+     io-time-ns-total:
+       metric: kafka.consumer.io.time.ns.total
+       type: gauge
+       desc: the total time waiting for reads from kafka
+       unit: '{nanoseconds}'
+
+ - bean: kafka.producer:type=producer-metrics,client-id=*
+   metricAttribute:
+     clientid: param(client-id)
+   mapping:
+     txn-commit-time-ns-total:
+       metric: kafka.producer.txn.commit.time.ns.total
+       type: gauge
+       desc: the total time spent committing in the producer
+       unit: '{nanoseconds}'
+     bufferpool-wait-time-ns-total:
+       metric: kafka.producer.bufferpool.wait.time.ns.total
+       type: gauge
+       desc: the total time spent waiting on writes to kafka
+       unit: '{nanoseconds}'
+     flush-time-ns-total:
+       metric: kafka.producer.flush.time.ns.total
+       type: gauge
+       desc: the total time spent waiting on producer flush
+       unit: '{nanoseconds}'
+     txn-send-offsets-time-ns-total:
+       metric: kafka.producer.txn.send.offsets.time.ns.total
+       type: gauge
+       desc: the total time spent sending offsets in producer
+       unit: '{nanoseconds}'
+     metadata-wait-time-ns-total:
+        metric: kafka.producer.metadata.wait.time.ns.total
+        type: gauge
+        desc: the total time spent waiting on producer metadata
+        unit: '{nanoseconds}'
+
+  # Kafka Streams client metrics
+ - bean: kafka.streams:type=stream-metrics,client-id=*
+   metricAttribute:
+     clientId: param(client-id)
+   mapping:
+     failed-stream-threads:
+       metric: kafka.streams.failed.stream.threads
+       type: gauge
+       desc: The number of failed stream threads since this client started
+       unit: '{threads}'
+
+ # Kafka Streams topic metrics
+ - bean: kafka.streams:type=stream-topic-metrics,thread-id=*,task-id=*,processor-node-id=*,topic=*
+   metricAttribute:
+     thread: param(thread-id)
+     task: param(task-id)
+     processor: param(processor-node-id)
+     topic: param(topic)
+   mapping:
+     records-consumed-total:
+       metric: kafka.streams.topic.records.consumed.total
+       type: gauge
+       desc: the total records consumed
+       unit: '{records}'
+     bytes-consumed-total:
+       metric: kafka.streams.topic.bytes.consumed.total
+       type: gauge
+       desc: the total bytes consumed
+       unit: '{bytes}'
+     records-produced-total:
+       metric: kafka.streams.topic.records.produced.total
+       type: gauge
+       desc: the total records produced
+       unit: '{records}'
+     bytes-produced-total:
+       metric: kafka.streams.topic.bytes.produced.total
+       type: gauge
+       desc: the total bytes produced
+       unit: '{bytes}'
+
+ # Kafka Streams thread metrics
+ - bean: kafka.streams:type=stream-thread-metrics,thread-id=*
+   metricAttribute:
+     thread: param(thread-id)
+   mapping:
+     process-total:
+       metric: kafka.streams.thread.process.total
+       type: gauge
+       desc: total records processed
+       unit: '{records}'
+     process-rate:
+       metric: kafka.streams.thread.process.rate
+       type: gauge
+       desc: rate of records processed
+       unit: '{records-per-second}'
+     process-ratio:
+       metric: kafka.streams.thread.process.ratio
+       type: gauge
+       desc: fraction of time spent in process
+     commit-rate:
+       metric: kafka.streams.thread.commit.rate
+       type: gauge
+       desc: rate of commit
+       unit: '{ops-per-second}'
+     commit-ratio:
+       metric: kafka.streams.thread.commit.ratio
+       type: gauge
+       desc: fraction of time spent in commit
+     commit-latency-avg:
+       metric: kafka.streams.thread.commit.latency.avg
+       type: gauge
+       desc: avg latency of a commit
+       unit: '{milliseconds}'
+     commit-latency-max:
+       metric: kafka.streams.thread.commit.latency.max
+       type: gauge
+       desc: max latency of a commit
+       unit: '{milliseconds}'
+     poll-rate:
+       metric: kafka.streams.thread.poll.rate
+       type: gauge
+       desc: rate of poll calls
+       unit: '{ops-per-second}'
+     poll-ratio:
+       metric: kafka.streams.thread.poll.ratio
+       type: gauge
+       desc: fraction of time spent in poll
+     poll-records-avg:
+       metric: kafka.streams.thread.poll.records.avg
+       type: gauge
+       desc: avg records per poll
+       unit: '{records}'
+     punctuate-ratio:
+       metric: kafka.streams.thread.punctuate.ratio
+       type: gauge
+       desc: fraction of time spent in punctuate
+     task-closed-rate:
+       metric: kafka.streams.thread.task.closed.rate
+       type: gauge
+       desc: rate of tasks closed
+       unit: '{tasks-per-second}'
+     blocked-time-ns-total:
+       metric: kafka.streams.thread.blocked.time.total.ns
+       type: gauge
+       desc: total time the stream thread was blocked
+       unit: '{nanoseconds}'
+     thread-start-time:
+       metric: kafka.streams.thread.start.time
+       type: gauge
+       desc: the time the kafka streams thread was started
+       unit: '{milliseconds}'
+
+ # Kafka Streams task metrics
+ ## THESE ARE GENERALLY **DEBUG** METRICS AND MIGHT NOT BE ENABLED
+ ## Most Streams metrics below the client and thread level are debug or even trace
+ - bean: kafka.streams:type=stream-task-metrics,thread-id=*,task-id=*
+   metricAttribute:
+     thread: param(thread-id)
+     task: param(task-id)
+   mapping:
+     ## INFO
+     active-process-ratio:
+       metric: kafka.streams.task.process.ratio
+       type: gauge
+       desc: fraction of time spent processing this task out of all the active tasks
+     ## DEBUG
+     process-total:
+       metric: kafka.streams.task.process.total
+       type: gauge
+       desc: total records processed
+       unit: '{records}'

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/metrics/EndOffsetsPollerTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/metrics/EndOffsetsPollerTest.java
@@ -91,7 +91,7 @@ class EndOffsetsPollerTest {
     lenient().when(executor.scheduleAtFixedRate(any(), anyLong(), anyLong(), any()))
         .thenReturn((ScheduledFuture) pollFuture);
 
-    final ResponsiveMetrics responsiveMetrics = new ResponsiveMetrics(metrics);
+    final var responsiveMetrics = new ResponsiveMetrics(metrics, OtelMetricsService.noop());
     responsiveMetrics.initializeTags(
         GROUP, CLIENT, new ClientVersionMetadata("1", "abc", "2", "dfe"), Collections.emptyMap());
 

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/metrics/MetricPublishingCommitListenerTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/metrics/MetricPublishingCommitListenerTest.java
@@ -64,7 +64,8 @@ class MetricPublishingCommitListenerTest {
 
   @BeforeEach
   public void setup() {
-    final ResponsiveMetrics responsiveMetrics = new ResponsiveMetrics(metrics);
+    final ResponsiveMetrics responsiveMetrics
+        = new ResponsiveMetrics(metrics, OtelMetricsService.noop());
     responsiveMetrics.initializeTags(
         GROUP, CLIENT, new ClientVersionMetadata("1", "abc", "2", "dfe"), Collections.emptyMap());
     listener = new MetricPublishingCommitListener(responsiveMetrics, THREAD_ID, offsetRecorder);

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/metrics/ResponsiveRestoreListenerTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/metrics/ResponsiveRestoreListenerTest.java
@@ -68,7 +68,7 @@ public class ResponsiveRestoreListenerTest {
 
   @BeforeEach
   public void setup() {
-    responsiveMetrics = new ResponsiveMetrics(metrics);
+    responsiveMetrics = new ResponsiveMetrics(metrics, OtelMetricsService.noop());
     responsiveMetrics.initializeTags(
         APP_ID,
         CLIENT_ID,

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/CommitBufferTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/CommitBufferTest.java
@@ -58,6 +58,7 @@ import dev.responsive.kafka.internal.db.KeySpec;
 import dev.responsive.kafka.internal.db.partitioning.SubPartitioner;
 import dev.responsive.kafka.internal.db.spec.BaseTableSpec;
 import dev.responsive.kafka.internal.metrics.ClientVersionMetadata;
+import dev.responsive.kafka.internal.metrics.OtelMetricsService;
 import dev.responsive.kafka.internal.metrics.ResponsiveMetrics;
 import dev.responsive.kafka.internal.utils.ExceptionSupplier;
 import dev.responsive.kafka.internal.utils.SessionClients;
@@ -173,7 +174,7 @@ public class CommitBufferTest {
         Optional.of(client),
         admin
     );
-    final var responsiveMetrics = new ResponsiveMetrics(metrics);
+    final var responsiveMetrics = new ResponsiveMetrics(metrics, OtelMetricsService.noop());
     responsiveMetrics.initializeTags(
         "commit-buffer-test-app",
         "commit-buffer-test-app-node-1",

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/internal/stores/TTDRestoreListener.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/internal/stores/TTDRestoreListener.java
@@ -17,6 +17,7 @@
 package dev.responsive.kafka.internal.stores;
 
 import dev.responsive.kafka.internal.metrics.ClientVersionMetadata;
+import dev.responsive.kafka.internal.metrics.OtelMetricsService;
 import dev.responsive.kafka.internal.metrics.ResponsiveMetrics;
 import dev.responsive.kafka.internal.metrics.ResponsiveRestoreListener;
 import java.util.Collections;
@@ -35,7 +36,7 @@ public class TTDRestoreListener extends ResponsiveRestoreListener {
 
   public static TTDRestoreListener mockRestoreListener(final Properties props) {
     final String appId = props.getProperty(StreamsConfig.APPLICATION_ID_CONFIG);
-    final var metrics = new ResponsiveMetrics(new Metrics());
+    final var metrics = new ResponsiveMetrics(new Metrics(), OtelMetricsService.noop());
     metrics.initializeTags(
         appId,
         appId + "-client",

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -85,6 +85,21 @@ dependencyResolutionManagement {
 
             library("slf4j-api", "org.slf4j", "slf4j-api").versionRef("slf4j")
 
+            library("otel-api", "io.opentelemetry:opentelemetry-api:1.32.0");
+            library("otel-sdk", "io.opentelemetry:opentelemetry-sdk:1.32.0");
+            library("otel-sdk-metrics", "io.opentelemetry:opentelemetry-sdk-metrics:1.32.0");
+            library("otel-exporter-logging", "io.opentelemetry:opentelemetry-exporter-logging:1.32.0");
+            library("otel-exporter-otlp", "io.opentelemetry:opentelemetry-exporter-otlp:1.32.0");
+            library("otel-jmx", "io.opentelemetry.instrumentation:opentelemetry-jmx-metrics:1.32.0-alpha")
+            bundle("otel", listOf(
+                    "otel-api",
+                    "otel-sdk",
+                    "otel-sdk-metrics",
+                    "otel-exporter-logging",
+                    "otel-exporter-otlp",
+                    "otel-jmx",
+            ))
+
             // do not include these in jars that are distributed - these
             // should only be used when the distributed artifact is deployable (e.g.
             // a docker image)


### PR DESCRIPTION
I tested this with a local controller setup directly reporting to DD: https://us5.datadoghq.com/s/7d2b7ec4-e391-11ed-b891-da7ad0900005/iua-jdy-8wc

In a follow-up PR I'll modify `kafka-client-examples/simple-example` to run with agent-free metrics reporting.