### PR TITLE
add an option for migration mode and avoid unnecessary ttl writes

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
@@ -225,6 +225,12 @@ public class ResponsiveConfig extends AbstractConfig {
       + "lookups but requires more heap memory";
 
 
+  public static final String RESPONSIVE_MODE = "responsive.mode";
+  public static final String RESPONSIVE_MODE_DEFAULT = ResponsiveMode.RUN.name();
+  public static final String RESPONSIVE_MODE_DOC = "Determines the mode the Responsive application " +
+      "runs in. When set to RUN, runs the Kafka Streams app. When set to MIGRATE, runs app" +
+      " migration.";
+
   // ------------------ StreamsConfig overrides ----------------------
 
   // These configuration values are required by Responsive, and a ConfigException will
@@ -435,6 +441,17 @@ public class ResponsiveConfig extends AbstractConfig {
                   .toArray(String[]::new)),
           Importance.MEDIUM,
           WRITE_CONSISTENCY_LEVEL_DOC
+      ).define(
+          RESPONSIVE_MODE,
+          Type.STRING,
+          RESPONSIVE_MODE_DEFAULT,
+          ConfigDef.CaseInsensitiveValidString.in(
+              Arrays.stream(ResponsiveMode.values())
+                  .map(Enum::name)
+                  .toArray(String[]::new)
+          ),
+          Importance.LOW,
+          RESPONSIVE_MODE_DOC
       );
 
   /**

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
@@ -227,9 +227,9 @@ public class ResponsiveConfig extends AbstractConfig {
 
   public static final String RESPONSIVE_MODE = "responsive.mode";
   public static final String RESPONSIVE_MODE_DEFAULT = ResponsiveMode.RUN.name();
-  public static final String RESPONSIVE_MODE_DOC = "Determines the mode the Responsive application " +
-      "runs in. When set to RUN, runs the Kafka Streams app. When set to MIGRATE, runs app" +
-      " migration.";
+  public static final String RESPONSIVE_MODE_DOC = "Determines the mode the Responsive application "
+      + "runs in. When set to RUN, runs the Kafka Streams app. When set to MIGRATE, runs app"
+      + " migration.";
 
   // ------------------ StreamsConfig overrides ----------------------
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveMode.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveMode.java
@@ -1,0 +1,6 @@
+package dev.responsive.kafka.api.config;
+
+public enum ResponsiveMode {
+  MIGRATE,
+  RUN
+}

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/stores/ResponsiveKeyValueParams.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/stores/ResponsiveKeyValueParams.java
@@ -19,7 +19,6 @@ package dev.responsive.kafka.api.stores;
 import dev.responsive.kafka.internal.stores.SchemaTypes.KVSchema;
 import dev.responsive.kafka.internal.utils.TableName;
 import java.time.Duration;
-import java.time.Instant;
 import java.util.Optional;
 import javax.annotation.Nullable;
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/stores/ResponsiveKeyValueParams.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/stores/ResponsiveKeyValueParams.java
@@ -19,6 +19,7 @@ package dev.responsive.kafka.api.stores;
 import dev.responsive.kafka.internal.stores.SchemaTypes.KVSchema;
 import dev.responsive.kafka.internal.utils.TableName;
 import java.time.Duration;
+import java.time.Instant;
 import java.util.Optional;
 import javax.annotation.Nullable;
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/PartitionedOperations.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/PartitionedOperations.java
@@ -23,6 +23,7 @@ import static org.apache.kafka.streams.processor.internals.ProcessorContextUtils
 import static org.apache.kafka.streams.processor.internals.ProcessorContextUtils.changelogFor;
 
 import dev.responsive.kafka.api.config.ResponsiveConfig;
+import dev.responsive.kafka.api.config.ResponsiveMode;
 import dev.responsive.kafka.api.stores.ResponsiveKeyValueParams;
 import dev.responsive.kafka.internal.db.BatchFlusher;
 import dev.responsive.kafka.internal.db.BytesKeySpec;
@@ -35,7 +36,10 @@ import dev.responsive.kafka.internal.metrics.ResponsiveRestoreListener;
 import dev.responsive.kafka.internal.utils.Result;
 import dev.responsive.kafka.internal.utils.SessionClients;
 import dev.responsive.kafka.internal.utils.TableName;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Collection;
+import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.concurrent.TimeoutException;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -61,6 +65,8 @@ public class PartitionedOperations implements KeyValueOperations {
   private final ResponsiveStoreRegistry storeRegistry;
   private final ResponsiveStoreRegistration registration;
   private final ResponsiveRestoreListener restoreListener;
+  private final boolean migrationMode;
+  private final long startingTimestamp;
 
   public static PartitionedOperations create(
       final TableName name,
@@ -127,6 +133,14 @@ public class PartitionedOperations implements KeyValueOperations {
     );
     storeRegistry.registerStore(registration);
 
+    final boolean migrationMode = config.getString(ResponsiveConfig.RESPONSIVE_MODE)
+        .equals(ResponsiveMode.MIGRATE.name());
+    long startingTimestamp = -1;
+    final Optional<Duration> ttl = params.timeToLive();
+    if (migrationMode && ttl.isPresent()) {
+      startingTimestamp = Instant.now().minus(ttl.get()).toEpochMilli();
+    }
+
     return new PartitionedOperations(
         log,
         context,
@@ -136,7 +150,9 @@ public class PartitionedOperations implements KeyValueOperations {
         changelog,
         storeRegistry,
         registration,
-        sessionClients.restoreListener()
+        sessionClients.restoreListener(),
+        migrationMode,
+        startingTimestamp
     );
   }
 
@@ -192,7 +208,9 @@ public class PartitionedOperations implements KeyValueOperations {
       final TopicPartition changelog,
       final ResponsiveStoreRegistry storeRegistry,
       final ResponsiveStoreRegistration registration,
-      final ResponsiveRestoreListener restoreListener
+      final ResponsiveRestoreListener restoreListener,
+      final boolean migrationMode,
+      final long startingTimestamp
   ) {
     this.log = log;
     this.context = context;
@@ -203,10 +221,17 @@ public class PartitionedOperations implements KeyValueOperations {
     this.storeRegistry = storeRegistry;
     this.registration = registration;
     this.restoreListener = restoreListener;
+    this.migrationMode = migrationMode;
+    this.startingTimestamp = startingTimestamp;
   }
 
   @Override
   public void put(final Bytes key, final byte[] value) {
+    if (migratingAndTimestampTooEarly()) {
+      // we are bootstrapping a store. Only apply the write if the timestamp
+      // is fresher than the starting timestamp
+      return;
+    }
     buffer.put(key, value, context.timestamp());
   }
 
@@ -304,5 +329,17 @@ public class PartitionedOperations implements KeyValueOperations {
         .timeToLive()
         .map(ttl -> context.timestamp() - ttl.toMillis())
         .orElse(-1L);
+  }
+
+  private boolean migratingAndTimestampTooEarly() {
+    if (!migrationMode) {
+      return false;
+    }
+    if (startingTimestamp > 0) {
+      // we are bootstrapping a store. Only apply the write if the timestamp
+      // is fresher than the starting timestamp
+      return context.timestamp() < startingTimestamp;
+    }
+    return false;
   }
 }


### PR DESCRIPTION
This patch starts the work to support running responsive in "migrate" mode,
which will be used to migrate apps to Responsive, or to a different Responsive
store. For now, all its used to do is enable a write optimization for TTL stores,
where we don't write records that are older than the TTL when the migration
started.