### PR TITLE
Mongo range queries: setup and KVTable implementations

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveKafkaStreams.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveKafkaStreams.java
@@ -458,6 +458,7 @@ public class ResponsiveKafkaStreams extends KafkaStreams {
           sessionClients = new SessionClients(
               Optional.of(new ResponsiveMongoClient(
                   mongoClient,
+                  admin,
                   timestampFirstOrder,
                   CollectionCreationOptions.fromConfig(responsiveConfig)
               )),

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/RemoteTableSpecFactory.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/RemoteTableSpecFactory.java
@@ -42,16 +42,21 @@ public class RemoteTableSpecFactory {
 
   public static RemoteTableSpec globalSpec(
       final ResponsiveKeyValueParams params,
+      final String changelogTopic,
       final TablePartitioner<Bytes, Integer> partitioner
   ) {
-    return new GlobalTableSpec(new BaseTableSpec(params.name().tableName(), partitioner));
+    return new GlobalTableSpec(
+        new BaseTableSpec(params.name().tableName(), changelogTopic, partitioner)
+    );
   }
 
   public static RemoteTableSpec fromKVParams(
       final ResponsiveKeyValueParams params,
+      final String changelogTopicName,
       final TablePartitioner<Bytes, Integer> partitioner
   ) {
-    RemoteTableSpec spec = new BaseTableSpec(params.name().tableName(), partitioner);
+    RemoteTableSpec spec =
+        new BaseTableSpec(params.name().tableName(), changelogTopicName, partitioner);
 
     if (params.timeToLive().isPresent()) {
       spec = new TtlTableSpec(spec, params.timeToLive().get());
@@ -66,9 +71,10 @@ public class RemoteTableSpecFactory {
 
   public static RemoteTableSpec fromWindowParams(
       final ResponsiveWindowParams params,
+      final String changelogTopicName,
       final TablePartitioner<WindowedKey, SegmentPartition> partitioner
   ) {
-    return new BaseTableSpec(params.name().tableName(), partitioner);
+    return new BaseTableSpec(params.name().tableName(), changelogTopicName, partitioner);
   }
 
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/KVDoc.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/KVDoc.java
@@ -24,13 +24,13 @@ import org.bson.codecs.pojo.annotations.BsonId;
 public class KVDoc {
 
   // TODO(agavra): figure out if we can use @BsonProperty to set the names explicitly
-  public static final String ID = "_id";
+  public static final String KEY = "_id";
   public static final String VALUE = "value";
   public static final String EPOCH = "epoch";
   public static final String TOMBSTONE_TS = "tombstoneTs";
 
   @BsonId
-  byte[] id;
+  byte[] key;
   byte[] value;
   long epoch;
   Date tombstoneTs;
@@ -39,16 +39,17 @@ public class KVDoc {
   }
 
   public KVDoc(final byte[] key, final byte[] value, final long epoch) {
+    this.key = key;
     this.value = value;
     this.epoch = epoch;
   }
 
   public byte[] getKey() {
-    return id;
+    return key;
   }
 
   public void setKey(final byte[] id) {
-    this.id = id;
+    this.key = id;
   }
 
   public void setValue(final byte[] value) {
@@ -85,14 +86,15 @@ public class KVDoc {
     }
     final KVDoc kvDoc = (KVDoc) o;
     return epoch == kvDoc.epoch
-        && Arrays.equals(id, kvDoc.id)
+        && Arrays.equals(key, kvDoc.key)
         && Arrays.equals(value, kvDoc.value)
         && Objects.equals(tombstoneTs, kvDoc.tombstoneTs);
   }
 
   @Override
   public int hashCode() {
-    int result = Objects.hash(id, epoch, tombstoneTs);
+    int result = Objects.hash(epoch, tombstoneTs);
+    result = 31 * result + Arrays.hashCode(key);
     result = 31 * result + Arrays.hashCode(value);
     return result;
   }
@@ -100,7 +102,7 @@ public class KVDoc {
   @Override
   public String toString() {
     return "KVDoc{"
-        + "id=" + Arrays.toString(id)
+        + "key=" + Arrays.toString(key)
         + ", value=" + Arrays.toString(value)
         + ", epoch=" + epoch
         + ", tombstoneTs=" + tombstoneTs

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/KVMetadataDoc.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/KVMetadataDoc.java
@@ -20,23 +20,23 @@ import java.util.Objects;
 
 public class KVMetadataDoc {
 
-  public static final String PARTITION = "_id";
+  public static final String KAFKA_PARTITION = "_id";
   public static final String OFFSET = "offset";
   public static final String EPOCH = "epoch";
 
-  int partition;
+  int kafkaPartition;
   long offset;
   long epoch;
 
   public KVMetadataDoc() {
   }
 
-  public int partition() {
-    return partition;
+  public int kafkaPartition() {
+    return kafkaPartition;
   }
 
-  public void setPartition(final int partition) {
-    this.partition = partition;
+  public void setKafkaPartition(final int kafkaPartition) {
+    this.kafkaPartition = kafkaPartition;
   }
 
   public long offset() {
@@ -64,20 +64,20 @@ public class KVMetadataDoc {
       return false;
     }
     final KVMetadataDoc that = (KVMetadataDoc) o;
-    return partition == that.partition
+    return kafkaPartition == that.kafkaPartition
         && offset == that.offset
         && epoch == that.epoch;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(partition, epoch, offset);
+    return Objects.hash(kafkaPartition, epoch, offset);
   }
 
   @Override
   public String toString() {
     return "KVMetadataDoc{"
-        + ", partition=" + partition
+        + ", partition=" + kafkaPartition
         + ", offset=" + offset
         + ", epoch=" + epoch
         + '}';

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoKVTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoKVTable.java
@@ -18,6 +18,7 @@ package dev.responsive.kafka.internal.db.mongo;
 
 import static com.mongodb.MongoClientSettings.getDefaultCodecRegistry;
 import static dev.responsive.kafka.internal.stores.ResponsiveStoreRegistration.NO_COMMITTED_OFFSET;
+import static dev.responsive.kafka.internal.utils.StoreUtil.numPartitionsForKafkaTopic;
 import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
 import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
 
@@ -36,12 +37,17 @@ import com.mongodb.client.model.WriteModel;
 import com.mongodb.client.result.UpdateResult;
 import dev.responsive.kafka.internal.db.MongoKVFlushManager;
 import dev.responsive.kafka.internal.db.RemoteKVTable;
+import dev.responsive.kafka.internal.utils.Iterators;
 import java.time.Instant;
 import java.util.Date;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.producer.internals.BuiltInPartitioner;
 import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.bson.codecs.configuration.CodecProvider;
 import org.bson.codecs.configuration.CodecRegistry;
@@ -57,17 +63,39 @@ public class MongoKVTable implements RemoteKVTable<WriteModel<KVDoc>> {
 
   private final String name;
 
+  // TODO(sophie): allow use with custom partitioner
+  private Function<Bytes, Integer> partitioner;
+
   private final MongoCollection<KVDoc> docs;
   private final MongoCollection<KVMetadataDoc> metadata;
 
   private final ConcurrentMap<Integer, Long> kafkaPartitionToEpoch = new ConcurrentHashMap<>();
 
+  public static MongoKVTable create(
+      final MongoClient client,
+      final String name,
+      final String changelogTopicName,
+      final Admin admin,
+      final CollectionCreationOptions collectionCreationOptions
+  ) {
+    final int numPartitions = numPartitionsForKafkaTopic(admin, changelogTopicName);
+    return new MongoKVTable(
+        client,
+        name,
+        numPartitions,
+        collectionCreationOptions
+    );
+  }
+
   public MongoKVTable(
       final MongoClient client,
       final String name,
+      final int numPartitions,
       final CollectionCreationOptions collectionCreationOptions
   ) {
     this.name = name;
+    this.partitioner = key -> BuiltInPartitioner.partitionForKey(key.get(), numPartitions);
+
     final CodecProvider pojoCodecProvider = PojoCodecProvider.builder().automatic(true).build();
     final CodecRegistry pojoCodecRegistry = fromRegistries(
         getDefaultCodecRegistry(),
@@ -105,10 +133,10 @@ public class MongoKVTable implements RemoteKVTable<WriteModel<KVDoc>> {
   @Override
   public MongoKVFlushManager init(final int kafkaPartition) {
     final KVMetadataDoc metaDoc = metadata.findOneAndUpdate(
-        Filters.eq(KVMetadataDoc.PARTITION, kafkaPartition),
+        Filters.eq(KVMetadataDoc.KAFKA_PARTITION, kafkaPartition),
         Updates.combine(
-            Updates.setOnInsert(KVMetadataDoc.PARTITION, kafkaPartition),
-            Updates.setOnInsert(KVMetadataDoc.PARTITION, kafkaPartition),
+            Updates.setOnInsert(KVMetadataDoc.KAFKA_PARTITION, kafkaPartition),
+            Updates.setOnInsert(KVMetadataDoc.KAFKA_PARTITION, kafkaPartition),
             Updates.setOnInsert(KVMetadataDoc.OFFSET, NO_COMMITTED_OFFSET),
             Updates.inc(KVMetadataDoc.EPOCH, 1) // will set the value to 1 if it doesn't exist
         ),
@@ -129,7 +157,7 @@ public class MongoKVTable implements RemoteKVTable<WriteModel<KVDoc>> {
 
   @Override
   public byte[] get(final int kafkaPartition, final Bytes key, final long minValidTs) {
-    final KVDoc v = docs.find(Filters.eq(KVDoc.ID, key.get())).first();
+    final KVDoc v = docs.find(Filters.eq(KVDoc.KEY, key.get())).first();
     return v == null ? null : v.getValue();
   }
 
@@ -140,12 +168,24 @@ public class MongoKVTable implements RemoteKVTable<WriteModel<KVDoc>> {
       final Bytes to,
       final long minValidTs
   ) {
-    throw new UnsupportedOperationException();
+    final Iterable<KVDoc> results = docs.find(Filters.and(
+        Filters.gte(KVDoc.KEY, from.get()),
+        Filters.lte(KVDoc.KEY, to.get())
+    ));
+    return Iterators.filterKv(
+        Iterators.kv(results.iterator(), MongoKVTable::extractKeyValue),
+        k -> partitioner.apply(k) == kafkaPartition
+    );
   }
 
   @Override
   public KeyValueIterator<Bytes, byte[]> all(final int kafkaPartition, final long minValidTs) {
-    throw new UnsupportedOperationException();
+    final Iterable<KVDoc> results = docs.find();
+
+    return Iterators.filterKv(
+        Iterators.kv(results.iterator(), MongoKVTable::extractKeyValue),
+        k -> partitioner.apply(k) == kafkaPartition
+    );
   }
 
   @Override
@@ -158,7 +198,7 @@ public class MongoKVTable implements RemoteKVTable<WriteModel<KVDoc>> {
     final long epoch = kafkaPartitionToEpoch.get(kafkaPartition);
     return new UpdateOneModel<>(
         Filters.and(
-            Filters.eq(KVDoc.ID, key.get()),
+            Filters.eq(KVDoc.KEY, key.get()),
             Filters.lte(KVDoc.EPOCH, epoch)
         ),
         Updates.combine(
@@ -175,7 +215,7 @@ public class MongoKVTable implements RemoteKVTable<WriteModel<KVDoc>> {
     final long epoch = kafkaPartitionToEpoch.get(kafkaPartition);
     return new UpdateOneModel<>(
         Filters.and(
-            Filters.eq(KVDoc.ID, key.get()),
+            Filters.eq(KVDoc.KEY, key.get()),
             Filters.lte(KVDoc.EPOCH, epoch)
         ),
         Updates.combine(
@@ -190,7 +230,7 @@ public class MongoKVTable implements RemoteKVTable<WriteModel<KVDoc>> {
   @Override
   public long fetchOffset(final int kafkaPartition) {
     final KVMetadataDoc result = metadata.find(
-        Filters.eq(KVMetadataDoc.PARTITION, kafkaPartition)
+        Filters.eq(KVMetadataDoc.KAFKA_PARTITION, kafkaPartition)
     ).first();
     if (result == null) {
       throw new IllegalStateException("Expected to find metadata row");
@@ -203,7 +243,7 @@ public class MongoKVTable implements RemoteKVTable<WriteModel<KVDoc>> {
 
     return metadata.updateOne(
         Filters.and(
-            Filters.eq(KVMetadataDoc.PARTITION, kafkaPartition),
+            Filters.eq(KVMetadataDoc.KAFKA_PARTITION, kafkaPartition),
             Filters.lte(KVMetadataDoc.EPOCH, epoch)
         ),
         Updates.combine(
@@ -219,7 +259,7 @@ public class MongoKVTable implements RemoteKVTable<WriteModel<KVDoc>> {
 
   public long fetchEpoch(final int kafkaPartition) {
     final KVMetadataDoc result = metadata.find(
-        Filters.eq(KVMetadataDoc.PARTITION, kafkaPartition)
+        Filters.eq(KVMetadataDoc.KAFKA_PARTITION, kafkaPartition)
     ).first();
     if (result == null) {
       throw new IllegalStateException("Expected to find metadata row");
@@ -231,6 +271,13 @@ public class MongoKVTable implements RemoteKVTable<WriteModel<KVDoc>> {
   public long approximateNumEntries(final int kafkaPartition) {
     LOG.warn("approximateNumEntries is not yet implemented for Mongo");
     return 0;
+  }
+
+  private static KeyValue<Bytes, byte[]> extractKeyValue(final KVDoc row) {
+    return new KeyValue<>(
+        Bytes.wrap(row.getKey()),
+        row.getValue()
+    );
   }
 
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/spec/BaseTableSpec.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/spec/BaseTableSpec.java
@@ -24,16 +24,27 @@ import java.util.EnumSet;
 public class BaseTableSpec implements RemoteTableSpec {
 
   private final String name;
+  private final String changelogTopicName;
   final TablePartitioner<?, ?> partitioner;
 
-  public BaseTableSpec(final String name, final TablePartitioner<?, ?> partitioner) {
+  public BaseTableSpec(
+      final String name,
+      final String changelogTopicName,
+      final TablePartitioner<?, ?> partitioner
+  ) {
     this.name = name;
+    this.changelogTopicName = changelogTopicName;
     this.partitioner = partitioner;
   }
 
   @Override
   public String tableName() {
     return name;
+  }
+
+  @Override
+  public String changelogTopicName() {
+    return changelogTopicName;
   }
 
   @Override

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/spec/DelegatingTableSpec.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/spec/DelegatingTableSpec.java
@@ -35,6 +35,11 @@ public abstract class DelegatingTableSpec implements RemoteTableSpec {
   }
 
   @Override
+  public String changelogTopicName() {
+    return delegate().changelogTopicName();
+  }
+
+  @Override
   public TablePartitioner<?, ?> partitioner() {
     return delegate.partitioner();
   }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/spec/RemoteTableSpec.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/spec/RemoteTableSpec.java
@@ -30,6 +30,8 @@ public interface RemoteTableSpec {
 
   String tableName();
 
+  String changelogTopicName();
+
   TablePartitioner<?, ?> partitioner();
 
   /**

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/GlobalOperations.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/GlobalOperations.java
@@ -59,7 +59,8 @@ public class GlobalOperations implements KeyValueOperations {
 
     final SessionClients sessionClients = loadSessionClients(appConfigs);
     final var client = sessionClients.cassandraClient();
-    final var spec = RemoteTableSpecFactory.globalSpec(params, defaultPartitioner());
+    final var spec =
+        RemoteTableSpecFactory.globalSpec(params, context.topic(), defaultPartitioner());
 
     final var table = client.globalFactory().create(spec);
     table.init(IGNORED_PARTITION);

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/PartitionedOperations.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/PartitionedOperations.java
@@ -100,7 +100,7 @@ public class PartitionedOperations implements KeyValueOperations {
         table = createCassandra(params, config, sessionClients, changelog.topic());
         break;
       case MONGO_DB:
-        table = createMongo(params, sessionClients);
+        table = createMongo(params, changelog.topic(), sessionClients);
         break;
       default:
         throw new IllegalStateException("Unexpected value: " + sessionClients.storageBackend());
@@ -184,7 +184,7 @@ public class PartitionedOperations implements KeyValueOperations {
             changelogTopicName
         );
     final var client = sessionClients.cassandraClient();
-    final var spec = RemoteTableSpecFactory.fromKVParams(params, partitioner);
+    final var spec = RemoteTableSpecFactory.fromKVParams(params, changelogTopicName, partitioner);
     switch (params.schemaType()) {
       case KEY_VALUE:
         return client.kvFactory().create(spec);
@@ -197,9 +197,10 @@ public class PartitionedOperations implements KeyValueOperations {
 
   private static RemoteKVTable<?> createMongo(
       final ResponsiveKeyValueParams params,
+      final String changelogTopicName,
       final SessionClients sessionClients
   ) throws InterruptedException, TimeoutException {
-    return sessionClients.mongoClient().kvTable(params.name().tableName());
+    return sessionClients.mongoClient().kvTable(params.name().tableName(), changelogTopicName);
   }
 
   @SuppressWarnings("rawtypes")

--- a/kafka-client/src/test/java/dev/responsive/kafka/bootstrap/ChangelogMigrationToolIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/bootstrap/ChangelogMigrationToolIntegrationTest.java
@@ -166,7 +166,7 @@ class ChangelogMigrationToolIntegrationTest {
       pipeInput(inputTopic(), partitions, produce, System::currentTimeMillis, 0, perKey, keys);
 
       LOG.info("Awaiting the output from all 1000 records");
-      readOutput(outputTopic(), 0, numEvents, true, baseProps);
+      readOutput(outputTopic(), 0, 0, numEvents, true, baseProps);
     }
 
     // 2: Run the changelog migration tool to bootstrap the new Cassandra table
@@ -238,7 +238,7 @@ class ChangelogMigrationToolIntegrationTest {
       pipeInput(inputTopic(), partitions, produce, System::currentTimeMillis, 0, perKey, keys);
 
       LOG.info("Awaiting the output from all {} keys", numKeys);
-      readOutput(outputTopic(), 0, numKeys, true, baseProps);
+      readOutput(outputTopic(), 0, 0, numKeys, true, baseProps);
     }
 
     // 2: Run the changelog migration tool to bootstrap the new Cassandra table

--- a/kafka-client/src/test/java/dev/responsive/kafka/integration/MinimalIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/integration/MinimalIntegrationTest.java
@@ -124,7 +124,7 @@ public class MinimalIntegrationTest {
         Thread.sleep(100);
       }
 
-      final var kvs = readOutput(outputTopic(), 0, 20, true, properties);
+      final var kvs = readOutput(outputTopic(), 0, 0, 20, true, properties);
       assertThat(
           kvs,
           hasItems(new KeyValue<>(0L, 10L), new KeyValue<>(1L, 10L)));

--- a/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveKeyValueStoreEosIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveKeyValueStoreEosIntegrationTest.java
@@ -156,7 +156,7 @@ public class ResponsiveKeyValueStoreEosIntegrationTest {
       // an additional 10 values are uncommitted (5 for each partition)
       // this statement below just blocks until we've read 30 uncommitted
       // records before causing one of the tasks to stall
-      readOutput(outputTopic(), 0, 30, true, properties);
+      readOutput(outputTopic(), 0, 0, 30, true, properties);
 
       state.stall.set(Stall.INJECTED);
 
@@ -184,8 +184,8 @@ public class ResponsiveKeyValueStoreEosIntegrationTest {
       // 20 more values beyond the first read are now committed (10
       // for each partition), but 5 should never have been committed
       // so there should be more uncommitted reads in total
-      final List<KeyValue<Long, Long>> readC = readOutput(outputTopic(), 0, 40, false, properties);
-      final List<KeyValue<Long, Long>> readU = readOutput(outputTopic(), 0, 45, true, properties);
+      final List<KeyValue<Long, Long>> readC = readOutput(outputTopic(), 0, 0, 40, false, properties);
+      final List<KeyValue<Long, Long>> readU = readOutput(outputTopic(), 0, 0, 45, true, properties);
 
       // now we release the stalled consumer
       state.stall.set(Stall.RELEASED);

--- a/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveKeyValueStoreRestoreIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveKeyValueStoreRestoreIntegrationTest.java
@@ -332,11 +332,13 @@ public class ResponsiveKeyValueStoreRestoreIntegrationTest {
               changelog.topic()
           );
           table = cassandraClient.kvFactory()
-              .create(new BaseTableSpec(aggName(), partitioner));
+              .create(new BaseTableSpec(aggName(), changelog.topic(), partitioner));
           break;
         case FACT:
           table = cassandraClient.factFactory()
-              .create(new BaseTableSpec(aggName(), TablePartitioner.defaultPartitioner()));
+              .create(new BaseTableSpec(
+                  aggName(), changelog.topic(), TablePartitioner.defaultPartitioner())
+              );
           break;
         default:
           throw new IllegalArgumentException("Unexpected type " + type);
@@ -353,6 +355,7 @@ public class ResponsiveKeyValueStoreRestoreIntegrationTest {
       table = new MongoKVTable(
           mongoClient,
           aggName(),
+          NUM_PARTITIONS,
           CollectionCreationOptions.fromConfig(config)
       );
       table.init(0);

--- a/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveWindowStoreIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveWindowStoreIntegrationTest.java
@@ -315,7 +315,7 @@ public class ResponsiveWindowStoreIntegrationTest {
           new KeyValueTimestamp<>("key", "k", minutesToMillis(16L))  // [15, 30] --> "degk"
       );
 
-      pipeRecords(producer, inputTopic(), input1);
+      pipeRecords(producer, inputTopic(), 0, input1);
 
       outputLatch.await();
       assertThat(results.size(), equalTo(3));
@@ -385,7 +385,7 @@ public class ResponsiveWindowStoreIntegrationTest {
           new KeyValueTimestamp<>("key", "h", 5_000L)   // within grace for [5, 15s] window
       );
 
-      pipeRecords(producer, inputTopic(), input1);
+      pipeRecords(producer, inputTopic(), 0, input1);
       outputLatch.await();
 
       assertThat(results.size(), equalTo(4));

--- a/kafka-client/src/test/java/dev/responsive/kafka/integration/StoreQueryIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/integration/StoreQueryIntegrationTest.java
@@ -74,7 +74,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 public class StoreQueryIntegrationTest {
 
   @RegisterExtension
-  static ResponsiveExtension EXTENSION = new ResponsiveExtension(StorageBackend.CASSANDRA);
+  static ResponsiveExtension EXTENSION = new ResponsiveExtension(StorageBackend.MONGO_DB);
 
   private static final String INPUT_TOPIC = "input";
   private static final String OUTPUT_TOPIC = "output";

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/CassandraFactTableIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/CassandraFactTableIntegrationTest.java
@@ -45,6 +45,7 @@ class CassandraFactTableIntegrationTest {
   private static final long MIN_VALID_TS = 0L;
 
   private String storeName; // ie the "kafkaName", NOT the "cassandraName"
+  private String changelog;
   private ResponsiveKeyValueParams params;
   private CassandraClient client;
   private CqlSession session;
@@ -57,6 +58,7 @@ class CassandraFactTableIntegrationTest {
   ) {
     String name = info.getTestMethod().orElseThrow().getName();
     storeName = name + "store";
+    changelog = storeName + "-changelog";
 
     session = CqlSession.builder()
         .addContactPoint(cassandra.getContactPoint())
@@ -73,7 +75,7 @@ class CassandraFactTableIntegrationTest {
     final String tableName = params.name().tableName();
     final CassandraFactTable schema = (CassandraFactTable) client
         .factFactory()
-        .create(RemoteTableSpecFactory.fromKVParams(params, defaultPartitioner()));
+        .create(RemoteTableSpecFactory.fromKVParams(params, changelog, defaultPartitioner()));
 
     // When:
     final var token = schema.init(1);
@@ -105,7 +107,7 @@ class CassandraFactTableIntegrationTest {
 
     // When:
     client.factFactory()
-        .create(RemoteTableSpecFactory.fromKVParams(params, defaultPartitioner()));
+        .create(RemoteTableSpecFactory.fromKVParams(params, changelog, defaultPartitioner()));
 
     // Then:
     final var table = session.getMetadata()
@@ -132,7 +134,7 @@ class CassandraFactTableIntegrationTest {
 
     // When:
     client.factFactory()
-        .create(RemoteTableSpecFactory.fromKVParams(params, defaultPartitioner()));
+        .create(RemoteTableSpecFactory.fromKVParams(params, changelog, defaultPartitioner()));
 
     // Then:
     final var table = session.getMetadata()
@@ -151,7 +153,7 @@ class CassandraFactTableIntegrationTest {
     params = ResponsiveKeyValueParams.fact(storeName);
     final RemoteKVTable<BoundStatement> table = client
         .factFactory()
-        .create(RemoteTableSpecFactory.fromKVParams(params, defaultPartitioner()));
+        .create(RemoteTableSpecFactory.fromKVParams(params, changelog, defaultPartitioner()));
 
     table.init(1);
 
@@ -177,7 +179,7 @@ class CassandraFactTableIntegrationTest {
 
     final RemoteKVTable<BoundStatement> table = client
         .factFactory()
-        .create(RemoteTableSpecFactory.fromKVParams(params, defaultPartitioner()));
+        .create(RemoteTableSpecFactory.fromKVParams(params, changelog, defaultPartitioner()));
 
     table.init(1);
 

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/CassandraKVTableIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/CassandraKVTableIntegrationTest.java
@@ -70,6 +70,7 @@ public class CassandraKVTableIntegrationTest {
     client = new CassandraClient(session, config);
 
     final String name = info.getTestMethod().orElseThrow().getName();
+    final String changelog = name + "-changelog";
     final ResponsiveConfig partitionerConfig = copyConfigWithOverrides(
         config,
         singletonMap(STORAGE_DESIRED_NUM_PARTITION_CONFIG, NUM_SUBPARTITIONS_TOTAL)
@@ -79,10 +80,10 @@ public class CassandraKVTableIntegrationTest {
         NUM_KAFKA_PARTITIONS,
         name,
         partitionerConfig,
-        name + "-changelog"
+        changelog
     );
     table = CassandraKeyValueTable.create(
-        new BaseTableSpec(name, partitioner), client);
+        new BaseTableSpec(name, changelog, partitioner), client);
   }
 
   @Test

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/mongo/MongoKVTableTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/mongo/MongoKVTableTest.java
@@ -61,7 +61,7 @@ class MongoKVTableTest {
   @Test
   public void shouldSucceedWriterWithSameEpoch() throws ExecutionException, InterruptedException {
     // Given:
-    final MongoKVTable table = new MongoKVTable(client, name, UNSHARDED);
+    final MongoKVTable table = new MongoKVTable(client, name, 1, UNSHARDED);
 
     var writerFactory = table.init(0);
     var writer = writerFactory.createWriter(0);
@@ -80,7 +80,7 @@ class MongoKVTableTest {
   @Test
   public void shouldSucceedWriterWithLargerEpoch() throws ExecutionException, InterruptedException {
     // Given:
-    var table = new MongoKVTable(client, name, UNSHARDED);
+    var table = new MongoKVTable(client, name, 1, UNSHARDED);
     var writerFactory = table.init(0);
     var writer = writerFactory.createWriter(0);
     writer.insert(Bytes.wrap(new byte[] {1}), new byte[] {1}, 100);
@@ -88,7 +88,7 @@ class MongoKVTableTest {
 
     // When:
     // initialize new writer with higher epoch
-    table = new MongoKVTable(client, name, UNSHARDED);
+    table = new MongoKVTable(client, name, 1, UNSHARDED);
     writerFactory = table.init(0);
     writer = writerFactory.createWriter(0);
     writer.insert(Bytes.wrap(new byte[] {1}), new byte[] {1}, 101);
@@ -101,11 +101,11 @@ class MongoKVTableTest {
   @Test
   public void shouldFenceWriterSmallerEpoch() throws ExecutionException, InterruptedException {
     // Given:
-    var table0 = new MongoKVTable(client, name, UNSHARDED);
+    var table0 = new MongoKVTable(client, name, 1, UNSHARDED);
     var writerFactory0 = table0.init(0);
     var writer0 = writerFactory0.createWriter(0);
 
-    var table1 = new MongoKVTable(client, name, UNSHARDED);
+    var table1 = new MongoKVTable(client, name, 1, UNSHARDED);
     var writerFactory1 = table1.init(0);
     var writer1 = writerFactory1.createWriter(0);
 

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/CommitBufferTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/CommitBufferTest.java
@@ -194,7 +194,7 @@ public class CommitBufferTest {
 
     sessionClients.initialize(responsiveMetrics, null);
     table = (CassandraKeyValueTable) client.kvFactory().create(
-        new BaseTableSpec(name, partitioner));
+        new BaseTableSpec(name, changelog.topic(), partitioner));
     changelog = new TopicPartition(name + "-changelog", KAFKA_PARTITION);
 
     when(admin.deleteRecords(Mockito.any())).thenReturn(new DeleteRecordsResult(Map.of(

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/utils/TableNameTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/utils/TableNameTest.java
@@ -16,6 +16,9 @@
 
 package dev.responsive.kafka.internal.utils;
 
+import org.apache.kafka.clients.producer.internals.BuiltInPartitioner;
+import org.apache.kafka.common.serialization.Serializer;
+import org.apache.kafka.common.serialization.StringSerializer;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
This PR includes the basic setup for our approach to range queries via client-side filtering based on a partitioner, as well as the implementation for KV stores. The window range queries are in a separate PR since they're a bit more involved.