### PR TITLE
Async POC: Split queues into readonly / writeonly variants

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/AsyncThread.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/AsyncThread.java
@@ -17,11 +17,10 @@
 package dev.responsive.kafka.api.async.internals;
 
 import dev.responsive.kafka.api.async.internals.contexts.AsyncThreadProcessorContext;
-import dev.responsive.kafka.api.async.internals.queues.FinalizingQueue;
-import dev.responsive.kafka.api.async.internals.queues.ProcessingQueue;
 import dev.responsive.kafka.api.async.internals.events.AsyncEvent;
+import dev.responsive.kafka.api.async.internals.queues.FinalizingQueue.WriteOnlyFinalizingQueue;
+import dev.responsive.kafka.api.async.internals.queues.ProcessingQueue.ReadOnlyProcessingQueue;
 import java.io.Closeable;
-import java.io.IOException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.streams.processor.api.ProcessorContext;
@@ -37,14 +36,14 @@ public class AsyncThread extends Thread implements Closeable {
   //  will need to become a map from processor to context/queue as there should be
   //  an async context per processor instance
   private final AsyncThreadProcessorContext<?, ?> asyncContext;
-  private final ProcessingQueue<?, ?> processingQueue;
-  private final FinalizingQueue<?, ?> finalizingQueue;
+  private final ReadOnlyProcessingQueue<?, ?> processingQueue;
+  private final WriteOnlyFinalizingQueue<?, ?> finalizingQueue;
 
   public AsyncThread(
       final String name,
       final ProcessorContext<?, ?> context,
-      final ProcessingQueue<?, ?> processingQueue,
-      final FinalizingQueue<?, ?> finalizingQueue
+      final ReadOnlyProcessingQueue<?, ?> processingQueue,
+      final WriteOnlyFinalizingQueue<?, ?> finalizingQueue
   ) {
     super(name);
     this.asyncContext = new AsyncThreadProcessorContext<>(context);

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/AsyncThreadPool.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/AsyncThreadPool.java
@@ -19,8 +19,8 @@ package dev.responsive.kafka.api.async.internals;
 import static dev.responsive.kafka.internal.utils.Utils.extractStreamThreadIndex;
 
 import dev.responsive.kafka.api.async.internals.contexts.AsyncThreadProcessorContext;
-import dev.responsive.kafka.api.async.internals.queues.FinalizingQueue;
-import dev.responsive.kafka.api.async.internals.queues.ProcessingQueue;
+import dev.responsive.kafka.api.async.internals.queues.FinalizingQueue.WriteOnlyFinalizingQueue;
+import dev.responsive.kafka.api.async.internals.queues.ProcessingQueue.ReadOnlyProcessingQueue;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -45,8 +45,8 @@ public class AsyncThreadPool {
       final int threadPoolSize,
       final ProcessorContext<?, ?> originalContext,
       final String streamThreadName,
-      final ProcessingQueue<?, ?> processableRecords,
-      final FinalizingQueue<?, ?> finalizableRecords
+      final ReadOnlyProcessingQueue<?, ?> processableRecords,
+      final WriteOnlyFinalizingQueue<?, ?> finalizableRecords
       ) {
     this.log = new LogContext(String.format(
         "stream-thread [%s]", streamThreadName)

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/queues/FinalizingQueue.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/queues/FinalizingQueue.java
@@ -94,5 +94,40 @@ public class FinalizingQueue<KIn, VIn> {
     return finalizableRecords.isEmpty();
   }
 
+  public ReadOnlyFinalizingQueue<KIn, VIn> readOnly() {
+    return new ReadOnlyFinalizingQueue<>(this);
+  }
+
+  public WriteOnlyFinalizingQueue<KIn, VIn> writeOnly() {
+    return new WriteOnlyFinalizingQueue<>(this);
+  }
+
+  public static class ReadOnlyFinalizingQueue<KIn, VIn> {
+    private final FinalizingQueue<KIn, VIn> delegate;
+
+    public ReadOnlyFinalizingQueue(FinalizingQueue<KIn, VIn> delegate) {
+      this.delegate = delegate;
+    }
+
+    public AsyncEvent<KIn, VIn> nextFinalizableEvent() {
+      return delegate.nextFinalizableEvent();
+    }
+
+    public boolean isEmpty() {
+      return delegate.isEmpty();
+    }
+  }
+
+  public static class WriteOnlyFinalizingQueue<KIn, VIn> {
+    private final FinalizingQueue<KIn, VIn> delegate;
+
+    public WriteOnlyFinalizingQueue(FinalizingQueue<KIn, VIn> delegate) {
+      this.delegate = delegate;
+    }
+
+    public void scheduleForFinalization(final AsyncEvent<?, ?> processedEvent) {
+      this.delegate.scheduleForFinalization(processedEvent);
+    }
+  }
 }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/queues/ProcessingQueue.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/queues/ProcessingQueue.java
@@ -16,9 +16,8 @@
 
 package dev.responsive.kafka.api.async.internals.queues;
 
-import dev.responsive.kafka.api.async.internals.events.AsyncEvent;
 import dev.responsive.kafka.api.async.internals.AsyncThread;
-
+import dev.responsive.kafka.api.async.internals.events.AsyncEvent;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import org.apache.kafka.common.utils.LogContext;
@@ -80,4 +79,35 @@ public class ProcessingQueue<KIn, VIn> {
     }
   }
 
+  public ReadOnlyProcessingQueue<KIn, VIn> readOnly() {
+    return new ReadOnlyProcessingQueue<>(this);
+  }
+
+  public WriteOnlyProcessingQueue<KIn, VIn> writeOnly() {
+    return new WriteOnlyProcessingQueue<>(this);
+  }
+
+  public static class ReadOnlyProcessingQueue<KIn, VIn> {
+    private final ProcessingQueue<KIn, VIn> delegate;
+
+    public ReadOnlyProcessingQueue(ProcessingQueue<KIn, VIn> delegate) {
+      this.delegate = delegate;
+    }
+
+    public AsyncEvent<KIn, VIn> nextProcessableEvent() {
+      return delegate.nextProcessableEvent();
+    }
+  }
+
+  public static class WriteOnlyProcessingQueue<KIn, VIn> {
+    private final ProcessingQueue<KIn, VIn> delegate;
+
+    public WriteOnlyProcessingQueue(ProcessingQueue<KIn, VIn> delegate) {
+      this.delegate = delegate;
+    }
+
+    public void scheduleForProcessing(final AsyncEvent<KIn, VIn> processableEvent) {
+      delegate.scheduleForProcessing(processableEvent);
+    }
+  }
 }


### PR DESCRIPTION
This helps make sure they are used correctly in the processor and thread classes.