### PR TITLE
add changelog migration tooling

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/bootstrap/ChangelogMigrationConfig.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/bootstrap/ChangelogMigrationConfig.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.kafka.bootstrap;
+
+import java.util.Map;
+import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.common.config.ConfigDef;
+
+public class ChangelogMigrationConfig extends AbstractConfig {
+
+  // ----------------- general configurations ---------------------------
+
+  public static final String CHANGELOG_TOPIC_CONFIG = "responsive.migration.changelog.topic";
+  private static final String CHANGELOG_TOPIC_DOC = "The changelog from the store to migrate.";
+
+  public static final String TABLE_NAME_CONFIG = "responsive.migration.table.name";
+  private static final String TABLE_NAME_DOC = "The table name. This should match the table "
+      + "name in the original application that is being migrated.";
+
+  private static final ConfigDef CONFIG_DEF = new ConfigDef()
+      .define(
+          CHANGELOG_TOPIC_CONFIG,
+          ConfigDef.Type.STRING,
+          ConfigDef.Importance.HIGH,
+          CHANGELOG_TOPIC_DOC
+      ).define(
+          TABLE_NAME_CONFIG,
+          ConfigDef.Type.STRING,
+          ConfigDef.Importance.HIGH,
+          TABLE_NAME_DOC
+      );
+
+  public ChangelogMigrationConfig(final Map<?, ?> originals) {
+    super(CONFIG_DEF, originals);
+  }
+
+}

