### PR TITLE
Use constant collection names and validate TableName length

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraTableSpecFactory.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraTableSpecFactory.java
@@ -44,14 +44,14 @@ public class CassandraTableSpecFactory {
       final ResponsiveKeyValueParams params,
       final TablePartitioner<Bytes, Integer> partitioner
   ) {
-    return new GlobalTableSpec(new BaseTableSpec(params.name().remoteName(), partitioner));
+    return new GlobalTableSpec(new BaseTableSpec(params.name().tableName(), partitioner));
   }
 
   public static CassandraTableSpec fromKVParams(
       final ResponsiveKeyValueParams params,
       final TablePartitioner<Bytes, Integer> partitioner
   ) {
-    CassandraTableSpec spec = new BaseTableSpec(params.name().remoteName(), partitioner);
+    CassandraTableSpec spec = new BaseTableSpec(params.name().tableName(), partitioner);
 
     if (params.timeToLive().isPresent()) {
       spec = new TtlTableSpec(spec, params.timeToLive().get());
@@ -68,7 +68,7 @@ public class CassandraTableSpecFactory {
       final ResponsiveWindowParams params,
       final TablePartitioner<WindowedKey, SegmentPartition> partitioner
   ) {
-    return new BaseTableSpec(params.name().remoteName(), partitioner);
+    return new BaseTableSpec(params.name().tableName(), partitioner);
   }
 
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/PartitionedOperations.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/PartitionedOperations.java
@@ -98,7 +98,7 @@ public class PartitionedOperations implements KeyValueOperations {
 
     final WriterFactory<Bytes, ?> writerFactory = table.init(changelog.partition());
 
-    log.info("Remote table {} is available for querying.", name.remoteName());
+    log.info("Remote table {} is available for querying.", name.tableName());
 
     final BytesKeySpec keySpec = new BytesKeySpec();
     final CommitBuffer<Bytes, ?> buffer = CommitBuffer.from(
@@ -153,7 +153,7 @@ public class PartitionedOperations implements KeyValueOperations {
         : SubPartitioner.create(
             actualRemoteCount,
             numChangelogPartitions,
-            params.name().remoteName(),
+            params.name().tableName(),
             config,
             changelogTopicName
         );
@@ -173,7 +173,7 @@ public class PartitionedOperations implements KeyValueOperations {
       final ResponsiveKeyValueParams params,
       final SessionClients sessionClients
   ) throws InterruptedException, TimeoutException {
-    return sessionClients.mongoClient().kvTable(params.name().remoteName());
+    return sessionClients.mongoClient().kvTable(params.name().tableName());
   }
 
   @SuppressWarnings("rawtypes")

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/SegmentedOperations.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/SegmentedOperations.java
@@ -100,7 +100,7 @@ public class SegmentedOperations implements WindowOperations {
 
     final WriterFactory<WindowedKey, ?> writerFactory = table.init(changelog.partition());
 
-    log.info("Remote table {} is available for querying.", name.remoteName());
+    log.info("Remote table {} is available for querying.", name.tableName());
 
     final WindowedKeySpec keySpec = new WindowedKeySpec(withinRetention);
     final CommitBuffer<WindowedKey, ?> buffer = CommitBuffer.from(

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/utils/TableName.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/utils/TableName.java
@@ -18,38 +18,48 @@ package dev.responsive.kafka.internal.utils;
 
 import java.util.Objects;
 import java.util.regex.Pattern;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * {@code TableName} represents the name for a table and all variations
  * of it - some characters that are valid for Kafka names are not valid
- * as Cassandra table names.
+ * as table names.
  */
 public class TableName {
 
-  // cassandra names are case-insensitive and can only contain
+  private static final Logger LOG = LoggerFactory.getLogger(TableName.class);
+
+  private static final int MAXIMUM_LENGTH = 65;
+
+  // table names are case-insensitive and should only contain
   // alphanumeric and underscore characters
-  private static final Pattern INVALID_CASSANDRA_CHARS =
+  private static final Pattern INVALID_CHARS =
       Pattern.compile("[^a-zA-Z0-9_]");
 
   private final String kafkaName;
-  private final String remoteName;
+  private final String tableName;
 
   public TableName(final String kafkaName) {
     this.kafkaName = kafkaName;
     final var escaped = kafkaName.replaceAll("_", "__"); // escape existing underscores
-    remoteName = INVALID_CASSANDRA_CHARS
+    tableName = INVALID_CHARS
         .matcher(escaped)
         .replaceAll("_")
         .toLowerCase();
+
+    if (tableName.length() > MAXIMUM_LENGTH) {
+      LOG.error("Invalid table name for state store {}, must be no more than {} characters long"
+                    + " but length was {}", tableName, MAXIMUM_LENGTH, tableName.length());
+    }
   }
 
   public String kafkaName() {
     return kafkaName;
   }
 
-  // TODO: rename this to tableName()
-  public String remoteName() {
-    return remoteName;
+  public String tableName() {
+    return tableName;
   }
 
   @Override
@@ -62,16 +72,16 @@ public class TableName {
     }
     final TableName tableName = (TableName) o;
     return Objects.equals(kafkaName, tableName.kafkaName)
-        && Objects.equals(remoteName, tableName.remoteName);
+        && Objects.equals(this.tableName, tableName.tableName);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(kafkaName, remoteName);
+    return Objects.hash(kafkaName, tableName);
   }
 
   @Override
   public String toString() {
-    return kafkaName + "(" + remoteName + ")";
+    return kafkaName + "(" + tableName + ")";
   }
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/utils/TableName.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/utils/TableName.java
@@ -51,6 +51,7 @@ public class TableName {
     if (tableName.length() > MAXIMUM_LENGTH) {
       LOG.error("Invalid table name for state store {}, must be no more than {} characters long"
                     + " but length was {}", tableName, MAXIMUM_LENGTH, tableName.length());
+      throw new IllegalArgumentException("Table name exceeds 65 character limit: " + tableName);
     }
   }
 

--- a/kafka-client/src/test/java/dev/responsive/kafka/integration/TablePartitionerIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/integration/TablePartitionerIntegrationTest.java
@@ -173,7 +173,7 @@ public class TablePartitionerIntegrationTest {
           true,
           properties
       );
-      final String cassandraName = new TableName(storeName).remoteName();
+      final String cassandraName = new TableName(storeName).tableName();
       final var partitioner = SubPartitioner.create(
           OptionalInt.empty(),
           NUM_PARTITIONS_INPUT,
@@ -238,7 +238,7 @@ public class TablePartitionerIntegrationTest {
           true,
           properties
       );
-      final String cassandraName = new TableName(storeName).remoteName();
+      final String cassandraName = new TableName(storeName).tableName();
       final var partitioner = TablePartitioner.defaultPartitioner();
       final CassandraFactTable table = CassandraFactTable.create(
           new BaseTableSpec(cassandraName, partitioner), client);
@@ -320,7 +320,7 @@ public class TablePartitionerIntegrationTest {
           true,
           properties
       );
-      final String cassandraName = new TableName(storeName).remoteName();
+      final String cassandraName = new TableName(storeName).tableName();
       final var partitioner = SubPartitioner.create(
           OptionalInt.empty(),
           NUM_PARTITIONS_INPUT,

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/CassandraFactTableIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/CassandraFactTableIntegrationTest.java
@@ -71,7 +71,7 @@ class CassandraFactTableIntegrationTest {
   public void shouldInitializeWithCorrectMetadata() throws Exception {
     // Given:
     params = ResponsiveKeyValueParams.fact(storeName);
-    final String tableName = params.name().remoteName();
+    final String tableName = params.name().tableName();
     final RemoteKVTable<BoundStatement> schema = client
         .factFactory()
         .create(CassandraTableSpecFactory.fromKVParams(params, defaultPartitioner()));
@@ -103,7 +103,7 @@ class CassandraFactTableIntegrationTest {
     // Given:
     final var ttl = Duration.ofDays(30);
     params = ResponsiveKeyValueParams.fact(storeName).withTimeToLive(ttl);
-    final String tableName = params.name().remoteName();
+    final String tableName = params.name().tableName();
 
     // When:
     client.factFactory()
@@ -130,7 +130,7 @@ class CassandraFactTableIntegrationTest {
   public void shouldUseTwcsWithoutTtl() throws Exception {
     // Given:
     params = ResponsiveKeyValueParams.fact(storeName);
-    final String tableName = params.name().remoteName();
+    final String tableName = params.name().tableName();
 
     // When:
     client.factFactory()
@@ -175,7 +175,7 @@ class CassandraFactTableIntegrationTest {
   public void shouldRespectSemanticTTL() throws Exception {
     // Given:
     params = ResponsiveKeyValueParams.fact(storeName);
-    final String tableName = params.name().remoteName();
+    final String tableName = params.name().tableName();
 
     final RemoteKVTable<BoundStatement> table = client
         .factFactory()

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/partitioning/SubPartitionerTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/partitioning/SubPartitionerTest.java
@@ -81,7 +81,7 @@ class SubPartitionerTest {
     final SubPartitioner subPartitioner = SubPartitioner.create(
         actualRemoteCount,
         kafkaPartitions,
-        NAME.remoteName(),
+        NAME.tableName(),
         responsiveConfig(desiredPartitions),
         CHANGELOG_TOPIC_NAME
     );
@@ -101,7 +101,7 @@ class SubPartitionerTest {
     final SubPartitioner subPartitioner = SubPartitioner.create(
         actualRemoteCount,
         kafkaPartitions,
-        NAME.remoteName(),
+        NAME.tableName(),
         responsiveConfig(desiredPartitions),
         CHANGELOG_TOPIC_NAME
     );
@@ -123,7 +123,7 @@ class SubPartitionerTest {
         () -> SubPartitioner.create(
             actualRemoteCount,
             kafkaPartitions,
-            NAME.remoteName(),
+            NAME.tableName(),
             responsiveConfig(desiredPartitions),
             CHANGELOG_TOPIC_NAME
         )

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/utils/TableNameTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/utils/TableNameTest.java
@@ -31,7 +31,7 @@ class TableNameTest {
     final var name = new TableName(kafkaName);
 
     // Then:
-    MatcherAssert.assertThat(name.remoteName(), Matchers.is("foo_bar_baz__qux"));
+    MatcherAssert.assertThat(name.tableName(), Matchers.is("foo_bar_baz__qux"));
   }
 
 }


### PR DESCRIPTION
Mongo limits database names to 65 characters (at the most -- may be even smaller in some cases) and also enforces the combined `<database_name>.<collection_name>` string to not exceed 128 characters. 

We should validate the table name length up front for fast-failure (I actually ran into this in a test with a long name). We should also remove the table name from the collection naming scheme for the MongoKVTable. We don't need to include the table name again since the collections are by definition scoped to that database, which is named after the state store. This way we are able to use up to the full allotted character count for table names (since otherwise the metadata collections could exceed 128 characters with a 64-character table name).