### PR TITLE
Rename MetadataDoc to KVMetadataDoc and use partition for _id field

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/KVMetadataDoc.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/KVMetadataDoc.java
@@ -18,27 +18,17 @@ package dev.responsive.kafka.internal.db.mongo;
 
 import java.util.Objects;
 
-public class MetadataDoc {
+public class KVMetadataDoc {
 
-  public static final String ID = "_id";
-  public static final String PARTITION = "partition";
+  public static final String PARTITION = "_id";
   public static final String OFFSET = "offset";
   public static final String EPOCH = "epoch";
 
-  int id;
   int partition;
   long offset;
   long epoch;
 
-  public MetadataDoc() {
-  }
-
-  public int id() {
-    return id;
-  }
-
-  public void setId(final int id) {
-    this.id = id;
+  public KVMetadataDoc() {
   }
 
   public int partition() {
@@ -73,22 +63,20 @@ public class MetadataDoc {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    final MetadataDoc that = (MetadataDoc) o;
+    final KVMetadataDoc that = (KVMetadataDoc) o;
     return partition == that.partition
         && offset == that.offset
-        && epoch == that.epoch
-        && Objects.equals(id, that.id);
+        && epoch == that.epoch;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, partition, epoch, offset);
+    return Objects.hash(partition, epoch, offset);
   }
 
   @Override
   public String toString() {
-    return "MetadataDoc{"
-        + "id=" + id
+    return "KVMetadataDoc{"
         + ", partition=" + partition
         + ", offset=" + offset
         + ", epoch=" + epoch


### PR DESCRIPTION
Two changes in this PR:
1. Rename the MetadataDoc class to KVMetadataDoc to distinguish from the upcoming WindowDoc
2. Remove the redundant `"partition"` field but rename all the `"_id"` field variables as partition

For testing, in addition to the baseline tests, I also ran `ResponsiveKeyValueStoreRestoreIntegrationTest` with the storage backend set to Mongo. (As an aside, it would be nice to parametrize this test)