### PR TITLE
fix restoration for changelogs that dont start at offset 0

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/PartitionedOperations.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/PartitionedOperations.java
@@ -18,6 +18,7 @@ package dev.responsive.kafka.internal.stores;
 
 import static dev.responsive.kafka.internal.config.InternalSessionConfigs.loadSessionClients;
 import static dev.responsive.kafka.internal.config.InternalSessionConfigs.loadStoreRegistry;
+import static dev.responsive.kafka.internal.stores.ResponsiveStoreRegistration.NO_COMMITTED_OFFSET;
 import static dev.responsive.kafka.internal.utils.StoreUtil.numPartitionsForKafkaTopic;
 import static org.apache.kafka.streams.processor.internals.ProcessorContextUtils.asInternalProcessorContext;
 import static org.apache.kafka.streams.processor.internals.ProcessorContextUtils.changelogFor;
@@ -42,6 +43,7 @@ import java.time.Instant;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.OptionalLong;
 import java.util.concurrent.TimeoutException;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.TopicPartition;
@@ -129,7 +131,9 @@ public class PartitionedOperations implements KeyValueOperations {
     final var registration = new ResponsiveStoreRegistration(
         name.kafkaName(),
         changelog,
-        restoreStartOffset == -1 ? 0 : restoreStartOffset,
+        restoreStartOffset == NO_COMMITTED_OFFSET
+            ? OptionalLong.empty()
+            : OptionalLong.of(restoreStartOffset),
         buffer::flush
     );
     storeRegistry.registerStore(registration);

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveStoreRegistration.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveStoreRegistration.java
@@ -32,7 +32,7 @@ public final class ResponsiveStoreRegistration {
   private final TopicPartition changelogTopicPartition;
   private final Consumer<Long> onCommit;
 
-  private final OptionalLong startOffset; // stored offset during init, ie where restore should start
+  private final OptionalLong startOffset; // stored offset during init, (where restore should start)
 
   @VisibleForTesting
   public ResponsiveStoreRegistration(

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveStoreRegistration.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveStoreRegistration.java
@@ -18,6 +18,7 @@ package dev.responsive.kafka.internal.stores;
 
 import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting;
 import java.util.Objects;
+import java.util.OptionalLong;
 import java.util.function.Consumer;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.LogContext;
@@ -31,13 +32,13 @@ public final class ResponsiveStoreRegistration {
   private final TopicPartition changelogTopicPartition;
   private final Consumer<Long> onCommit;
 
-  private final long startOffset; // stored offset during init, ie where restore should start
+  private final OptionalLong startOffset; // stored offset during init, ie where restore should start
 
   @VisibleForTesting
   public ResponsiveStoreRegistration(
       final String storeName,
       final TopicPartition changelogTopicPartition,
-      final long startOffset,
+      final OptionalLong startOffset,
       final Consumer<Long> onCommit
   ) {
     this.storeName = Objects.requireNonNull(storeName);
@@ -50,7 +51,7 @@ public final class ResponsiveStoreRegistration {
     log.debug("Created store registration with stored offset={}", startOffset);
   }
 
-  public long startOffset() {
+  public OptionalLong startOffset() {
     return startOffset;
   }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveStoreRegistry.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveStoreRegistry.java
@@ -16,8 +16,6 @@
 
 package dev.responsive.kafka.internal.stores;
 
-import static dev.responsive.kafka.internal.stores.ResponsiveStoreRegistration.NO_COMMITTED_OFFSET;
-
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveStoreRegistry.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveStoreRegistry.java
@@ -16,6 +16,8 @@
 
 package dev.responsive.kafka.internal.stores;
 
+import static dev.responsive.kafka.internal.stores.ResponsiveStoreRegistration.NO_COMMITTED_OFFSET;
+
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Optional;
@@ -32,8 +34,11 @@ public class ResponsiveStoreRegistry {
   private final List<ResponsiveStoreRegistration> stores = new LinkedList<>();
 
   public synchronized OptionalLong getCommittedOffset(final TopicPartition topicPartition) {
-    return getRegisteredStoresForChangelog(topicPartition).stream()
-        .mapToLong(ResponsiveStoreRegistration::startOffset)
+    return getRegisteredStoresForChangelog(topicPartition)
+        .stream()
+        .map(ResponsiveStoreRegistration::startOffset)
+        .filter(OptionalLong::isPresent)
+        .mapToLong(OptionalLong::getAsLong)
         .max();
   }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/SegmentedOperations.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/SegmentedOperations.java
@@ -20,6 +20,7 @@ package dev.responsive.kafka.internal.stores;
 
 import static dev.responsive.kafka.internal.config.InternalSessionConfigs.loadSessionClients;
 import static dev.responsive.kafka.internal.config.InternalSessionConfigs.loadStoreRegistry;
+import static dev.responsive.kafka.internal.stores.ResponsiveStoreRegistration.NO_COMMITTED_OFFSET;
 import static org.apache.kafka.streams.processor.internals.ProcessorContextUtils.asInternalProcessorContext;
 import static org.apache.kafka.streams.processor.internals.ProcessorContextUtils.changelogFor;
 
@@ -41,6 +42,7 @@ import dev.responsive.kafka.internal.utils.TableName;
 import dev.responsive.kafka.internal.utils.WindowedKey;
 import java.util.Collection;
 import java.util.Map;
+import java.util.OptionalLong;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Predicate;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -128,7 +130,9 @@ public class SegmentedOperations implements WindowOperations {
     final var registration = new ResponsiveStoreRegistration(
         name.kafkaName(),
         changelog,
-        restoreStartOffset == -1 ? 0 : restoreStartOffset,
+        restoreStartOffset == NO_COMMITTED_OFFSET
+            ? OptionalLong.empty()
+            : OptionalLong.of(restoreStartOffset),
         buffer::flush
     );
     storeRegistry.registerStore(registration);

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/clients/StoreCommitListenerTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/clients/StoreCommitListenerTest.java
@@ -9,6 +9,7 @@ import dev.responsive.kafka.internal.stores.ResponsiveStoreRegistration;
 import dev.responsive.kafka.internal.stores.ResponsiveStoreRegistry;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.OptionalLong;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
@@ -38,13 +39,13 @@ class StoreCommitListenerTest {
     registry.registerStore(new ResponsiveStoreRegistration(
         "store1",
         PARTITION1,
-        0,
+        OptionalLong.of(0),
         store1Flush
     ));
     registry.registerStore(new ResponsiveStoreRegistration(
         "store2",
         PARTITION2,
-        0,
+        OptionalLong.of(0),
         store2Flush
     ));
     commitListener = new StoreCommitListener(registry, offsetRecorder);

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/ResponsiveStoreRegistryTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/ResponsiveStoreRegistryTest.java
@@ -34,6 +34,7 @@ class ResponsiveStoreRegistryTest {
   @BeforeEach
   public void setup() {
     registry.registerStore(REGISTRATION);
+    registry.registerStore(UNINIT_REGISTRATION);
   }
 
   @Test
@@ -52,7 +53,7 @@ class ResponsiveStoreRegistryTest {
   @Test
   public void shouldReturnEmptyCommittedOffsetFromChangelogWithNoOffset() {
     assertThat(
-        registry.getCommittedOffset(TOPIC_PARTITION),
+        registry.getCommittedOffset(UNINIT_TOPIC_PARTITION),
         is(OptionalLong.empty())
     );
   }

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/ResponsiveStoreRegistryTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/ResponsiveStoreRegistryTest.java
@@ -42,15 +42,15 @@ class ResponsiveStoreRegistryTest {
   }
 
   @Test
-  public void shouldReturnEmptyCommittedOffsetFromRegisteredStoreWithNoOffset() {
+  public void shouldReturnEmptyCommittedOffsetFromNotRegisteredStore() {
     assertThat(
-        registry.getCommittedOffset(UNINIT_TOPIC_PARTITION),
+        registry.getCommittedOffset(new TopicPartition("foo", 1)),
         is(OptionalLong.empty())
     );
   }
 
   @Test
-  public void shouldReturnEmptyCommittedOffsetFromNotRegisteredStore() {
+  public void shouldReturnEmptyCommittedOffsetFromChangelogWithNoOffset() {
     assertThat(
         registry.getCommittedOffset(TOPIC_PARTITION),
         is(OptionalLong.empty())

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/ResponsiveStoreRegistryTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/ResponsiveStoreRegistryTest.java
@@ -12,12 +12,22 @@ import org.junit.jupiter.api.Test;
 
 class ResponsiveStoreRegistryTest {
   private static final TopicPartition TOPIC_PARTITION = new TopicPartition("changelog-topic", 5);
+  private static final TopicPartition UNINIT_TOPIC_PARTITION =
+      new TopicPartition("changelog-topic", 2);
   private static final ResponsiveStoreRegistration REGISTRATION = new ResponsiveStoreRegistration(
       "store",
       TOPIC_PARTITION,
-      123L,
+      OptionalLong.of(123L),
       o -> {}
   );
+
+  private static final ResponsiveStoreRegistration UNINIT_REGISTRATION =
+      new ResponsiveStoreRegistration(
+          "store",
+          UNINIT_TOPIC_PARTITION,
+          OptionalLong.empty(),
+          o -> { }
+      );
 
   private final ResponsiveStoreRegistry registry = new ResponsiveStoreRegistry();
 
@@ -32,9 +42,17 @@ class ResponsiveStoreRegistryTest {
   }
 
   @Test
+  public void shouldReturnEmptyCommittedOffsetFromRegisteredStoreWithNoOffset() {
+    assertThat(
+        registry.getCommittedOffset(UNINIT_TOPIC_PARTITION),
+        is(OptionalLong.empty())
+    );
+  }
+
+  @Test
   public void shouldReturnEmptyCommittedOffsetFromNotRegisteredStore() {
     assertThat(
-        registry.getCommittedOffset(new TopicPartition("foo", 1)),
+        registry.getCommittedOffset(TOPIC_PARTITION),
         is(OptionalLong.empty())
     );
   }

--- a/kafka-client/src/test/java/dev/responsive/kafka/testutils/IntegrationTestUtils.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/testutils/IntegrationTestUtils.java
@@ -98,6 +98,8 @@ public final class IntegrationTestUtils {
     // add displayName to name to account for parameterized tests
     return info.getTestMethod().orElseThrow().getName().toLowerCase(Locale.ROOT)
         + info.getDisplayName().substring("[X] ".length()).toLowerCase(Locale.ROOT)
+        .replace(" ", "") // this can happen if multiple params in parameterized test
+        .replace(",", "") // this can happen if multiple params in parameterized test
         .replace("_", ""); // keep only valid cassandra chars to keep testing code easier
   }
 


### PR DESCRIPTION
If changelogs started with non-O offsets, we would hit the exception below. This could happen if either:

1. the changelog is compacted and the compaction has removed the 0th offset
2. the changelog has retention and the 0th offset is beyond retention

This PR fixes this by forcing a call to `seekToBeginning` if the offsets in the metadata store are `NO_COMMITTED_OFFSET`.

```
[2024-02-23 11:11:48,494] WARN stream-thread [shouldflushstoresbeforeclosekeyvaluetrue-9a203ca0-f55a-4224-b171-9db93ff7d0fe-StreamThread-1] Encountered org.apache.kafka.clients.consumer.OffsetOutOfRangeException fetching records from restore consumer for partitions [shouldflushstoresbeforeclosekeyvaluetrue-shouldflushstoresbeforeclosekeyvaluetrueagg-changelog-0], it is likely that the consumer's position has fallen out of the topic partition offset range because the topic was truncated or compacted on the broker, marking the corresponding tasks as corrupted and re-initializing it later. (org.apache.kafka.streams.processor.internals.StoreChangelogReader:495)
org.apache.kafka.clients.consumer.OffsetOutOfRangeException: Fetch position FetchPosition{offset=0, offsetEpoch=Optional.empty, currentLeader=LeaderAndEpoch{leader=Optional[localhost:50351 (id: 1 rack: null)], epoch=0}} is out of range for partition shouldflushstoresbeforeclosekeyvaluetrue-shouldflushstoresbeforeclosekeyvaluetrueagg-changelog-0
	at org.apache.kafka.clients.consumer.internals.AbstractFetch.handleOffsetOutOfRange(AbstractFetch.java:664)
	at org.apache.kafka.clients.consumer.internals.AbstractFetch.handleInitializeCompletedFetchErrors(AbstractFetch.java:625)
	at org.apache.kafka.clients.consumer.internals.AbstractFetch.initializeCompletedFetch(AbstractFetch.java:514)
	at org.apache.kafka.clients.consumer.internals.AbstractFetch.collectFetch(AbstractFetch.java:283)
	at org.apache.kafka.clients.consumer.KafkaConsumer.pollForFetches(KafkaConsumer.java:1262)
	at org.apache.kafka.clients.consumer.KafkaConsumer.poll(KafkaConsumer.java:1186)
	at org.apache.kafka.clients.consumer.KafkaConsumer.poll(KafkaConsumer.java:1159)
	at dev.responsive.kafka.internal.clients.DelegatingConsumer.poll(DelegatingConsumer.java:94)
	at dev.responsive.kafka.internal.clients.ResponsiveRestoreConsumer.poll(ResponsiveRestoreConsumer.java:104)
	at org.apache.kafka.streams.processor.internals.StoreChangelogReader.pollRecordsFromRestoreConsumer(StoreChangelogReader.java:490)
	at org.apache.kafka.streams.processor.internals.StoreChangelogReader.restore(StoreChangelogReader.java:446)
	at org.apache.kafka.streams.processor.internals.StreamThread.initializeAndRestorePhase(StreamThread.java:918)
	at org.apache.kafka.streams.processor.internals.StreamThread.runOnce(StreamThread.java:778)
	at org.apache.kafka.streams.processor.internals.StreamThread.runLoop(StreamThread.java:617)
	at org.apache.kafka.streams.processor.internals.StreamThread.run(StreamThread.java:579)
```