### PR TITLE
update offsets on flush even when buffer is empty

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/CommitBuffer.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/CommitBuffer.java
@@ -455,11 +455,6 @@ public class CommitBuffer<K extends Comparable<K>, P>
 
     flushTriggers.reset();
 
-    if (buffer.getReader().isEmpty()) {
-      log.debug("Ignoring flush() of empty commit buffer");
-      return;
-    }
-
     doFlush(consumedOffset, maxBatchSize);
 
     lastFlush = clock.get();

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/CommitBufferTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/CommitBufferTest.java
@@ -78,7 +78,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;


### PR DESCRIPTION
run `preFlush` and `postFlush` even if the actual data is empty - this only makes a difference in the bootstrapping tool where we filter TTL'd data as we process it