### PR TITLE
Mongo KV range queries (option 1)

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/KVDoc.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/KVDoc.java
@@ -24,47 +24,59 @@ import org.bson.codecs.pojo.annotations.BsonId;
 public class KVDoc {
 
   // TODO(agavra): figure out if we can use @BsonProperty to set the names explicitly
-  public static final String ID = "_id";
+  public static final String KEY = "_id";
   public static final String VALUE = "value";
+  public static final String KAFKA_PARTITION = "partition";
   public static final String EPOCH = "epoch";
   public static final String TOMBSTONE_TS = "tombstoneTs";
 
   @BsonId
-  byte[] id;
+  byte[] key;
   byte[] value;
+  int kafkaPartition;
   long epoch;
   Date tombstoneTs;
 
   public KVDoc() {
   }
 
-  public KVDoc(final byte[] key, final byte[] value, final long epoch) {
+  public KVDoc(final byte[] key, final byte[] value, final int kafkaPartition, final long epoch) {
+    this.key = key;
     this.value = value;
+    this.kafkaPartition = kafkaPartition;
     this.epoch = epoch;
   }
 
   public byte[] getKey() {
-    return id;
+    return key;
   }
 
   public void setKey(final byte[] id) {
-    this.id = id;
-  }
-
-  public void setValue(final byte[] value) {
-    this.value = value;
-  }
-
-  public void setEpoch(final long epoch) {
-    this.epoch = epoch;
+    this.key = id;
   }
 
   public byte[] getValue() {
     return value;
   }
 
+  public void setValue(final byte[] value) {
+    this.value = value;
+  }
+
   public long getEpoch() {
     return epoch;
+  }
+
+  public void setEpoch(final long epoch) {
+    this.epoch = epoch;
+  }
+
+  public int getKafkaPartition() {
+    return kafkaPartition;
+  }
+
+  public void setKafkaPartition(final int kafkaPartition) {
+    this.kafkaPartition = kafkaPartition;
   }
 
   public Date getTombstoneTs() {
@@ -83,16 +95,18 @@ public class KVDoc {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    final KVDoc kvDoc = (KVDoc) o;
-    return epoch == kvDoc.epoch
-        && Arrays.equals(id, kvDoc.id)
-        && Arrays.equals(value, kvDoc.value)
-        && Objects.equals(tombstoneTs, kvDoc.tombstoneTs);
+    final KVDoc other = (KVDoc) o;
+    return epoch == other.epoch
+        && kafkaPartition == other.kafkaPartition
+        && Arrays.equals(key, other.key)
+        && Arrays.equals(value, other.value)
+        && Objects.equals(tombstoneTs, other.tombstoneTs);
   }
 
   @Override
   public int hashCode() {
-    int result = Objects.hash(id, epoch, tombstoneTs);
+    int result = Objects.hash(kafkaPartition, epoch, tombstoneTs);
+    result = 31 * result + Arrays.hashCode(key);
     result = 31 * result + Arrays.hashCode(value);
     return result;
   }
@@ -100,8 +114,9 @@ public class KVDoc {
   @Override
   public String toString() {
     return "KVDoc{"
-        + "id=" + Arrays.toString(id)
+        + "id=" + Arrays.toString(key)
         + ", value=" + Arrays.toString(value)
+        + ", kafkaPartition=" + kafkaPartition
         + ", epoch=" + epoch
         + ", tombstoneTs=" + tombstoneTs
         + '}';

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/KVMetadataDoc.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/KVMetadataDoc.java
@@ -20,11 +20,11 @@ import java.util.Objects;
 
 public class KVMetadataDoc {
 
-  public static final String PARTITION = "_id";
+  public static final String KAFKA_PARTITION = "_id";
   public static final String OFFSET = "offset";
   public static final String EPOCH = "epoch";
 
-  int partition;
+  int kafkaPartition;
   long offset;
   long epoch;
 
@@ -32,11 +32,11 @@ public class KVMetadataDoc {
   }
 
   public int partition() {
-    return partition;
+    return kafkaPartition;
   }
 
-  public void setPartition(final int partition) {
-    this.partition = partition;
+  public void setKafkaPartition(final int kafkaPartition) {
+    this.kafkaPartition = kafkaPartition;
   }
 
   public long offset() {
@@ -64,20 +64,20 @@ public class KVMetadataDoc {
       return false;
     }
     final KVMetadataDoc that = (KVMetadataDoc) o;
-    return partition == that.partition
+    return kafkaPartition == that.kafkaPartition
         && offset == that.offset
         && epoch == that.epoch;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(partition, epoch, offset);
+    return Objects.hash(kafkaPartition, epoch, offset);
   }
 
   @Override
   public String toString() {
     return "KVMetadataDoc{"
-        + ", partition=" + partition
+        + ", partition=" + kafkaPartition
         + ", offset=" + offset
         + ", epoch=" + epoch
         + '}';

--- a/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveWindowStoreIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveWindowStoreIntegrationTest.java
@@ -135,8 +135,8 @@ public class ResponsiveWindowStoreIntegrationTest {
 
     final ConcurrentMap<Windowed<Long>, Long> collect = new ConcurrentHashMap<>();
     final CountdownLatchWrapper outputLatch = new CountdownLatchWrapper(0);
-
     final CountDownLatch finalLatch = new CountDownLatch(2);
+
     final KStream<Long, Long> input = builder.stream(inputTopic());
     
     input

--- a/kafka-client/src/test/java/dev/responsive/kafka/integration/StoreQueryIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/integration/StoreQueryIntegrationTest.java
@@ -18,7 +18,6 @@ package dev.responsive.kafka.integration;
 
 import static dev.responsive.kafka.api.config.ResponsiveConfig.STORE_FLUSH_RECORDS_TRIGGER_CONFIG;
 import static dev.responsive.kafka.testutils.IntegrationTestUtils.createTopicsAndWait;
-
 import static dev.responsive.kafka.testutils.IntegrationTestUtils.pipeRecords;
 import static dev.responsive.kafka.testutils.IntegrationTestUtils.readOutput;
 import static dev.responsive.kafka.testutils.IntegrationTestUtils.startAppAndAwaitRunning;

--- a/kafka-client/src/test/java/dev/responsive/kafka/integration/StoreQueryIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/integration/StoreQueryIntegrationTest.java
@@ -74,7 +74,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 public class StoreQueryIntegrationTest {
 
   @RegisterExtension
-  static ResponsiveExtension EXTENSION = new ResponsiveExtension(StorageBackend.CASSANDRA);
+  static ResponsiveExtension EXTENSION = new ResponsiveExtension(StorageBackend.MONGO_DB);
 
   private static final String INPUT_TOPIC = "input";
   private static final String OUTPUT_TOPIC = "output";

--- a/kafka-client/src/test/java/dev/responsive/kafka/integration/StoreQueryIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/integration/StoreQueryIntegrationTest.java
@@ -18,6 +18,7 @@ package dev.responsive.kafka.integration;
 
 import static dev.responsive.kafka.api.config.ResponsiveConfig.STORE_FLUSH_RECORDS_TRIGGER_CONFIG;
 import static dev.responsive.kafka.testutils.IntegrationTestUtils.createTopicsAndWait;
+
 import static dev.responsive.kafka.testutils.IntegrationTestUtils.pipeRecords;
 import static dev.responsive.kafka.testutils.IntegrationTestUtils.readOutput;
 import static dev.responsive.kafka.testutils.IntegrationTestUtils.startAppAndAwaitRunning;


### PR DESCRIPTION
Implementation of `range` and `all` queries for the MongoKVTable.

In order to follow Streams semantics, we need to be able to differentiate data that falls within a kafka partition. There are two options:

1. Add a `kafkaPartition` field to KVDoc and filter range queries with this
2. Separate data into different collections for each kafka partition

This PR implements option 1, although we may want to go with option 2 for two reasons: (a) increased read/write/storage due to added field (though it's just an int) and (b) in the current implementation for Mongo window stores, we need separate collections for each kafka partition anyway (to track stream-time on a partition basis), so it probably makes sene to be consistent.

I'll follow up with a PR for option 2 after finishing the window store range queries