### PR TITLE
Mongo window range queries

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
@@ -180,12 +180,13 @@ public class ResponsiveConfig extends AbstractConfig {
   // ------------------ WindowStore configurations ----------------------
 
   public static final String MONGO_WINDOWED_KEY_TIMESTAMP_FIRST_CONFIG = "responsive.mongo.windowed.key.timestamp.first";
-  private static final boolean MONGO_WINDOWED_KEY_TIMESTAMP_FIRST_DEFAULT = false;
+  private static final boolean MONGO_WINDOWED_KEY_TIMESTAMP_FIRST_DEFAULT = true;
   private static final String MONGO_WINDOWED_KEY_TIMESTAMP_FIRST_DOC = "Whether to put the window start timestamp "
       + "first in the composite windowed key format for MongoDB. This can be toggled true/false to get better "
       + "performance depending on the density of unique keys per window, and should be experimented "
-      + "with for best results. However it is important to note that this cannot be changed for "
-      + "an active application. Messing with this can corrupt existing state!";
+      + "with for best results. Must be true for any application that uses range queries on window stores. "
+      + "It is also important to note that this cannot be changed for an active application -- flipping "
+      + "this can corrupt existing state.";
 
   public static final String WINDOW_BLOOM_FILTER_COUNT_CONFIG = "responsive.window.bloom.filter.count";
   private static final int WINDOW_BLOOM_FILTER_COUNT_DEFAULT = 0;

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoWindowedTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoWindowedTable.java
@@ -66,6 +66,9 @@ public class MongoWindowedTable implements RemoteWindowedTable<WriteModel<Window
 
   private static final UpdateOptions UPSERT_OPTIONS = new UpdateOptions().upsert(true);
 
+  // The "minimum" possible key when comparing bytewise, used to define range query bounds
+  private static final Bytes MIN_KEY = Bytes.wrap(new byte[0]);
+
   private final String name;
   private final SegmentPartitioner partitioner;
 
@@ -457,13 +460,37 @@ public class MongoWindowedTable implements RemoteWindowedTable<WriteModel<Window
   @Override
   public KeyValueIterator<WindowedKey, byte[]> fetchRange(
       final int kafkaPartition,
-      final Bytes fromKey,
-      final Bytes toKey,
+      final Bytes keyFrom,
+      final Bytes keyTo,
       final long timeFrom,
       final long timeTo
   ) {
-    throw new UnsupportedOperationException("fetchRange not yet supported for Mongo backends");
+    final List<KeyValueIterator<WindowedKey, byte[]>> segmentIterators = new LinkedList<>();
+    final var partitionSegments = kafkaPartitionToSegments.get(kafkaPartition);
 
+    for (final var segment : partitioner.range(kafkaPartition, timeFrom, timeTo)) {
+      final var segmentWindows = partitionSegments.segmentWindows.get(segment);
+
+      // Since we use a flat keyspace by concatenating the timestamp with the data key and have
+      // variable length data keys, it's impossible to request only valid data that's within
+      // the given bounds. Instead issue a broad request from the valid bounds and then post-filter
+      final var lowerBound = compositeKey(keyFrom, timeFrom);
+      final var upperBound = compositeKey(keyTo, timeTo);
+
+      final FindIterable<WindowDoc> fetchResults = segmentWindows.find(
+          Filters.and(
+              Filters.gte(WindowDoc.ID, lowerBound),
+              Filters.lte(WindowDoc.ID, upperBound))
+      );
+
+
+      segmentIterators.add(
+          Iterators.filterKv(
+              Iterators.kv(fetchResults.iterator(), MongoWindowedTable::windowFromDoc),
+              kv -> filterFetchRange(kv, timeFrom, timeTo, keyFrom, keyTo, timestampFirstOrder))
+      );
+    }
+    return Iterators.wrapped(segmentIterators);
   }
 
   @Override
@@ -483,7 +510,35 @@ public class MongoWindowedTable implements RemoteWindowedTable<WriteModel<Window
       final long timeFrom,
       final long timeTo
   ) {
-    throw new UnsupportedOperationException("fetchAll not yet supported for Mongo backends");
+    if (timestampFirstOrder) {
+      throw new UnsupportedOperationException("Range queries such as fetchAll require stores to be "
+                                                  + "configured with timestamp-first order");
+    }
+
+    final List<KeyValueIterator<WindowedKey, byte[]>> segmentIterators = new LinkedList<>();
+    final var partitionSegments = kafkaPartitionToSegments.get(kafkaPartition);
+
+    for (final var segment : partitioner.range(kafkaPartition, timeFrom, timeTo)) {
+      final var segmentWindows = partitionSegments.segmentWindows.get(segment);
+
+      // To avoid scanning the entire segment, we use the bytewise "minimum key" to start the scan
+      // at the lower time bound. Since there's no corresponding "maximum key" given the variable
+      // length keys, we have to set the upper bound at timeTo + 1, while using strict comparison
+      // (ie #lt rather than #lte) to exclude said upper bound
+      final var lowerBound = compositeKey(MIN_KEY, timeFrom);
+      final var upperBound = compositeKey(MIN_KEY, timeTo + 1);
+
+      final FindIterable<WindowDoc> fetchResults = segmentWindows.find(
+          Filters.and(
+              Filters.gte(WindowDoc.ID, lowerBound),
+              Filters.lt(WindowDoc.ID, upperBound))
+      );
+
+      segmentIterators.add(
+          Iterators.kv(fetchResults.iterator(), MongoWindowedTable::windowFromDoc)
+      );
+    }
+    return Iterators.wrapped(segmentIterators);
   }
 
   @Override
