### PR TITLE
add host.name to otel metrics

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/metrics/exporter/otel/OtelMetricsService.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/metrics/exporter/otel/OtelMetricsService.java
@@ -32,6 +32,7 @@ import io.opentelemetry.instrumentation.jmx.yaml.JmxConfig;
 import io.opentelemetry.instrumentation.jmx.yaml.JmxRule;
 import io.opentelemetry.instrumentation.jmx.yaml.RuleParser;
 import io.opentelemetry.instrumentation.resources.ContainerResource;
+import io.opentelemetry.instrumentation.resources.HostResource;
 import io.opentelemetry.sdk.OpenTelemetrySdk;
 import io.opentelemetry.sdk.metrics.SdkMeterProvider;
 import io.opentelemetry.sdk.metrics.export.PeriodicMetricReader;
@@ -87,6 +88,7 @@ public class OtelMetricsService implements MetricsExportService  {
     final var resource = Resource
         .empty() // the .default() one has attributes we don't care about
         .merge(ContainerResource.get())
+        .merge(HostResource.get())
         .merge(Resource.create(
             Attributes.builder()
                 .put(SERVICE_NAME_ATTR, appId + "-otel")


### PR DESCRIPTION
Without this the `host.name` resource tag was not populated by the OTEL metrics exporter. This means that anything that aggregates by host would incorrectly aggregate metrics for every host by aggregating metrics for all hosts.

ex: if we had two hosts that were reporting 10 records/s, the metrics would consider both of them to be processing 20 records/s