### PR TITLE
add support to repair offsets on restore

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveKafkaStreams.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveKafkaStreams.java
@@ -421,6 +421,7 @@ public class ResponsiveKafkaStreams extends KafkaStreams {
     public Params build() {
       this.responsiveKafkaClientSupplier = new ResponsiveKafkaClientSupplier(
           clientSupplier,
+          responsiveConfig,
           streamsConfig,
           storeRegistry,
           metrics,

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
@@ -231,6 +231,15 @@ public class ResponsiveConfig extends AbstractConfig {
       + "runs in. When set to RUN, runs the Kafka Streams app. When set to MIGRATE, runs app"
       + " migration.";
 
+  // ------------------ Misc functional overrides ----------------------
+  public static final String RESTORE_OFFSET_REPAIR_ENABLED_CONFIG = "responsive.restore.offset.repair.enabled";
+  public static final boolean RESTORE_OFFSET_REPAIR_ENABLED_DEFAULT = false;
+  public static final String RESTORE_OFFSET_REPAIR_ENABLED_DOC = "When set to 'true', " + RESTORE_OFFSET_REPAIR_ENABLED_CONFIG
+      + " will ignore OffsetOutOfRangeException and instead seek to the earliest available offset. This exception "
+      + "should only happen in situations where there is truncation/retention on the changelog topic and restoring from the latest "
+      + "committed offset in the remote store is no longer possible. Note that in some situations this may cause data "
+      + "loss, use this configuration with caution";
+
   // ------------------ StreamsConfig overrides ----------------------
 
   // These configuration values are required by Responsive, and a ConfigException will
@@ -452,6 +461,12 @@ public class ResponsiveConfig extends AbstractConfig {
           ),
           Importance.LOW,
           RESPONSIVE_MODE_DOC
+      ).define(
+          RESTORE_OFFSET_REPAIR_ENABLED_CONFIG,
+          Type.BOOLEAN,
+          RESTORE_OFFSET_REPAIR_ENABLED_DEFAULT,
+          Importance.LOW,
+          RESTORE_OFFSET_REPAIR_ENABLED_DOC
       );
 
   /**

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/ResponsiveKafkaClientSupplier.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/ResponsiveKafkaClientSupplier.java
@@ -19,6 +19,7 @@ package dev.responsive.kafka.internal.clients;
 import static org.apache.kafka.streams.StreamsConfig.AT_LEAST_ONCE;
 
 import dev.responsive.kafka.api.config.CompatibilityMode;
+import dev.responsive.kafka.api.config.ResponsiveConfig;
 import dev.responsive.kafka.internal.metrics.EndOffsetsPoller;
 import dev.responsive.kafka.internal.metrics.MetricPublishingCommitListener;
 import dev.responsive.kafka.internal.metrics.ResponsiveMetrics;
@@ -67,15 +68,25 @@ public final class ResponsiveKafkaClientSupplier implements KafkaClientSupplier 
   private final String applicationId;
   private final boolean eos;
   private final CompatibilityMode compatibilityMode;
+  private final boolean repairRestoreOffsetOutOfRange;
 
   public ResponsiveKafkaClientSupplier(
       final KafkaClientSupplier clientSupplier,
+      final ResponsiveConfig responsiveConfig,
       final StreamsConfig configs,
       final ResponsiveStoreRegistry storeRegistry,
       final ResponsiveMetrics metrics,
       final CompatibilityMode compatibilityMode
   ) {
-    this(new Factories() {}, clientSupplier, configs, storeRegistry, metrics, compatibilityMode);
+    this(
+        new Factories() {},
+        clientSupplier,
+        configs,
+        storeRegistry,
+        metrics,
+        compatibilityMode,
+        responsiveConfig.getBoolean(ResponsiveConfig.RESTORE_OFFSET_REPAIR_ENABLED_CONFIG)
+    );
   }
 
   ResponsiveKafkaClientSupplier(
@@ -84,13 +95,15 @@ public final class ResponsiveKafkaClientSupplier implements KafkaClientSupplier 
       final StreamsConfig configs,
       final ResponsiveStoreRegistry storeRegistry,
       final ResponsiveMetrics metrics,
-      final CompatibilityMode compatibilityMode
+      final CompatibilityMode compatibilityMode,
+      final boolean repairRestoreOffsetOutOfRange
   ) {
     this.factories = factories;
     this.wrapped = wrapped;
     this.storeRegistry = storeRegistry;
     this.metrics = metrics;
     this.compatibilityMode = compatibilityMode;
+    this.repairRestoreOffsetOutOfRange = repairRestoreOffsetOutOfRange;
 
     eos = !(AT_LEAST_ONCE.equals(
         configs.getString(StreamsConfig.PROCESSING_GUARANTEE_CONFIG)));
@@ -174,7 +187,8 @@ public final class ResponsiveKafkaClientSupplier implements KafkaClientSupplier 
     return factories.createRestoreConsumer(
         clientId,
         wrapped.getRestoreConsumer(config),
-        storeRegistry::getCommittedOffset
+        storeRegistry::getCommittedOffset,
+        repairRestoreOffsetOutOfRange
     );
 
   }
@@ -403,12 +417,14 @@ public final class ResponsiveKafkaClientSupplier implements KafkaClientSupplier 
     default ResponsiveRestoreConsumer<byte[], byte[]> createRestoreConsumer(
         final String clientId,
         final Consumer<byte[], byte[]> restoreConsumer,
-        final Function<TopicPartition, OptionalLong> getCommittedOffset
+        final Function<TopicPartition, OptionalLong> getCommittedOffset,
+        final boolean repairRestoreOffsetOutOfRange
     ) {
       return new ResponsiveRestoreConsumer<>(
           clientId,
           restoreConsumer,
-          getCommittedOffset
+          getCommittedOffset,
+          repairRestoreOffsetOutOfRange
       );
     }
   }

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/clients/ResponsiveKafkaClientSupplierTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/clients/ResponsiveKafkaClientSupplierTest.java
@@ -247,7 +247,7 @@ class ResponsiveKafkaClientSupplierTest {
 
     // then:
     verify(factories, Mockito.atLeastOnce()).createGlobalConsumer(any(), any(), any());
-    verify(factories, Mockito.atLeastOnce()).createRestoreConsumer(any(), any(), any());
+    verify(factories, Mockito.atLeastOnce()).createRestoreConsumer(any(), any(), any(), any());
   }
 
   @Test
@@ -261,7 +261,7 @@ class ResponsiveKafkaClientSupplierTest {
 
     // then:
     verify(factories, Mockito.never()).createGlobalConsumer(any(), any(), any());
-    verify(factories, Mockito.never()).createRestoreConsumer(any(), any(), any());
+    verify(factories, Mockito.never()).createRestoreConsumer(any(), any(), any(), any());
   }
 
   @NotNull
@@ -275,7 +275,8 @@ class ResponsiveKafkaClientSupplierTest {
         new StreamsConfig(CONFIGS),
         storeRegistry,
         metrics,
-        compat
+        compat,
+        false
     );
   }
 

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/clients/ResponsiveRestoreConsumerTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/clients/ResponsiveRestoreConsumerTest.java
@@ -1,25 +1,31 @@
 package dev.responsive.kafka.internal.clients;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
-import dev.responsive.kafka.internal.clients.ResponsiveRestoreConsumer;
 import java.time.Duration;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.OptionalLong;
 import java.util.Set;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.OffsetOutOfRangeException;
 import org.apache.kafka.common.TopicPartition;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
@@ -35,7 +41,11 @@ public class ResponsiveRestoreConsumerTest {
 
   @BeforeEach
   public void setup() {
-    restoreConsumer = new ResponsiveRestoreConsumer<>(
+    restoreConsumer = getRestoreConsumer(false);
+  }
+
+  private ResponsiveRestoreConsumer<?, ?> getRestoreConsumer(boolean repairOffsets) {
+    return  new ResponsiveRestoreConsumer<>(
         "restore-consumer",
         wrapped,
         tp -> {
@@ -46,7 +56,9 @@ public class ResponsiveRestoreConsumerTest {
             return OptionalLong.of(456L);
           }
           return OptionalLong.empty();
-        });
+        },
+        repairOffsets
+    );
   }
 
   @Test
@@ -191,6 +203,43 @@ public class ResponsiveRestoreConsumerTest {
 
     // then:
     restoreConsumer.poll(Duration.ofMillis(100));
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void shouldSeekToBeginningOnOffsetOutOfRangeIfRepairOffsetConfigured() {
+    // Given:
+    restoreConsumer = getRestoreConsumer(true);
+    final ArgumentCaptor<Collection<TopicPartition>> seekedTps
+        = ArgumentCaptor.forClass(Collection.class);
+
+    when(wrapped.poll(any()))
+        .thenThrow(new OffsetOutOfRangeException(Map.of(TOPIC_PARTITION1, 1L)))
+        .thenReturn(null);
+    doNothing().when(wrapped).seekToBeginning(seekedTps.capture());
+
+    // When:
+    restoreConsumer.assign(List.of(TOPIC_PARTITION1));
+    restoreConsumer.seekToBeginning(List.of(TOPIC_PARTITION1));
+    restoreConsumer.poll(Duration.ofMillis(100));
+
+    // Then:
+    verify(wrapped, Mockito.times(2)).poll(any());
+    verify(wrapped).seekToBeginning(Set.of(TOPIC_PARTITION1));
+  }
+
+  @Test
+  public void shouldThrowOffsetOutOfRangeExceptionIfNoRepairConfigured() {
+    // Given:
+    when(wrapped.poll(any()))
+        .thenThrow(new OffsetOutOfRangeException(Map.of(TOPIC_PARTITION1, 1L)))
+        .thenReturn(null);
+
+    // Then:
+    Assertions.assertThrows(
+        OffsetOutOfRangeException.class,
+        () -> restoreConsumer.poll(Duration.ofMillis(100))
+    );
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
`responsive.restore.offset.repair.enabled` allows users to restore from remote committed offsets that have fallen off retention for whatever reason, the behavior will instead seek to beginning