### PR TITLE
first pass at supporting migrating by setting a config

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/api/stores/ResponsiveKeyValueBytesStoreSupplier.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/stores/ResponsiveKeyValueBytesStoreSupplier.java
@@ -17,6 +17,7 @@
 package dev.responsive.kafka.api.stores;
 
 import dev.responsive.kafka.internal.stores.ResponsiveKeyValueStore;
+import dev.responsive.kafka.internal.stores.StoreAccumulator;
 import java.util.Locale;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
@@ -28,6 +29,7 @@ public class ResponsiveKeyValueBytesStoreSupplier implements KeyValueBytesStoreS
 
   public ResponsiveKeyValueBytesStoreSupplier(final ResponsiveKeyValueParams params) {
     this.params = params;
+    StoreAccumulator.INSTANCE.register(this);
   }
 
   @Override

--- a/kafka-client/src/main/java/dev/responsive/kafka/bootstrap/EmbeddedChangelogMigrationRunner.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/bootstrap/EmbeddedChangelogMigrationRunner.java
@@ -1,0 +1,101 @@
+package dev.responsive.kafka.bootstrap;
+
+import dev.responsive.kafka.api.ResponsiveKafkaStreams;
+import dev.responsive.kafka.api.config.ResponsiveConfig;
+import dev.responsive.kafka.api.config.ResponsiveMode;
+import dev.responsive.kafka.api.stores.ResponsiveKeyValueBytesStoreSupplier;
+import dev.responsive.kafka.internal.stores.StoreAccumulator;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.TopologyDescription;
+import org.apache.kafka.streams.TopologyDescription.Node;
+import org.apache.kafka.streams.TopologyDescription.Processor;
+import org.apache.kafka.streams.TopologyDescription.Subtopology;
+import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
+import org.apache.kafka.streams.processor.internals.ProcessorContextUtils;
+import org.apache.kafka.streams.processor.internals.ProcessorStateManager;
+import org.apache.kafka.streams.processor.internals.namedtopology.NamedTopology;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class EmbeddedChangelogMigrationRunner {
+  private static final Logger LOG = LoggerFactory.getLogger(EmbeddedChangelogMigrationRunner.class);
+
+  private EmbeddedChangelogMigrationRunner() {
+  }
+
+  public static void runMigration(
+      final ResponsiveConfig responsiveConfig,
+      final String applicationId,
+      final Topology topology
+  ) {
+    final var kvBytesStores = StoreAccumulator.INSTANCE.getRegisteredKeyValueBytesStoreSuppliers();
+    if (kvBytesStores.size() != 1) {
+      throw new IllegalStateException("migration only supported for a single state store");
+    }
+    final ResponsiveKeyValueBytesStoreSupplier supplier = kvBytesStores.get(0);
+    final String storeName = supplier.name();
+    validateStoreIsNotSource(storeName, topology);
+    final Properties properties = new Properties();
+    properties.putAll(responsiveConfig.originals());
+    final String changelogTopic = changelogFor(
+        responsiveConfig.originals(),
+        applicationId,
+        storeName,
+        topology instanceof NamedTopology ? ((NamedTopology) topology).name() : null
+    );
+    final ChangelogMigrationTool tool = new ChangelogMigrationTool(
+        properties,
+        supplier,
+        changelogTopic
+    );
+    properties.put(ResponsiveConfig.RESPONSIVE_MODE, ResponsiveMode.RUN.name());
+    properties.put(StreamsConfig.APPLICATION_ID_CONFIG, applicationId + "-migrate");
+    final ResponsiveKafkaStreams app = tool.buildStreams();
+    final CountDownLatch closed = new CountDownLatch(1);
+    Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+      app.close(Duration.ofMinutes(5));
+      closed.countDown();
+    }));
+    LOG.info("starting bootstrap application for store {}", storeName);
+    app.start();
+    try {
+      LOG.info("blocking until JVM is shut down");
+      closed.await();
+    } catch (final InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static void validateStoreIsNotSource(final String storeName, final Topology topology) {
+    final TopologyDescription desc = topology.describe();
+    for (final Subtopology st : desc.subtopologies()) {
+      for (final Node n : st.nodes()) {
+        if (n instanceof Processor) {
+          final Processor processor = (Processor) n;
+          if (processor.stores().contains(storeName)) {
+            LOG.info("found store with name {} in processor {}", storeName, processor.name());
+            return;
+          }
+        }
+      }
+    }
+    throw new RuntimeException("Could not find processor with store. " +
+        "Source and global stores not supported with embedded migration");
+  }
+
+  private static String changelogFor(
+      final Map<String, Object> configs,
+      final String applicationId,
+      final String storeName,
+      final String topologyName
+  ) {
+    final String prefix = ProcessorContextUtils.getPrefix(configs, applicationId);
+    return ProcessorStateManager.storeChangelogTopic(prefix, storeName, topologyName);
+  }
+}

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/StoreAccumulator.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/StoreAccumulator.java
@@ -1,0 +1,26 @@
+package dev.responsive.kafka.internal.stores;
+
+import com.google.common.collect.ImmutableList;
+import dev.responsive.kafka.api.stores.ResponsiveKeyValueBytesStoreSupplier;
+import java.util.LinkedList;
+import java.util.List;
+import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
+import org.apache.kafka.streams.state.StoreSupplier;
+
+public class StoreAccumulator {
+  public static final StoreAccumulator INSTANCE = new StoreAccumulator();
+
+  private final List<ResponsiveKeyValueBytesStoreSupplier> registeredKeyValueBytesStoreSuppliers
+      = new LinkedList<>();
+
+  private StoreAccumulator() {
+  }
+
+  public void register(final ResponsiveKeyValueBytesStoreSupplier instance) {
+    registeredKeyValueBytesStoreSuppliers.add(instance);
+  }
+
+  public List<ResponsiveKeyValueBytesStoreSupplier> getRegisteredKeyValueBytesStoreSuppliers() {
+    return ImmutableList.copyOf(registeredKeyValueBytesStoreSuppliers);
+  }
+}