--- a/kafka-client/src/main/java/dev/responsive/kafka/bootstrap/ChangelogMigrationTool.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/bootstrap/ChangelogMigrationTool.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.kafka.bootstrap;
+
+import static dev.responsive.kafka.bootstrap.ChangelogMigrationConfig.CHANGELOG_TOPIC_CONFIG;
+import static dev.responsive.kafka.bootstrap.ChangelogMigrationConfig.TABLE_NAME_CONFIG;
+
+import dev.responsive.kafka.api.ResponsiveKafkaStreams;
+import dev.responsive.kafka.api.config.ResponsiveConfig;
+import dev.responsive.kafka.api.config.ResponsiveMode;
+import dev.responsive.kafka.api.stores.ResponsiveStores;
+import java.time.Instant;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.kstream.KTable;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.processor.api.Processor;
+import org.apache.kafka.streams.processor.api.ProcessorContext;
+import org.apache.kafka.streams.processor.api.Record;
+
+public class ChangelogMigrationTool {
+
+  private static final org.slf4j.Logger LOG =
+      org.slf4j.LoggerFactory.getLogger(ChangelogMigrationTool.class);
+
+  private final ResponsiveKafkaStreams streams;
+
+  public ChangelogMigrationTool(final Properties properties) {
+    properties.put(StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG, StreamsConfig.OPTIMIZE);
+    properties.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+    properties.put(ResponsiveConfig.RESPONSIVE_MODE, ResponsiveMode.MIGRATE.name());
+
+    // it is possible to push this number higher, but this is a relatively safe
+    // number and still gets decent performance -- use putIfAbsent in case the
+    // customer wants to override this to push more performance at the risk of
+    // stability
+    properties.putIfAbsent(ResponsiveConfig.STORE_FLUSH_RECORDS_TRIGGER_CONFIG, 10_000);
+
+    final ChangelogMigrationConfig config = new ChangelogMigrationConfig(properties);
+    this.streams = buildStreams(config, properties);
+  }
+
+  public ResponsiveKafkaStreams getStreams() {
+    return streams;
+  }
+
+  private ResponsiveKafkaStreams buildStreams(
+      final ChangelogMigrationConfig config,
+      final Properties properties
+  ) {
+    final StreamsBuilder builder = new StreamsBuilder();
+    final String source = config.getString(CHANGELOG_TOPIC_CONFIG);
+    final String tableName = config.getString(TABLE_NAME_CONFIG);
+    final AtomicLong processed = new AtomicLong();
+
+    final KTable<byte[], byte[]> table =
+        builder.table(
+            source,
+            Materialized.as(ResponsiveStores.factStore(tableName))
+    );
+
+    table
+        .toStream()
+        .process(() -> (new Processor<byte[], byte[], byte[], byte[]>() {
+          private ProcessorContext<byte[], byte[]> context;
+
+          @Override
+          public void init(final ProcessorContext<byte[], byte[]> context) {
+            this.context = context;
+          }
+
+          @Override
+          public void process(final Record<byte[], byte[]> record) {
+            if (processed.incrementAndGet() % 10_000 == 0) {
+              final long ms = context.currentStreamTimeMs();
+              LOG.info("Migration has restored task {} up until stream time {}",
+                  context.taskId(),
+                  Instant.ofEpochMilli(ms));
+            }
+          }
+        }));
+
+    return new ResponsiveKafkaStreams(builder.build(properties), properties);
+  }
+}

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/PartitionedOperations.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/PartitionedOperations.java
@@ -246,6 +246,15 @@ public class PartitionedOperations implements KeyValueOperations {
 
   @Override
   public byte[] get(final Bytes key) {
+    if (migrationMode) {
+      // we don't want to issue gets in migration mode since
+      // we're just reading from the changelog. the problem is
+      // that materialized tables issue get() on every put() to
+      // send the "undo" data downstream -- we intercept all gets
+      // and just return null
+      return null;
+    }
+
     // try the buffer first, it acts as a local cache
     // but this is also necessary for correctness as
     // it is possible that the data is either uncommitted

--- a/kafka-client/src/test/java/dev/responsive/kafka/bootstrap/ChangelogMigrationToolTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/bootstrap/ChangelogMigrationToolTest.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.kafka.bootstrap;
+
+import static dev.responsive.kafka.api.config.ResponsiveConfig.STORE_FLUSH_RECORDS_TRIGGER_CONFIG;
+import static dev.responsive.kafka.testutils.IntegrationTestUtils.createTopicsAndWait;
+import static dev.responsive.kafka.testutils.IntegrationTestUtils.pipeInput;
+import static dev.responsive.kafka.testutils.IntegrationTestUtils.readOutput;
+import static dev.responsive.kafka.testutils.IntegrationTestUtils.startAppAndAwaitRunning;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.AUTO_OFFSET_RESET_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.APPLICATION_ID_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.COMMIT_INTERVAL_MS_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.NUM_STREAM_THREADS_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.OPTIMIZE;
+import static org.apache.kafka.streams.StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.TOPOLOGY_OPTIMIZATION_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.consumerPrefix;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItems;
+
+import dev.responsive.kafka.api.ResponsiveKafkaStreams;
+import dev.responsive.kafka.api.config.StorageBackend;
+import dev.responsive.kafka.testutils.ResponsiveConfigParam;
+import dev.responsive.kafka.testutils.ResponsiveExtension;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Random;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.common.serialization.LongDeserializer;
+import org.apache.kafka.common.serialization.LongSerializer;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.Materialized;
+import org.apache.kafka.streams.state.Stores;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+// this test can be run manually to verify Cluster Bootstrapping behavior
+@Disabled
+class ChangelogMigrationToolTest {
+
+  @RegisterExtension
+  static ResponsiveExtension EXTENSION = new ResponsiveExtension(StorageBackend.CASSANDRA);
+
+  private static final String INPUT_TOPIC = "input";
+  private static final String OUTPUT_TOPIC = "output";
+
+  private final Map<String, Object> responsiveProps = new HashMap<>();
+
+  private String name;
+  private Admin admin;
+
+  @BeforeEach
+  public void before(
+      final TestInfo info,
+      final Admin admin,
+      @ResponsiveConfigParam final Map<String, Object> responsiveProps
+  ) {
+    // add displayName to name to account for parameterized tests
+    final Random random = new Random();
+    name = info.getDisplayName().replace("()", "") + random.nextInt();
+    ScheduledExecutorService executor = new ScheduledThreadPoolExecutor(2);
+
+    this.responsiveProps.putAll(responsiveProps);
+
+    this.admin = admin;
+    createTopicsAndWait(admin, Map.of(inputTopic(), 2, outputTopic(), 1));
+  }
+
+  @AfterEach
+  public void after() {
+    admin.deleteTopics(List.of(inputTopic(), outputTopic()));
+  }
+
+  private String inputTopic() {
+    return name + "." + INPUT_TOPIC;
+  }
+
+  private String outputTopic() {
+    return name + "." + OUTPUT_TOPIC;
+  }
+
+  @Test
+  public void test() throws Exception {
+    final Map<String, Object> properties = getProperties();
+    final KafkaProducer<Long, Long> producer = new KafkaProducer<>(properties);
+
+    // Run A Normal KS Application with rocksDB
+    try (final ResponsiveKafkaStreams streams = buildRocksBased(properties)) {
+      startAppAndAwaitRunning(Duration.ofSeconds(10), streams);
+      for (int i = 0; i < 1000; i++) {
+        pipeInput(inputTopic(), 2, producer, System::currentTimeMillis, 0, 10, 0, 1);
+      }
+
+      // just verify all 1000 were written
+      readOutput(outputTopic(), 0, 1000, true, properties);
+    }
+
+    // Run the bootstrap application with Cassandra
+    final Properties bootstrapProps = new Properties();
+    bootstrapProps.putAll(getProperties());
+    bootstrapProps.put(ChangelogMigrationConfig.CHANGELOG_TOPIC_CONFIG, name + "-count-changelog");
+    bootstrapProps.put(ChangelogMigrationConfig.TABLE_NAME_CONFIG, name + "-count");
+    final ChangelogMigrationTool app =
+        new ChangelogMigrationTool(bootstrapProps);
+    startAppAndAwaitRunning(Duration.ofSeconds(120), app.getStreams());
+
+    // Manually Check Cassandra
+    Thread.sleep(100000);
+
+    app.getStreams().close();
+    app.getStreams().cleanUp();
+  }
+
+  private ResponsiveKafkaStreams buildRocksBased(final Map<String, Object> properties) {
+    final StreamsBuilder builder = new StreamsBuilder();
+
+    final KStream<Long, Long> input = builder.stream(inputTopic());
+    input
+        .groupByKey()
+        .count(Materialized.as(Stores.persistentKeyValueStore("count")))
+        .toStream()
+        .to(outputTopic());
+
+    return new ResponsiveKafkaStreams(builder.build(), properties);
+  }
+
+  private Map<String, Object> getProperties() {
+    final Map<String, Object> properties = new HashMap<>(responsiveProps);
+
+    properties.put(KEY_SERIALIZER_CLASS_CONFIG, LongSerializer.class);
+    properties.put(VALUE_SERIALIZER_CLASS_CONFIG, LongSerializer.class);
+    properties.put(KEY_DESERIALIZER_CLASS_CONFIG, LongDeserializer.class);
+    properties.put(VALUE_DESERIALIZER_CLASS_CONFIG, LongDeserializer.class);
+
+    properties.put(APPLICATION_ID_CONFIG, name);
+    properties.put(DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.LongSerde.class.getName());
+    properties.put(DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.LongSerde.class.getName());
+    properties.put(NUM_STREAM_THREADS_CONFIG, 1);
+    properties.put(STATESTORE_CACHE_MAX_BYTES_CONFIG, 0);
+    properties.put(STORE_FLUSH_RECORDS_TRIGGER_CONFIG, 1);
+    properties.put(COMMIT_INTERVAL_MS_CONFIG, 1);
+    properties.put(TOPOLOGY_OPTIMIZATION_CONFIG, OPTIMIZE);
+    properties.put(AUTO_OFFSET_RESET_CONFIG, "earliest");
+
+    properties.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 1);
+    properties.put(consumerPrefix(ConsumerConfig.METADATA_MAX_AGE_CONFIG), "1000");
+    properties.put(consumerPrefix(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG), "earliest");
+
+    return properties;
+  }
+
+}


### PR DESCRIPTION
Testing Done:
1. The integration test here allows us to manually verify that the migration populated data into what we expected and that there were no additional topics created
2. Deployed to an EKS cluster with a VPC Peered Cassandra cluster and migrated from a Mongo-backed application to Cassandra while the application was still running.

We still need to figure out the best way to deliver this.