@@ -509,6 +564,23 @@ public class MongoWindowedTable implements RemoteWindowedTable<WriteModel<Window
 
   private static KeyValue<WindowedKey, byte[]> windowFromDoc(final WindowDoc windowDoc) {
     return new KeyValue<>(WindowDoc.windowedKey(windowDoc.id), windowDoc.value);
+  }
+
+  private static boolean filterFetchRange(
+      final WindowedKey windowedKey,
+      final long timeFrom,
+      final long timeTo,
+      final Bytes keyFrom,
+      final Bytes keyTo,
+      final boolean timestampFirstOrder
+  ) {
+    // If we use timestamp-first order, then the upper/lower bounds guarantee the timestamps are
+    // valid, so therefore we only need to filter out the invalid keys (and vice versa)
+    if (timestampFirstOrder) {
+      return windowedKey.key.compareTo(keyFrom) > 0 && windowedKey.key.compareTo(keyTo) < 0;
+    } else {
+      return windowedKey.windowStartMs > timeFrom && windowedKey.windowStartMs < timeTo;
+    }
   }
 
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoWindowedTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoWindowedTable.java
@@ -510,7 +510,7 @@ public class MongoWindowedTable implements RemoteWindowedTable<WriteModel<Window
       final long timeFrom,
       final long timeTo
   ) {
-    if (timestampFirstOrder) {
+    if (!timestampFirstOrder) {
       throw new UnsupportedOperationException("Range queries such as fetchAll require stores to be "
                                                   + "configured with timestamp-first order");
     }

--- a/kafka-client/src/test/java/dev/responsive/kafka/integration/StoreQueryIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/integration/StoreQueryIntegrationTest.java
@@ -201,7 +201,8 @@ public class StoreQueryIntegrationTest {
       pipeRecords(producer, inputTopic(), records);
 
       // Then:
-      //TODO
+      final var kvs = readOutput(outputTopic(), 0, 5, true, properties);
+      // TODO
     }
   }
 

--- a/kafka-client/src/test/java/dev/responsive/kafka/integration/StoreQueryIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/integration/StoreQueryIntegrationTest.java
@@ -17,6 +17,7 @@
 package dev.responsive.kafka.integration;
 
 import static dev.responsive.kafka.api.config.ResponsiveConfig.STORE_FLUSH_RECORDS_TRIGGER_CONFIG;
+import static dev.responsive.kafka.api.stores.ResponsiveWindowParams.window;
 import static dev.responsive.kafka.testutils.IntegrationTestUtils.createTopicsAndWait;
 import static dev.responsive.kafka.testutils.IntegrationTestUtils.pipeRecords;
 import static dev.responsive.kafka.testutils.IntegrationTestUtils.readOutput;
@@ -58,6 +59,7 @@ import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.Windowed;
 import org.apache.kafka.streams.processor.api.FixedKeyProcessor;
 import org.apache.kafka.streams.processor.api.FixedKeyProcessorContext;
 import org.apache.kafka.streams.processor.api.FixedKeyProcessorSupplier;
@@ -65,6 +67,7 @@ import org.apache.kafka.streams.processor.api.FixedKeyRecord;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.StoreBuilder;
+import org.apache.kafka.streams.state.WindowStore;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -74,7 +77,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 public class StoreQueryIntegrationTest {
 
   @RegisterExtension
-  static ResponsiveExtension EXTENSION = new ResponsiveExtension(StorageBackend.CASSANDRA);
+  static ResponsiveExtension EXTENSION = new ResponsiveExtension(StorageBackend.MONGO_DB);
 
   private static final String INPUT_TOPIC = "input";
   private static final String OUTPUT_TOPIC = "output";
@@ -178,6 +181,30 @@ public class StoreQueryIntegrationTest {
     }
   }
 
+  @Test
+  public void shouldAggregateAllWindowsInRangeQuery() throws Exception {
+    // Given:
+    final Map<String, Object> properties = getMutableProperties();
+    final KafkaProducer<String, String> producer = new KafkaProducer<>(properties);
+    try (final ResponsiveKafkaStreams streams = buildWindowStreams(properties, true)) {
+      startAppAndAwaitRunning(Duration.ofSeconds(10), streams);
+
+      final List<KeyValueTimestamp<String, String>> records = Arrays.asList(
+          new KeyValueTimestamp<>("A", "A", 0L),
+          new KeyValueTimestamp<>("b", "b", 1L),
+          new KeyValueTimestamp<>("C", "C", 2L),
+          new KeyValueTimestamp<>("d", "d", 3L),
+          new KeyValueTimestamp<>("E", "E", 4L)
+      );
+
+      // When:
+      pipeRecords(producer, inputTopic(), records);
+
+      // Then:
+      //TODO
+    }
+  }
+
   private ResponsiveKafkaStreams buildKVStreams(
       final Map<String, Object> properties,
       final boolean range
@@ -188,11 +215,34 @@ public class StoreQueryIntegrationTest {
 
     final StoreBuilder<KeyValueStore<String, String>> storeBuilder =
         ResponsiveStores.keyValueStoreBuilder(
-            ResponsiveStores.keyValueStore(ResponsiveKeyValueParams.keyValue(kvStoreName())),
+            ResponsiveStores.keyValueStore(ResponsiveKeyValueParams.keyValue(storeName())),
             Serdes.String(),
             Serdes.String());
     input
-        .processValues(new TransformerSupplier(range, storeBuilder), kvStoreName())
+        .processValues(new TransformerSupplier(false, range, storeBuilder), storeName())
+        .to(outputTopic());
+
+    return new ResponsiveKafkaStreams(builder.build(), properties);
+  }
+
+  private ResponsiveKafkaStreams buildWindowStreams(
+      final Map<String, Object> properties,
+      final boolean range
+  ) {
+    final StreamsBuilder builder = new StreamsBuilder();
+
+    final KStream<String, String> input = builder.stream(inputTopic());
+
+    final Duration windowSize = Duration.ofMillis(10L);
+    final Duration gracePeriod = Duration.ofMillis(100L);
+
+    final StoreBuilder<WindowStore<String, String>> storeBuilder =
+        ResponsiveStores.windowStoreBuilder(
+            ResponsiveStores.windowStoreSupplier(window(storeName(), windowSize, gracePeriod)),
+            Serdes.String(),
+            Serdes.String());
+    input
+        .processValues(new TransformerSupplier(true, range, storeBuilder), storeName())
         .to(outputTopic());
 
     return new ResponsiveKafkaStreams(builder.build(), properties);
@@ -200,17 +250,27 @@ public class StoreQueryIntegrationTest {
 
   private class TransformerSupplier implements FixedKeyProcessorSupplier<String, String, String> {
 
-    private final StoreBuilder<?> storeBuilder;
+    private final boolean windowed;
     private final boolean rangeQuery;
+    private final StoreBuilder<?> storeBuilder;
 
-    public TransformerSupplier(final boolean rangeQuery, final StoreBuilder<?> storeBuilder) {
+    public TransformerSupplier(
+        final boolean windowed,
+        final boolean rangeQuery,
+        final StoreBuilder<?> storeBuilder
+    ) {
+      this.windowed = windowed;
       this.rangeQuery = rangeQuery;
       this.storeBuilder = storeBuilder;
     }
 
     @Override
     public FixedKeyProcessor<String, String, String> get() {
-      return new CountingProcessor(rangeQuery);
+      if (windowed) {
+        return new CrossKeyWindowAggregator(rangeQuery);
+      } else {
+        return new CrossKeyKVAggregator(rangeQuery);
+      }
     }
 
     @Override
@@ -222,11 +282,56 @@ public class StoreQueryIntegrationTest {
     }
   }
 
-  private class CountingProcessor implements FixedKeyProcessor<String, String, String> {
+  private class CrossKeyWindowAggregator implements FixedKeyProcessor<String, String, String> {
 
     private final boolean rangeQuery;
 
-    public CountingProcessor(final boolean rangeQuery) {
+    public CrossKeyWindowAggregator(final boolean rangeQuery) {
+      this.rangeQuery = rangeQuery;
+    }
+
+    private WindowStore<String, String> windowStore;
+    private FixedKeyProcessorContext<String, String> context;
+
+    @Override
+    public void init(final FixedKeyProcessorContext<String, String> context) {
+      FixedKeyProcessor.super.init(context);
+      this.windowStore = context.getStateStore(storeName());
+      this.context = context;
+    }
+
+    @Override
+    public void process(final FixedKeyRecord<String, String> record) {
+      final StringBuilder builder = new StringBuilder();
+
+      KeyValueIterator<Windowed<String>, String> iterator = null;
+      try {
+
+        if (rangeQuery) {
+          iterator = windowStore.fetch("A", "Z", 0L, 5L);
+        } else {
+          iterator = windowStore.all();
+        }
+
+        while (iterator.hasNext()) {
+          builder.append(iterator.next().value);
+        }
+        builder.append(record.value());
+
+      } finally {
+        iterator.close();
+      }
+
+      windowStore.put(record.key(), record.value(), record.timestamp());
+      context.forward(record.withValue(builder.toString()));
+    }
+  }
+
+  private class CrossKeyKVAggregator implements FixedKeyProcessor<String, String, String> {
+
+    private final boolean rangeQuery;
+
+    public CrossKeyKVAggregator(final boolean rangeQuery) {
       this.rangeQuery = rangeQuery;
     }
 
@@ -236,7 +341,7 @@ public class StoreQueryIntegrationTest {
     @Override
     public void init(final FixedKeyProcessorContext<String, String> context) {
       FixedKeyProcessor.super.init(context);
-      this.kvStore = context.getStateStore(kvStoreName());
+      this.kvStore = context.getStateStore(storeName());
       this.context = context;
     }
 
@@ -267,8 +372,8 @@ public class StoreQueryIntegrationTest {
     }
   }
 
-  private String kvStoreName() {
-    return name + "-kv-store";
+  private String storeName() {
+    return name + "-store";
   }
 
   private Map<String, Object> getMutableProperties() {


### PR DESCRIPTION
Finish implementation for the remaining range queries of MongoWindowedTable. 

The two queries take a slightly different approach, as documented in code comments for each. Basically for the all-keys time range scan we can identify exact borders and issue a precise range query for only valid data. However for the key and time range scan, we have to scan over all keys and post-filter them when timestamp-first order is used (and vice versa for key-first order). This is due to the byte layout of the composite primary keys, and the fact that key bytes are variable length