--- a/kafka-client/src/test/java/dev/responsive/kafka/bootstrap/ChangelogMigrationToolIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/bootstrap/ChangelogMigrationToolIntegrationTest.java
@@ -147,7 +147,7 @@ class ChangelogMigrationToolIntegrationTest {
     final int numKeys = 100;
     final int numEvents = 1000;
 
-    final var params = ResponsiveKeyValueParams.keyValue(tableName);
+    final var params = ResponsiveStores.keyValueStore(tableName);
 
     final Map<String, Object> baseProps = getProperties();
     final Properties bootProps = new Properties();
@@ -172,7 +172,8 @@ class ChangelogMigrationToolIntegrationTest {
     // 2: Run the changelog migration tool to bootstrap the new Cassandra table
     final CountDownLatch processedAllRecords = new CountDownLatch(numEvents);
     final Consumer<Record<byte[], byte[]>> countdown = r -> processedAllRecords.countDown();
-    try (final var app = new ChangelogMigrationTool(bootProps, params, countdown).buildStreams()) {
+    try (final var app
+             = new ChangelogMigrationTool(bootProps, params, changelog, countdown).buildStreams()) {
       LOG.info("Awaiting for Bootstrapping application to start");
       startAppAndAwaitRunning(Duration.ofSeconds(120), app);
 
@@ -218,7 +219,7 @@ class ChangelogMigrationToolIntegrationTest {
     final int numKeys = 100;
     final int numEvents = 200;
 
-    final var params = ResponsiveKeyValueParams.fact(tableName);
+    final var params = ResponsiveStores.factStore(tableName);
 
     final Map<String, Object> baseProps = getProperties();
     final Properties bootProps = new Properties();
@@ -243,7 +244,8 @@ class ChangelogMigrationToolIntegrationTest {
     // 2: Run the changelog migration tool to bootstrap the new Cassandra table
     final CountDownLatch processedAllRecords = new CountDownLatch(numKeys);
     final Consumer<Record<byte[], byte[]>> countdown = r -> processedAllRecords.countDown();
-    final ChangelogMigrationTool app = new ChangelogMigrationTool(bootProps, params, countdown);
+    final ChangelogMigrationTool app
+        = new ChangelogMigrationTool(bootProps, params, changelog, countdown);
 
     LOG.info("Awaiting for Bootstrapping application to start");
     try (final var migrationApp = app.buildStreams()) {


### PR DESCRIPTION
This is a first pass at supporting migrating by setting a config. When the config is on, ResponsiveKafkaStreams runs migration instead of the application.

The migration requires discovering the set of stores. This is maintained in a singleton thats updated by the store supplier constructor.

Currently we only support a single non-source store