### PR TITLE
avoid test NPE [minor]

### DIFF
--- a/kafka-client/src/test/java/dev/responsive/kafka/integration/TablePartitionerIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/integration/TablePartitionerIntegrationTest.java
@@ -190,18 +190,9 @@ public class TablePartitionerIntegrationTest {
 
       for (long tp = 0; tp < 32; ++tp) {
         final var kBytes = Bytes.wrap(serializer.serialize("", tp));
-        assertThat(
-            deserializer.deserialize(
-                "foo",
-                // these store ValueAndTimestamp, so we need to just pluck the last 8 bytes
-                Arrays.copyOfRange(
-                    table.get(
-                        (int) (tp % NUM_PARTITIONS_INPUT),
-                        kBytes,
-                        MIN_VALID_TS),
-                    8,
-                    16)),
-            is(100L));
+        final byte[] valBytes = table.get((int) tp % NUM_PARTITIONS_INPUT, kBytes, MIN_VALID_TS);
+        final Long val = deserializer.deserialize("foo", Arrays.copyOfRange(valBytes, 8, 16));
+        assertThat(val, is(100L));
       }
     }
   }
@@ -249,23 +240,14 @@ public class TablePartitionerIntegrationTest {
       assertThat(offset0, is(notNullValue()));
       assertThat(offset1, is(notNullValue()));
 
-      // throws because it doesn't exist
       Assertions.assertEquals(table.fetchOffset(2), NO_COMMITTED_OFFSET);
 
       // these store ValueAndTimestamp, so we need to just pluck the last 8 bytes
       for (long k = 0; k < 32; k++) {
         final var kBytes = Bytes.wrap(serializer.serialize("", k));
-        assertThat(
-            deserializer.deserialize(
-                "foo",
-                Arrays.copyOfRange(
-                    table.get(
-                        (int) k % NUM_PARTITIONS_INPUT,
-                        kBytes,
-                        MIN_VALID_TS),
-                    8,
-                    16)),
-            is(100L));
+        final byte[] valBytes = table.get((int) k % NUM_PARTITIONS_INPUT, kBytes, MIN_VALID_TS);
+        final Long val = deserializer.deserialize("foo", Arrays.copyOfRange(valBytes, 8, 16));
+        assertThat(val, is(100L));
       }
     }
   }

--- a/kafka-client/src/test/java/dev/responsive/kafka/integration/TablePartitionerIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/integration/TablePartitionerIntegrationTest.java
@@ -226,7 +226,7 @@ public class TablePartitionerIntegrationTest {
               .boxed()
               .map(k -> new KeyValue<>(k, 100L))
               .collect(Collectors.toSet()),
-          true,
+          false,
           properties
       );
       final String cassandraName = new TableName(storeName).tableName();
@@ -299,7 +299,7 @@ public class TablePartitionerIntegrationTest {
               .boxed()
               .map(k -> new KeyValue<>(k, 100L))
               .collect(Collectors.toSet()),
-          true,
+          false,
           properties
       );
       final String cassandraName = new TableName(storeName).tableName();


### PR DESCRIPTION
UPDATE: I think I figured out the test flakiness! It was previously reading uncommitted so there was a possibility that the data was pushed downstream but not yet committed.

----------

This test is flaky (need to figure out why) but anyway we should avoid having an NPE:
```

  dev.responsive.kafka.integration.TablePartitionerIntegrationTest

    ✔ shouldFlushToRemoteTableWithSubpartitions() (6.5s)
    ✘ shouldFlushToRemoteTableWithoutSubpartitions() (5.8s)

      java.lang.NullPointerException
          at dev.responsive.kafka.integration.TablePartitionerIntegrationTest.shouldFlushToRemoteTableWithoutSubpartitions(TablePartitionerIntegrationTest.java:261)
```