### PR TITLE
add flush jitter config

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
@@ -139,6 +139,12 @@ public class ResponsiveConfig extends AbstractConfig {
   public static final long STORE_FLUSH_INTERVAL_TRIGGER_DEFAULT
       = Duration.ofSeconds(30).toMillis();
 
+  public static final String STORE_FLUSH_INTERVAL_TRIGGER_JITTER_CONFIG = "responsive.store.flush.trigger.local.jitter.ms";
+  public static final String STORE_FLUSH_INTERVAL_TRIGGER_JITTER_DOC = "The jitter to apply to the flush interval." +
+      "For flush interval i and jitter j, the flush interval for a given flush will a randomly selected duration" +
+      "between i-j and i+j.";
+  public static final int STORE_FLUSH_INTERVAL_TRIGGER_JITTER_DEFAULT = 0;
+
   // TODO: consider if we want this as a local, global or per-store configuration
   public static final String MAX_CONCURRENT_REQUESTS_CONFIG = "responsive.max.concurrent.requests";
   private static final String MAX_CONCURRENT_REQUESTS_DOC = "The maximum number of requests"
@@ -301,6 +307,12 @@ public class ResponsiveConfig extends AbstractConfig {
           STORE_FLUSH_INTERVAL_TRIGGER_DEFAULT,
           Importance.MEDIUM,
           STORE_FLUSH_INTERVAL_TRIGGER_DOC
+      ).define(
+          STORE_FLUSH_INTERVAL_TRIGGER_JITTER_CONFIG,
+          Type.INT,
+          STORE_FLUSH_INTERVAL_TRIGGER_JITTER_DEFAULT,
+          Importance.LOW,
+          STORE_FLUSH_INTERVAL_TRIGGER_JITTER_DOC
       ).define(
           SUBPARTITION_HASHER_CONFIG,
           Type.CLASS,

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
@@ -140,9 +140,9 @@ public class ResponsiveConfig extends AbstractConfig {
       = Duration.ofSeconds(30).toMillis();
 
   public static final String STORE_FLUSH_INTERVAL_TRIGGER_JITTER_CONFIG = "responsive.store.flush.trigger.local.jitter.ms";
-  public static final String STORE_FLUSH_INTERVAL_TRIGGER_JITTER_DOC = "The jitter to apply to the flush interval." +
-      "For flush interval i and jitter j, the flush interval for a given flush will a randomly selected duration" +
-      "between i-j and i+j.";
+  public static final String STORE_FLUSH_INTERVAL_TRIGGER_JITTER_DOC = "The jitter to apply to the flush interval."
+      + "For flush interval i and jitter j, the flush interval for a given flush will a randomly selected duration"
+      + "between i-j and i+j.";
   public static final int STORE_FLUSH_INTERVAL_TRIGGER_JITTER_DEFAULT = 0;
 
   // TODO: consider if we want this as a local, global or per-store configuration

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
@@ -141,7 +141,7 @@ public class ResponsiveConfig extends AbstractConfig {
 
   public static final String STORE_FLUSH_INTERVAL_TRIGGER_JITTER_CONFIG = "responsive.store.flush.trigger.local.jitter.ms";
   public static final String STORE_FLUSH_INTERVAL_TRIGGER_JITTER_DOC = "The jitter to apply to the flush interval."
-      + "For flush interval i and jitter j, the flush interval for a given flush will a randomly selected duration"
+      + "For flush interval i and jitter j, the actual flush interval for a given flush will a randomly selected duration"
       + "between i-j and i+j.";
   public static final int STORE_FLUSH_INTERVAL_TRIGGER_JITTER_DEFAULT = 0;
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/CommitBuffer.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/CommitBuffer.java
@@ -439,7 +439,6 @@ public class CommitBuffer<K extends Comparable<K>, P>
           now
       );
       timeTrigger = true;
-      flushTriggers.reset();
     } else {
       log.debug("Time since last flush {} not over trigger {}",
           Duration.between(lastFlush, now),
@@ -453,6 +452,8 @@ public class CommitBuffer<K extends Comparable<K>, P>
     if (!triggerFlush()) {
       return;
     }
+
+    flushTriggers.reset();
 
     if (buffer.getReader().isEmpty()) {
       log.debug("Ignoring flush() of empty commit buffer");

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/CommitBuffer.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/CommitBuffer.java
@@ -439,6 +439,7 @@ public class CommitBuffer<K extends Comparable<K>, P>
           now
       );
       timeTrigger = true;
+      flushTriggers.reset();
     } else {
       log.debug("Time since last flush {} not over trigger {}",
           Duration.between(lastFlush, now),

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/FlushTriggers.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/FlushTriggers.java
@@ -6,7 +6,7 @@ import java.util.Random;
 
 public class FlushTriggers {
   public static FlushTriggers ALWAYS = new FlushTriggers(0, 0, Duration.ZERO, Duration.ZERO);
-  private final Random RANDOM = new Random();
+  private static final Random RANDOM = new Random();
 
   private final int records;
   private final long bytes;
@@ -76,7 +76,7 @@ public class FlushTriggers {
   }
 
   public void reset() {
-    if (interval.toMillis() == 0) {
+    if (interval.isZero() || jitter.isZero()) {
       intervalOffset = 0;
     } else {
       intervalOffset = RANDOM.nextLong() % (jitter.toMillis());

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/FlushTriggers.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/FlushTriggers.java
@@ -2,38 +2,65 @@ package dev.responsive.kafka.internal.stores;
 
 import dev.responsive.kafka.api.config.ResponsiveConfig;
 import java.time.Duration;
+import java.util.Random;
 
 public class FlushTriggers {
-  public static FlushTriggers ALWAYS = new FlushTriggers(0, 0, Duration.ZERO);
+  public static FlushTriggers ALWAYS = new FlushTriggers(0, 0, Duration.ZERO, Duration.ZERO);
+  private final Random RANDOM = new Random();
 
   private final int records;
   private final long bytes;
+  private long intervalOffset;
   private final Duration interval;
+  private final Duration jitter;
 
   public static FlushTriggers fromConfig(final ResponsiveConfig config) {
     return new FlushTriggers(
         config.getInt(ResponsiveConfig.STORE_FLUSH_RECORDS_TRIGGER_CONFIG),
         config.getLong(ResponsiveConfig.STORE_FLUSH_BYTES_TRIGGER_CONFIG),
-        Duration.ofMillis(config.getLong(ResponsiveConfig.STORE_FLUSH_INTERVAL_TRIGGER_MS_CONFIG))
+        Duration.ofMillis(config.getLong(ResponsiveConfig.STORE_FLUSH_INTERVAL_TRIGGER_MS_CONFIG)),
+        Duration.ofMillis(
+            config.getInt(ResponsiveConfig.STORE_FLUSH_INTERVAL_TRIGGER_JITTER_CONFIG))
     );
   }
 
   static FlushTriggers ofRecords(final int records) {
-    return new FlushTriggers(records, Long.MAX_VALUE, Duration.ofMillis(Long.MAX_VALUE));
+    return new FlushTriggers(
+        records,
+        Long.MAX_VALUE,
+        Duration.ofMillis(Long.MAX_VALUE),
+        Duration.ZERO
+    );
   }
 
   static FlushTriggers ofBytes(final long bytes) {
-    return new FlushTriggers(Integer.MAX_VALUE, bytes, Duration.ofMillis(Long.MAX_VALUE));
+    return new FlushTriggers(
+        Integer.MAX_VALUE,
+        bytes,
+        Duration.ofMillis(Long.MAX_VALUE),
+        Duration.ZERO
+    );
   }
 
   static FlushTriggers ofInterval(final Duration interval) {
-    return new FlushTriggers(Integer.MAX_VALUE, Long.MAX_VALUE, interval);
+    return new FlushTriggers(Integer.MAX_VALUE, Long.MAX_VALUE, interval, Duration.ZERO);
   }
 
-  private FlushTriggers(final int records, final long bytes, final Duration interval) {
+  static FlushTriggers ofInterval(final Duration interval, final Duration jitter) {
+    return new FlushTriggers(Integer.MAX_VALUE, Long.MAX_VALUE, interval, jitter);
+  }
+
+  private FlushTriggers(
+      final int records,
+      final long bytes,
+      final Duration interval,
+      final Duration jitter
+  ) {
     this.records = records;
     this.bytes = bytes;
     this.interval = interval;
+    this.jitter = jitter;
+    reset();
   }
 
   public int getRecords() {
@@ -45,6 +72,15 @@ public class FlushTriggers {
   }
 
   public Duration getInterval() {
-    return interval;
+    return interval.plusMillis(intervalOffset);
+  }
+
+  public void reset() {
+    if (interval.toMillis() == 0) {
+      intervalOffset = 0;
+    } else {
+      intervalOffset = RANDOM.nextLong() % (jitter.toMillis());
+      intervalOffset = RANDOM.nextBoolean() ? intervalOffset : -1 * intervalOffset;
+    }
   }
 }

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/CommitBufferTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/CommitBufferTest.java
@@ -36,6 +36,8 @@ import static dev.responsive.kafka.internal.metrics.StoreMetrics.TIME_SINCE_LAST
 import static dev.responsive.kafka.internal.metrics.StoreMetrics.TIME_SINCE_LAST_FLUSH_DESCRIPTION;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -71,9 +73,11 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
@@ -574,6 +578,46 @@ public class CommitBufferTest {
       clock.set(clock.get().plus(Duration.ofSeconds(35)));
       buffer.flush(5L);
       assertThat(table.fetchOffset(KAFKA_PARTITION), is(5L));
+    }
+  }
+
+  private Optional<Instant> measureFlushTime(
+      final CommitBuffer<Bytes, Integer> buffer,
+      final AtomicReference<Instant> clock,
+      final long flushOffset,
+      final Instant to
+  ) {
+    buffer.put(Bytes.wrap(new byte[]{18}), VALUE, CURRENT_TS);
+    while (clock.get().isBefore(to)) {
+      buffer.flush(flushOffset);
+      if (table.fetchOffset(KAFKA_PARTITION) == flushOffset) {
+        return Optional.of(clock.get());
+      }
+      clock.set(clock.get().plus(Duration.ofSeconds(1)));
+    }
+    return Optional.empty();
+  }
+
+  @Test
+  public void shouldApplyJitterToFlushInterval() {
+    final AtomicReference<Instant> clock = new AtomicReference<>(Instant.now());
+    try (final CommitBuffer<Bytes, Integer> buffer = createCommitBuffer(
+        FlushTriggers.ofInterval(Duration.ofSeconds(20), Duration.ofSeconds(5)),
+        100,
+        clock::get)
+    ) {
+      final Set<Duration> intervals = new HashSet<>();
+      for (int i = 0; i < 20; i++) {
+        final Instant start = clock.get();
+        final Optional<Instant> flushTime
+            = measureFlushTime(buffer, clock, 5 + i, start.plus(Duration.ofSeconds(26)));
+        assertThat(flushTime.isPresent(), is(true));
+        final Duration flushInterval = Duration.between(start, flushTime.get());
+        final long flushIntervalSeconds = flushInterval.getSeconds();
+        assertThat(flushIntervalSeconds, greaterThanOrEqualTo(15L));
+        intervals.add(flushInterval);
+      }
+      assertThat(intervals.size(), greaterThan(1));
     }
   }
 

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/CommitBufferTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/CommitBufferTest.java
@@ -581,6 +581,9 @@ public class CommitBufferTest {
     }
   }
 
+  // measure how long before the commit buffer actually flushes the buffer (1-second granularity)
+  // the measurement is taken by iterating until the flush succeeds, advancing the clock by
+  // 1 second at each iteration.
   private Optional<Instant> measureFlushTime(
       final CommitBuffer<Bytes, Integer> buffer,
       final AtomicReference<Instant> clock,
@@ -600,23 +603,32 @@ public class CommitBufferTest {
 
   @Test
   public void shouldApplyJitterToFlushInterval() {
+    // applies a 5-second jitter (for a 10 seconds range) and measures the flush interval
+    // over 20 iterations. Then, the test asserts that we got at least 2 different intervals.
+    // The test has a (1/10 ^ 20) probability of returning a false-negative
     final AtomicReference<Instant> clock = new AtomicReference<>(Instant.now());
     try (final CommitBuffer<Bytes, Integer> buffer = createCommitBuffer(
         FlushTriggers.ofInterval(Duration.ofSeconds(20), Duration.ofSeconds(5)),
         100,
         clock::get)
     ) {
+      // given:
       final Set<Duration> intervals = new HashSet<>();
       for (int i = 0; i < 20; i++) {
         final Instant start = clock.get();
+
+        // when:
         final Optional<Instant> flushTime
             = measureFlushTime(buffer, clock, 5 + i, start.plus(Duration.ofSeconds(26)));
+
+        // then make sure the flush happened in a time that's in range:
         assertThat(flushTime.isPresent(), is(true));
         final Duration flushInterval = Duration.between(start, flushTime.get());
         final long flushIntervalSeconds = flushInterval.getSeconds();
         assertThat(flushIntervalSeconds, greaterThanOrEqualTo(15L));
         intervals.add(flushInterval);
       }
+      // then make sure that there was some randomness to the jitter:
       assertThat(intervals.size(), greaterThan(1));
     }
   }


### PR DESCRIPTION
adds a property that configures jitter around the flush interval to spread out load from flushes.