### PR TITLE
fix mongo metadata table _id field

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MetadataDoc.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MetadataDoc.java
@@ -17,8 +17,6 @@
 package dev.responsive.kafka.internal.db.mongo;
 
 import java.util.Objects;
-import org.bson.codecs.pojo.annotations.BsonId;
-import org.bson.types.ObjectId;
 
 public class MetadataDoc {
 
@@ -27,8 +25,7 @@ public class MetadataDoc {
   public static final String OFFSET = "offset";
   public static final String EPOCH = "epoch";
 
-  @BsonId
-  ObjectId id;
+  int id;
   int partition;
   long offset;
   long epoch;
@@ -36,11 +33,11 @@ public class MetadataDoc {
   public MetadataDoc() {
   }
 
-  public ObjectId id() {
+  public int id() {
     return id;
   }
 
-  public void setId(final ObjectId id) {
+  public void setId(final int id) {
     this.id = id;
   }
 


### PR DESCRIPTION
for some reason, the previous code was generating `_id` clashes, this fixes it by just setting the `_id` to be the partition.

note (cc @ableegoldman) this is a breaking change that requires manual fix if you have anything that's deployed using Mongo reach out to me and we can migrate it.