### PR TITLE
use pr # instead of branch name for pulumi stack

### DIFF
--- a/.github/workflows/github-pr.yaml
+++ b/.github/workflows/github-pr.yaml
@@ -68,16 +68,13 @@ jobs:
         with:
           install_only: true
 
-      - name: "Extract branch name"
-        shell: bash
-        run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
-
       - name: "Run Smoke Test"
         run: |
           sindri/scripts/update-versions -u -s responsiveOperator -e local -i responsive-operator:`./gradlew operator:cV | grep Project.version | sed 's/Project version: //'`
           sindri/scripts/update-client-versions -s main -p false -i simple-example -t `./gradlew kafka-client:cV  | grep "Project version" | sed 's/Project version: //'`
-          sindri/scripts/run-smoke-test -l -w system-tests-pub-${GITHUB_HEAD_REF} -s main
+          sindri/scripts/run-smoke-test -l -w system-tests-pub-pr-${PR_NUMBER} -s main
         env:
+            PR_NUMBER: ${{ github.event.number }}
             DD_SERVICE: "https://us5.datadoghq.com/"
             DD_API_KEY: ${{ secrets.DD_API_KEY }}
             PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}


### PR DESCRIPTION
```
 Created stack 'system-tests-pub-pr-242'
Stack file exists. Won't initialize.
Previewing refresh (system-tests-pub-pr-242):
```