### PR TITLE
strongly type our metrics export keys

### DIFF
--- a/controller-api/src/main/proto/responsive/metrics/v1/metrics.proto
+++ b/controller-api/src/main/proto/responsive/metrics/v1/metrics.proto
@@ -17,8 +17,11 @@ message TenantResource {
   string tenant = 1;
 
   // the resource (the entity in the system that reported the
-  // metrics that are collected)
-  opentelemetry.proto.resource.v1.Resource resource = 2;
+  // metrics that are collected) - we use oneof in order to
+  // allow for different types of resources in the future
+  oneof resource {
+    string applicationId = 2;
+  }
 }
 
 // a metric that is reported from Responsive, for now this is


### PR DESCRIPTION
**NOTE:** this is backwards incompatible, but I've disabled metrics reporting and we can delete the kafka topics that had these keys since they were effectively a blackhole sink topic that wasn't being used yet.