### PR TITLE
[BREAKING CHANGE] refactor configurations into something coherent

### DIFF
--- a/kafka-client-examples/simple-example/src/main/java/dev/responsive/examples/simpleapp/SimpleApplication.java
+++ b/kafka-client-examples/simple-example/src/main/java/dev/responsive/examples/simpleapp/SimpleApplication.java
@@ -124,9 +124,9 @@ public class SimpleApplication {
   }
 
   private void maybeCreateKeyspace() {
-    LOG.info("create keyspace test");
+    LOG.info("create keyspace responsive_test");
     try (final CqlSession session = cqlSession()) {
-      final CreateKeyspace createKeyspace = SchemaBuilder.createKeyspace("test")
+      final CreateKeyspace createKeyspace = SchemaBuilder.createKeyspace("responsive_test")
           .ifNotExists()
           .withSimpleStrategy(1);
       session.execute(createKeyspace.build());

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveKafkaStreams.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveKafkaStreams.java
@@ -16,11 +16,11 @@
 
 package dev.responsive.kafka.api;
 
-import static dev.responsive.kafka.api.config.ResponsiveConfig.CLIENT_ID_CONFIG;
-import static dev.responsive.kafka.api.config.ResponsiveConfig.CLIENT_SECRET_CONFIG;
 import static dev.responsive.kafka.api.config.ResponsiveConfig.METRICS_ENABLED_CONFIG;
+import static dev.responsive.kafka.api.config.ResponsiveConfig.MONGO_ENDPOINT_CONFIG;
+import static dev.responsive.kafka.api.config.ResponsiveConfig.MONGO_PASSWORD_CONFIG;
+import static dev.responsive.kafka.api.config.ResponsiveConfig.MONGO_USERNAME_CONFIG;
 import static dev.responsive.kafka.api.config.ResponsiveConfig.MONGO_WINDOWED_KEY_TIMESTAMP_FIRST_CONFIG;
-import static dev.responsive.kafka.api.config.ResponsiveConfig.STORAGE_HOSTNAME_CONFIG;
 import static dev.responsive.kafka.api.config.ResponsiveConfig.TASK_ASSIGNOR_CLASS_OVERRIDE;
 import static dev.responsive.kafka.internal.metrics.ResponsiveMetrics.RESPONSIVE_METRICS_NAMESPACE;
 import static org.apache.kafka.streams.StreamsConfig.APPLICATION_ID_CONFIG;
@@ -445,9 +445,9 @@ public class ResponsiveKafkaStreams extends KafkaStreams {
           );
           break;
         case MONGO_DB:
-          final var hostname = responsiveConfig.getString(STORAGE_HOSTNAME_CONFIG);
-          final String clientId = responsiveConfig.getString(CLIENT_ID_CONFIG);
-          final Password clientSecret = responsiveConfig.getPassword(CLIENT_SECRET_CONFIG);
+          final var hostname = responsiveConfig.getString(MONGO_ENDPOINT_CONFIG);
+          final String clientId = responsiveConfig.getString(MONGO_USERNAME_CONFIG);
+          final Password clientSecret = responsiveConfig.getPassword(MONGO_PASSWORD_CONFIG);
           final var mongoClient = SessionUtil.connect(
               hostname,
               clientId,

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
@@ -55,9 +55,7 @@ public class ResponsiveConfig extends AbstractConfig {
 
   public static final String CONTROLLER_ENDPOINT_CONFIG = "responsive.controller.endpoint";
   private static final String CONTROLLER_ENDPOINT_DOC = "The endpoint of the running responsive "
-      + "cloud controller (not including the tenant prefix). If enabled, metrics will be sent to "
-      + "this endpoint.";
-  private static final String CONTROLLER_ENDPOINT_DEFAULT = "ctl.us-west-2.aws.cloud.responsive.dev";
+      + "cloud controller. If enabled, metrics will be sent to this endpoint.";
 
   public static final String PLATFORM_API_KEY_CONFIG = "responsive.platform.api.key";
   private static final String PLATFORM_API_KEY_DOC = "The API Key provided for Metrics access.";
@@ -78,13 +76,13 @@ public class ResponsiveConfig extends AbstractConfig {
   // ------------------ MongoDB specific configurations -----------------------
 
   public static final String MONGO_USERNAME_CONFIG = "responsive.mongo.username";
-  private static final String MONGO_USERNAME_DOC = "";
+  private static final String MONGO_USERNAME_DOC = "The username to use when connecting to MongoDB.";
 
   public static final String MONGO_PASSWORD_CONFIG = "responsive.mongo.password";
-  private static final String MONGO_PASSWORD_DOC = "";
+  private static final String MONGO_PASSWORD_DOC = "The password to use when connecting to MongoDB.";
 
   public static final String MONGO_ENDPOINT_CONFIG = "responsive.mongo.endpoint";
-  private static final String MONGO_ENDPOINT_DOC = "";
+  private static final String MONGO_ENDPOINT_DOC = "The MongoDB endpoint to connect to.";
 
   public static final String MONGO_COLLECTION_SHARDING_ENABLED_CONFIG = "responsive.mongo.collection.sharding.enabled";
   private static final boolean MONGO_COLLECTION_SHARDING_ENABLED_DEFAULT = false;
@@ -108,19 +106,19 @@ public class ResponsiveConfig extends AbstractConfig {
   // ------------------ ScyllaDB specific configurations ----------------------
 
   public static final String CASSANDRA_USERNAME_CONFIG = "responsive.cassandra.username";
-  private static final String CASSANDRA_USERNAME_DOC = "";
+  private static final String CASSANDRA_USERNAME_DOC = "The username to use when connecting to Cassandra";
 
   public static final String CASSANDRA_PASSWORD_CONFIG = "responsive.cassandra.password";
-  private static final String CASSANDRA_PASSWORD_DOC = "";
+  private static final String CASSANDRA_PASSWORD_DOC = "The password to use when connecting to Cassandra";
 
   public static final String CASSANDRA_HOSTNAME_CONFIG = "responsive.cassandra.hostname";
-  private static final String CASSANDRA_HOSTNAME_DOC = "";
+  private static final String CASSANDRA_HOSTNAME_DOC = "The hostname to use when connecting to Cassandra";
 
   public static final String CASSANDRA_PORT_CONFIG = "responsive.cassandra.port";
-  private static final String CASSANDRA_PORT_DOC = "";
+  private static final String CASSANDRA_PORT_DOC = "The port to use when connecting to Cassandra";
 
   public static final String CASSANDRA_DATACENTER_CONFIG = "responsive.cassandra.datacenter";
-  private static final String CASSANDRA_DATACENTER_DOC = "";
+  private static final String CASSANDRA_DATACENTER_DOC = "The datacenter to use when connecting to Cassandra";
 
   public static final String READ_CONSISTENCY_LEVEL_CONFIG = "responsive.cassandra.consistency.reads";
   private static final String READ_CONSISTENCY_LEVEL_DEFAULT = ConsistencyLevel.QUORUM.name();
@@ -357,7 +355,7 @@ public class ResponsiveConfig extends AbstractConfig {
       ).define(
           CONTROLLER_ENDPOINT_CONFIG,
           Type.STRING,
-          CONTROLLER_ENDPOINT_DEFAULT,
+          "",
           Importance.HIGH,
           CONTROLLER_ENDPOINT_DOC
       ). define(

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
@@ -40,40 +40,112 @@ import org.apache.kafka.streams.processor.internals.assignment.StickyTaskAssigno
 @SuppressWarnings("checkstyle:linelength")
 public class ResponsiveConfig extends AbstractConfig {
 
-  // ------------------ connection configurations -----------------------------
+  // ------------------ general Responsive configurations ---------------------
+
+  public static final String RESPONSIVE_ORG_CONFIG = "responsive.org";
+  private static final String RESPONSIVE_ORG_DOC = "The Responsive organization slug (not the organization ID).";
+
+  public static final String RESPONSIVE_ENV_CONFIG = "responsive.env";
+  private static final String RESPONSIVE_ENV_DOC = "The Responsive environment slug (not the environment ID).";
 
   public static final String COMPATIBILITY_MODE_CONFIG = "responsive.compatibility.mode";
   private static final String COMPATIBILITY_MODE_DOC = "This configuration enables running Responsive "
       + "in compatibility mode, disabling certain features.";
   private static final CompatibilityMode COMPATIBILITY_MODE_DEFAULT = CompatibilityMode.FULL;
 
-  public static final String STORAGE_HOSTNAME_CONFIG = "responsive.storage.hostname";
-  private static final String STORAGE_HOSTNAME_DOC = "The hostname of the storage server.";
+  public static final String CONTROLLER_ENDPOINT_CONFIG = "responsive.controller.endpoint";
+  private static final String CONTROLLER_ENDPOINT_DOC = "The endpoint of the running responsive "
+      + "cloud controller (not including the tenant prefix). If enabled, metrics will be sent to "
+      + "this endpoint.";
+  private static final String CONTROLLER_ENDPOINT_DEFAULT = "ctl.us-west-2.aws.cloud.responsive.dev";
 
-  public static final String STORAGE_PORT_CONFIG = "responsive.storage.port";
-  private static final String STORAGE_PORT_DOC = "The port of the storage server.";
+  public static final String PLATFORM_API_KEY_CONFIG = "responsive.platform.api.key";
+  private static final String PLATFORM_API_KEY_DOC = "The API Key provided for Metrics access.";
 
-  public static final String STORAGE_DATACENTER_CONFIG = "responsive.storage.datacenter";
-  public static final String STORAGE_DATACENTER_DOC = "The datacenter for the storage server";
-
-  public static final String CONNECTION_BUNDLE_CONFIG = "responsive.connection.bundle";
-  private static final String CONNECTION_BUNDLE_DOC = "Path to the configuration bundle for "
-      + "connecting to Responsive cloud. Either this or " + STORAGE_HOSTNAME_CONFIG
-      + ", " + STORAGE_PORT_CONFIG + " and " + STORAGE_DATACENTER_CONFIG + " must be set.";
-
-  public static final String TENANT_ID_CONFIG = "responsive.tenant.id";
-  private static final String TENANT_ID_DOC = "The tenant ID provided by Responsive for "
-      + "resource isolation.";
-
-  public static final String CLIENT_ID_CONFIG = "responsive.client.id";
-  private static final String CLIENT_ID_DOC = "The client ID for authenticated access";
-
-  public static final String CLIENT_SECRET_CONFIG = "responsive.client.secret";
-  private static final String CLIENT_SECRET_DOC = "The client secret for authenticated access";
+  public static final String PLATFORM_API_SECRET_CONFIG = "responsive.platform.api.secret";
+  private static final String PLATFORM_API_SECRET_DOC = "The Secret provided for Metrics access.";
 
   public static final String STORAGE_BACKEND_TYPE_CONFIG = "responsive.storage.backend.type";
   private static final String STORAGE_BACKEND_TYPE_DOC = "The storage backend";
   private static final StorageBackend STORAGE_BACKEND_TYPE_DEFAULT = StorageBackend.CASSANDRA;
+
+  public static final String RESPONSIVE_MODE = "responsive.mode";
+  public static final String RESPONSIVE_MODE_DEFAULT = ResponsiveMode.RUN.name();
+  public static final String RESPONSIVE_MODE_DOC = "Determines the mode the Responsive application "
+      + "runs in. When set to RUN, runs the Kafka Streams app. When set to MIGRATE, runs app"
+      + " migration.";
+
+  // ------------------ MongoDB specific configurations -----------------------
+
+  public static final String MONGO_USERNAME_CONFIG = "responsive.mongo.username";
+  private static final String MONGO_USERNAME_DOC = "";
+
+  public static final String MONGO_PASSWORD_CONFIG = "responsive.mongo.password";
+  private static final String MONGO_PASSWORD_DOC = "";
+
+  public static final String MONGO_ENDPOINT_CONFIG = "responsive.mongo.endpoint";
+  private static final String MONGO_ENDPOINT_DOC = "";
+
+  public static final String MONGO_COLLECTION_SHARDING_ENABLED_CONFIG = "responsive.mongo.collection.sharding.enabled";
+  private static final boolean MONGO_COLLECTION_SHARDING_ENABLED_DEFAULT = false;
+  private static final String MONGO_COLLECTION_SHARDING_ENABLED_DOC = "Toggles use of sharded collections. Set "
+      + "this to true when running against a sharded mongo cluster, to shard a collection across multiple mongo "
+      + "replica sets.";
+
+  public static final String MONGO_COLLECTION_SHARDING_CHUNKS_CONFIG = "responsive.mongo.collection.sharding.chunks";
+  private static final int MONGO_COLLECTION_SHARDING_CHUNKS_DEFAULT = 4;
+  private static final String MONGO_COLLECTION_SHARDING_CHUNKS_DOC = "For sharded collections, sets the number of "
+      + "initial chunks to create the collection with.";
+
+  public static final String MONGO_WINDOWED_KEY_TIMESTAMP_FIRST_CONFIG = "responsive.mongo.windowed.key.timestamp.first";
+  private static final boolean MONGO_WINDOWED_KEY_TIMESTAMP_FIRST_DEFAULT = false;
+  private static final String MONGO_WINDOWED_KEY_TIMESTAMP_FIRST_DOC = "Whether to put the window start timestamp "
+      + "first in the composite windowed key format for MongoDB. This can be toggled true/false to get better "
+      + "performance depending on the density of unique keys per window, and should be experimented "
+      + "with for best results. However it is important to note that this cannot be changed for "
+      + "an active application. Messing with this can corrupt existing state!";
+
+  // ------------------ ScyllaDB specific configurations ----------------------
+
+  public static final String CASSANDRA_USERNAME_CONFIG = "responsive.cassandra.username";
+  private static final String CASSANDRA_USERNAME_DOC = "";
+
+  public static final String CASSANDRA_PASSWORD_CONFIG = "responsive.cassandra.password";
+  private static final String CASSANDRA_PASSWORD_DOC = "";
+
+  public static final String CASSANDRA_HOSTNAME_CONFIG = "responsive.cassandra.hostname";
+  private static final String CASSANDRA_HOSTNAME_DOC = "";
+
+  public static final String CASSANDRA_PORT_CONFIG = "responsive.cassandra.port";
+  private static final String CASSANDRA_PORT_DOC = "";
+
+  public static final String CASSANDRA_DATACENTER_CONFIG = "responsive.cassandra.datacenter";
+  private static final String CASSANDRA_DATACENTER_DOC = "";
+
+  public static final String READ_CONSISTENCY_LEVEL_CONFIG = "responsive.cassandra.consistency.reads";
+  private static final String READ_CONSISTENCY_LEVEL_DEFAULT = ConsistencyLevel.QUORUM.name();
+  private static final String READ_CONSISTENCY_LEVEL_DOC = "The consistency level to set for reads";
+
+  public static final String WRITE_CONSISTENCY_LEVEL_CONFIG = "responsive.cassandra.consistency.writes";
+  private static final String WRITE_CONSISTENCY_LEVEL_DEFAULT = ConsistencyLevel.QUORUM.name();
+  private static final String WRITE_CONSISTENCY_LEVEL_DOC = "The consistency level to set for writes";
+
+  public static final String CASSANDRA_CHECK_INTERVAL_MS = "responsive.cassandra.check.interval.ms";
+  private static final String CASSANDRA_CHECK_INTERVAL_MS_DOC = "The frequency at which to poll "
+      + "for whether or not a remote table has been created. Mostly used to speed up integration "
+      + "testing.";
+  private static final long CASSANDRA_CHECK_INTERVAL_MS_DEFAULT = 1000L;
+
+  // TODO: we should make this configurable per-store
+  public static final String CASSANDRA_DESIRED_NUM_PARTITION_CONFIG = "responsive.cassandra.desired.num.partitions";
+  private static final String CASSANDRA_DESIRED_NUM_PARTITIONS_DOC = "The desired number of "
+      + "partitions to create in the remote store. This is a best effort target, as the actual "
+      + "number of partitions will be the next multiple of the Kafka topic's number of partitions "
+      + "that is greater than or equal to this number. This configuration does not apply to global "
+      + "stores. A value of -1 indicates to use the number of Kafka Partitions as the remote "
+      + "partitions as well.";
+  public static final int CASSANDRA_DESIRED_NUM_PARTITIONS_DEFAULT = 4096;
+  public static final int NO_SUBPARTITIONS = -1;
 
   // ------------------ metrics configurations --------------------------------
 
@@ -86,52 +158,7 @@ public class ResponsiveConfig extends AbstractConfig {
   public static final String METRICS_ENABLED_CONFIG = "responsive.metrics.enabled";
   private static final String METRICS_ENABLED_DOC = "Whether or not metrics should be sent to Responsive Cloud";
 
-  public static final String CONTROLLER_ENDPOINT_CONFIG = "responsive.controller.endpoint";
-  private static final String CONTROLLER_ENDPOINT_DOC = "The endpoint of the running responsive "
-      + "cloud controller. If enabled, metrics will be sent to this endpoint.";
-
-  // TODO(agavra): we should consolidate API keys, but for now it's OK to use different ones
-  public static final String METRICS_API_KEY_CONFIG = "responsive.metrics.api.key";
-  private static final String METRICS_API_KEY_DOC = "The API Key provided for Metrics access.";
-
-  public static final String METRICS_SECRET_CONFIG = "responsive.metrics.secret";
-  private static final String METRICS_SECRET_DOC = "The Secret provided for Metrics access.";
-
-  // ------------------ cassandra configurations ------------------------------
-
-  public static final String READ_CONSISTENCY_LEVEL_CONFIG = "responsive.cassandra.consistency.reads";
-  private static final String READ_CONSISTENCY_LEVEL_DEFAULT = ConsistencyLevel.QUORUM.name();
-  private static final String READ_CONSISTENCY_LEVEL_DOC = "The consistency level to set for reads";
-
-  public static final String WRITE_CONSISTENCY_LEVEL_CONFIG = "responsive.cassandra.consistency.writes";
-  private static final String WRITE_CONSISTENCY_LEVEL_DEFAULT = ConsistencyLevel.QUORUM.name();
-  private static final String WRITE_CONSISTENCY_LEVEL_DOC = "The consistency level to set for writes";
-
-  // ------------------ request configurations --------------------------------
-
-  public static final String REQUEST_TIMEOUT_MS_CONFIG = "responsive.request.timeout.ms";
-  private static final String REQUEST_TIMEOUT_MS_DOC = "The timeout for making requests to the "
-      + "responsive server. This applies both to metadata requests and query execution.";
-  private static final long REQUEST_TIMEOUT_MS_DEFAULT = 5000L;
-
-  public static final String REMOTE_TABLE_CHECK_INTERVAL_MS_CONFIG = "responsive.remote.table.check.interval.ms";
-  private static final String REMOTE_TABLE_CHECK_INTERVAL_MS_DOC = "The frequency at which to poll "
-      + "for whether or not a remote table has been created. Mostly used to speed up integration "
-      + "testing.";
-  private static final long REMOTE_TABLE_CHECK_INTERVAL_MS_DEFAULT = 1000L;
-
   // ------------------ performance related configurations --------------------
-
-  // TODO: we should make this configurable per-store
-  public static final String STORAGE_DESIRED_NUM_PARTITION_CONFIG = "responsive.storage.desired.num.partitions";
-  private static final String STORAGE_DESIRED_NUM_PARTITIONS_DOC = "The desired number of "
-      + "partitions to create in the remote store. This is a best effort target, as the actual "
-      + "number of partitions will be the next multiple of the Kafka topic's number of partitions "
-      + "that is greater than or equal to this number. This configuration does not apply to global "
-      + "stores. A value of -1 indicates to use the number of Kafka Partitions as the remote "
-      + "partitions as well.";
-  public static final int STORAGE_DESIRED_NUM_PARTITIONS_DEFAULT = 4096;
-  public static final int NO_SUBPARTITIONS = -1;
 
   // TODO: we should have another config that's applied globally, that sets a size bound on
   //       the total amount of buffered data. That config can be used to keep a bound on
@@ -178,27 +205,8 @@ public class ResponsiveConfig extends AbstractConfig {
   private static final String SUBPARTITION_HASHER_DOC = "Hasher to use for sub-partitioning.";
   private static final Class<?> SUBPARTITION_HASHER_DEFAULT = Murmur3Hasher.class;
 
-  public static final String MONGO_COLLECTION_SHARDING_ENABLED_CONFIG = "responsive.mongo.collection.sharding.enabled";
-  private static final boolean MONGO_COLLECTION_SHARDING_ENABLED_DEFAULT = false;
-  private static final String MONGO_COLLECTION_SHARDING_ENABLED_DOC = "Toggles use of sharded collections. Set "
-      + "this to true when running against a sharded mongo cluster, to shard a collection across multiple mongo "
-      + "replica sets.";
-
-  public static final String MONGO_COLLECTION_SHARDING_CHUNKS_CONFIG = "responsive.mongo.collection.sharding.chunks";
-  private static final int MONGO_COLLECTION_SHARDING_CHUNKS_DEFAULT = 4;
-  private static final String MONGO_COLLECTION_SHARDING_CHUNKS_DOC = "For sharded collections, sets the number of "
-      + "initial chunks to create the collection with.";
-
 
   // ------------------ WindowStore configurations ----------------------
-
-  public static final String MONGO_WINDOWED_KEY_TIMESTAMP_FIRST_CONFIG = "responsive.mongo.windowed.key.timestamp.first";
-  private static final boolean MONGO_WINDOWED_KEY_TIMESTAMP_FIRST_DEFAULT = false;
-  private static final String MONGO_WINDOWED_KEY_TIMESTAMP_FIRST_DOC = "Whether to put the window start timestamp "
-      + "first in the composite windowed key format for MongoDB. This can be toggled true/false to get better "
-      + "performance depending on the density of unique keys per window, and should be experimented "
-      + "with for best results. However it is important to note that this cannot be changed for "
-      + "an active application. Messing with this can corrupt existing state!";
 
   public static final String WINDOW_BLOOM_FILTER_COUNT_CONFIG = "responsive.window.bloom.filter.count";
   private static final int WINDOW_BLOOM_FILTER_COUNT_DEFAULT = 0;
@@ -225,12 +233,6 @@ public class ResponsiveConfig extends AbstractConfig {
       + "lookups but requires more heap memory";
 
 
-  public static final String RESPONSIVE_MODE = "responsive.mode";
-  public static final String RESPONSIVE_MODE_DEFAULT = ResponsiveMode.RUN.name();
-  public static final String RESPONSIVE_MODE_DOC = "Determines the mode the Responsive application "
-      + "runs in. When set to RUN, runs the Kafka Streams app. When set to MIGRATE, runs app"
-      + " migration.";
-
   // ------------------ Misc functional overrides ----------------------
   public static final String RESTORE_OFFSET_REPAIR_ENABLED_CONFIG = "responsive.restore.offset.repair.enabled";
   public static final boolean RESTORE_OFFSET_REPAIR_ENABLED_DEFAULT = false;
@@ -255,53 +257,20 @@ public class ResponsiveConfig extends AbstractConfig {
           ConfigDef.CaseInsensitiveValidString.in(CompatibilityMode.names()),
           Importance.MEDIUM,
           COMPATIBILITY_MODE_DOC
-      )
-      .define(
-          STORAGE_HOSTNAME_CONFIG,
+      ).define(
+          RESPONSIVE_ORG_CONFIG,
           Type.STRING,
           null,
           new ConfigDef.NonEmptyString(),
           Importance.HIGH,
-          STORAGE_HOSTNAME_DOC
+          RESPONSIVE_ORG_DOC
       ).define(
-          STORAGE_PORT_CONFIG,
-          Type.INT,
-          -1,
-          Importance.HIGH,
-          STORAGE_PORT_DOC
-      ).define(
-          STORAGE_DATACENTER_CONFIG,
+          RESPONSIVE_ENV_CONFIG,
           Type.STRING,
           null,
           new ConfigDef.NonEmptyString(),
           Importance.HIGH,
-          STORAGE_DATACENTER_DOC
-      ).define(
-          CONNECTION_BUNDLE_CONFIG,
-          Type.STRING,
-          null,
-          new ConfigDef.NonEmptyString(),
-          Importance.HIGH,
-          CONNECTION_BUNDLE_DOC
-      ).define(
-          TENANT_ID_CONFIG,
-          Type.STRING,
-          Importance.HIGH,
-          TENANT_ID_DOC
-      ).define(
-          CLIENT_ID_CONFIG,
-          Type.STRING,
-          null,
-          new ConfigDef.NonEmptyString(),
-          Importance.HIGH,
-          CLIENT_ID_DOC
-      ).define(
-          CLIENT_SECRET_CONFIG,
-          Type.PASSWORD,
-          null,
-          new NonEmptyPassword(CLIENT_SECRET_CONFIG),
-          Importance.HIGH,
-          CLIENT_SECRET_DOC
+          RESPONSIVE_ENV_DOC
       ).define(
           STORAGE_BACKEND_TYPE_CONFIG,
           Type.STRING,
@@ -309,7 +278,71 @@ public class ResponsiveConfig extends AbstractConfig {
           ConfigDef.CaseInsensitiveValidString.in(StorageBackend.names()),
           Importance.HIGH,
           STORAGE_BACKEND_TYPE_DOC
+      )
+
+      // mongo connection configurations
+      .define(
+          MONGO_USERNAME_CONFIG,
+          Type.STRING,
+          null,
+          new ConfigDef.NonEmptyString(),
+          Importance.HIGH,
+          MONGO_USERNAME_DOC
       ).define(
+          MONGO_PASSWORD_CONFIG,
+          Type.PASSWORD,
+          null,
+          new NonEmptyPassword(MONGO_PASSWORD_CONFIG),
+          Importance.HIGH,
+          MONGO_PASSWORD_DOC
+      ).define(
+          MONGO_ENDPOINT_CONFIG,
+          Type.STRING,
+          null,
+          new ConfigDef.NonEmptyString(),
+          Importance.HIGH,
+          MONGO_ENDPOINT_DOC
+      )
+
+      // cassandra connection configurations
+      .define(
+          CASSANDRA_USERNAME_CONFIG,
+          Type.STRING,
+          null,
+          new ConfigDef.NonEmptyString(),
+          Importance.HIGH,
+          CASSANDRA_USERNAME_DOC
+      ).define(
+          CASSANDRA_PASSWORD_CONFIG,
+          Type.PASSWORD,
+          null,
+          new NonEmptyPassword(MONGO_PASSWORD_CONFIG),
+          Importance.HIGH,
+          CASSANDRA_PASSWORD_DOC
+      ).define(
+          CASSANDRA_HOSTNAME_CONFIG,
+          Type.STRING,
+          null,
+          new ConfigDef.NonEmptyString(),
+          Importance.HIGH,
+          CASSANDRA_HOSTNAME_DOC
+      ).define(
+          CASSANDRA_PORT_CONFIG,
+          Type.INT,
+          -1,
+          Importance.HIGH,
+          CASSANDRA_PORT_DOC
+      ).define(
+          CASSANDRA_DATACENTER_CONFIG,
+          Type.STRING,
+          null,
+          new ConfigDef.NonEmptyString(),
+          Importance.HIGH,
+          CASSANDRA_DATACENTER_DOC
+      )
+
+      // other configs
+      .define(
           RESPONSIVE_APPLICATION_ID_CONFIG,
           Type.STRING,
           "",
@@ -324,27 +357,21 @@ public class ResponsiveConfig extends AbstractConfig {
       ).define(
           CONTROLLER_ENDPOINT_CONFIG,
           Type.STRING,
-          "",
+          CONTROLLER_ENDPOINT_DEFAULT,
           Importance.HIGH,
           CONTROLLER_ENDPOINT_DOC
       ). define(
-          METRICS_API_KEY_CONFIG,
+          PLATFORM_API_KEY_CONFIG,
           Type.STRING,
           "",
           Importance.HIGH,
-          METRICS_API_KEY_DOC
+          PLATFORM_API_KEY_DOC
       ).define(
-          METRICS_SECRET_CONFIG,
+          PLATFORM_API_SECRET_CONFIG,
           Type.PASSWORD,
           "",
           Importance.HIGH,
-          METRICS_SECRET_DOC
-      ).define(
-          REQUEST_TIMEOUT_MS_CONFIG,
-          Type.LONG,
-          REQUEST_TIMEOUT_MS_DEFAULT,
-          Importance.MEDIUM,
-          REQUEST_TIMEOUT_MS_DOC
+          PLATFORM_API_SECRET_DOC
       ).define(
           STORE_FLUSH_RECORDS_TRIGGER_CONFIG,
           Type.INT,
@@ -352,11 +379,11 @@ public class ResponsiveConfig extends AbstractConfig {
           Importance.MEDIUM,
           STORE_FLUSH_RECORDS_TRIGGER_DOC
       ).define(
-          STORAGE_DESIRED_NUM_PARTITION_CONFIG,
+          CASSANDRA_DESIRED_NUM_PARTITION_CONFIG,
           Type.INT,
-          STORAGE_DESIRED_NUM_PARTITIONS_DEFAULT,
+          CASSANDRA_DESIRED_NUM_PARTITIONS_DEFAULT,
           Importance.MEDIUM,
-          STORAGE_DESIRED_NUM_PARTITIONS_DOC
+          CASSANDRA_DESIRED_NUM_PARTITIONS_DOC
       ).define(
           MAX_CONCURRENT_REQUESTS_CONFIG,
           Type.INT,
@@ -388,11 +415,11 @@ public class ResponsiveConfig extends AbstractConfig {
           Importance.LOW,
           SUBPARTITION_HASHER_DOC
       ).define(
-          REMOTE_TABLE_CHECK_INTERVAL_MS_CONFIG,
+          CASSANDRA_CHECK_INTERVAL_MS,
           Type.LONG,
-          REMOTE_TABLE_CHECK_INTERVAL_MS_DEFAULT,
+          CASSANDRA_CHECK_INTERVAL_MS_DEFAULT,
           Importance.LOW,
-          REMOTE_TABLE_CHECK_INTERVAL_MS_DOC
+          CASSANDRA_CHECK_INTERVAL_MS_DOC
       ).define(
           MONGO_COLLECTION_SHARDING_ENABLED_CONFIG,
           Type.BOOLEAN,

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/config/ConfigUtils.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/config/ConfigUtils.java
@@ -16,7 +16,10 @@
 
 package dev.responsive.kafka.internal.config;
 
+import static dev.responsive.kafka.api.config.ResponsiveConfig.CONTROLLER_ENDPOINT_CONFIG;
 import static dev.responsive.kafka.api.config.ResponsiveConfig.RESPONSIVE_APPLICATION_ID_CONFIG;
+import static dev.responsive.kafka.api.config.ResponsiveConfig.RESPONSIVE_ENV_CONFIG;
+import static dev.responsive.kafka.api.config.ResponsiveConfig.RESPONSIVE_ORG_CONFIG;
 
 import dev.responsive.kafka.api.config.CompatibilityMode;
 import dev.responsive.kafka.api.config.ResponsiveConfig;
@@ -35,6 +38,19 @@ public class ConfigUtils {
 
   private ConfigUtils() {
     /* Empty constructor for public class */
+  }
+
+  public static String tenant(final ResponsiveConfig config) {
+    return config.getString(RESPONSIVE_ORG_CONFIG) + "-" + config.getString(RESPONSIVE_ENV_CONFIG);
+  }
+
+  public static String cassandraKeyspace(final ResponsiveConfig config) {
+    return config.getString(RESPONSIVE_ORG_CONFIG) + "_" + config.getString(RESPONSIVE_ENV_CONFIG);
+  }
+
+  public static String controllerUri(final ResponsiveConfig config) {
+    final var controllerUri = config.getString(CONTROLLER_ENDPOINT_CONFIG);
+    return tenant(config) + "." + controllerUri;
   }
 
   public static StorageBackend storageBackend(final ResponsiveConfig config) {

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/config/ConfigUtils.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/config/ConfigUtils.java
@@ -16,7 +16,6 @@
 
 package dev.responsive.kafka.internal.config;
 
-import static dev.responsive.kafka.api.config.ResponsiveConfig.CONTROLLER_ENDPOINT_CONFIG;
 import static dev.responsive.kafka.api.config.ResponsiveConfig.RESPONSIVE_APPLICATION_ID_CONFIG;
 import static dev.responsive.kafka.api.config.ResponsiveConfig.RESPONSIVE_ENV_CONFIG;
 import static dev.responsive.kafka.api.config.ResponsiveConfig.RESPONSIVE_ORG_CONFIG;
@@ -40,17 +39,8 @@ public class ConfigUtils {
     /* Empty constructor for public class */
   }
 
-  public static String tenant(final ResponsiveConfig config) {
-    return config.getString(RESPONSIVE_ORG_CONFIG) + "-" + config.getString(RESPONSIVE_ENV_CONFIG);
-  }
-
   public static String cassandraKeyspace(final ResponsiveConfig config) {
     return config.getString(RESPONSIVE_ORG_CONFIG) + "_" + config.getString(RESPONSIVE_ENV_CONFIG);
-  }
-
-  public static String controllerUri(final ResponsiveConfig config) {
-    final var controllerUri = config.getString(CONTROLLER_ENDPOINT_CONFIG);
-    return tenant(config) + "." + controllerUri;
   }
 
   public static StorageBackend storageBackend(final ResponsiveConfig config) {

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraClient.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraClient.java
@@ -141,7 +141,7 @@ public class CassandraClient {
     return new RemoteMonitor(
         executor,
         checkRemote,
-        Duration.ofMillis(config.getLong(ResponsiveConfig.REMOTE_TABLE_CHECK_INTERVAL_MS_CONFIG))
+        Duration.ofMillis(config.getLong(ResponsiveConfig.CASSANDRA_CHECK_INTERVAL_MS))
     );
   }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/DefaultCassandraClientFactory.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/DefaultCassandraClientFactory.java
@@ -1,15 +1,15 @@
 package dev.responsive.kafka.internal.db;
 
-import static dev.responsive.kafka.api.config.ResponsiveConfig.CLIENT_ID_CONFIG;
-import static dev.responsive.kafka.api.config.ResponsiveConfig.CLIENT_SECRET_CONFIG;
+import static dev.responsive.kafka.api.config.ResponsiveConfig.CASSANDRA_DATACENTER_CONFIG;
+import static dev.responsive.kafka.api.config.ResponsiveConfig.CASSANDRA_HOSTNAME_CONFIG;
+import static dev.responsive.kafka.api.config.ResponsiveConfig.CASSANDRA_PASSWORD_CONFIG;
+import static dev.responsive.kafka.api.config.ResponsiveConfig.CASSANDRA_PORT_CONFIG;
+import static dev.responsive.kafka.api.config.ResponsiveConfig.CASSANDRA_USERNAME_CONFIG;
 import static dev.responsive.kafka.api.config.ResponsiveConfig.MAX_CONCURRENT_REQUESTS_CONFIG;
-import static dev.responsive.kafka.api.config.ResponsiveConfig.STORAGE_DATACENTER_CONFIG;
-import static dev.responsive.kafka.api.config.ResponsiveConfig.STORAGE_HOSTNAME_CONFIG;
-import static dev.responsive.kafka.api.config.ResponsiveConfig.STORAGE_PORT_CONFIG;
-import static dev.responsive.kafka.api.config.ResponsiveConfig.TENANT_ID_CONFIG;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import dev.responsive.kafka.api.config.ResponsiveConfig;
+import dev.responsive.kafka.internal.config.ConfigUtils;
 import dev.responsive.kafka.internal.utils.SessionUtil;
 import java.net.InetSocketAddress;
 import org.apache.kafka.common.config.types.Password;
@@ -18,21 +18,22 @@ public class DefaultCassandraClientFactory implements CassandraClientFactory {
   @Override
   public CqlSession createCqlSession(final ResponsiveConfig config) {
     final InetSocketAddress address = InetSocketAddress.createUnresolved(
-        config.getString(STORAGE_HOSTNAME_CONFIG),
-        config.getInt(STORAGE_PORT_CONFIG)
+        config.getString(CASSANDRA_HOSTNAME_CONFIG),
+        config.getInt(CASSANDRA_PORT_CONFIG)
     );
-    final String datacenter = config.getString(STORAGE_DATACENTER_CONFIG);
-    final String clientId = config.getString(CLIENT_ID_CONFIG);
-    final Password clientSecret = config.getPassword(CLIENT_SECRET_CONFIG);
-    final String tenant = config.getString(TENANT_ID_CONFIG);
+
+    final String datacenter = config.getString(CASSANDRA_DATACENTER_CONFIG);
+    final String username = config.getString(CASSANDRA_USERNAME_CONFIG);
+    final Password password = config.getPassword(CASSANDRA_PASSWORD_CONFIG);
+    final String keyspace = ConfigUtils.cassandraKeyspace(config);
     final int maxConcurrency = config.getInt(MAX_CONCURRENT_REQUESTS_CONFIG);
 
     return SessionUtil.connect(
         address,
         datacenter,
-        tenant,
-        clientId,
-        clientSecret == null ? null : clientSecret.value(),
+        keyspace,
+        username,
+        password == null ? null : password.value(),
         maxConcurrency
     );
   }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/partitioning/SubPartitioner.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/partitioning/SubPartitioner.java
@@ -16,7 +16,7 @@
 
 package dev.responsive.kafka.internal.db.partitioning;
 
-import static dev.responsive.kafka.api.config.ResponsiveConfig.STORAGE_DESIRED_NUM_PARTITION_CONFIG;
+import static dev.responsive.kafka.api.config.ResponsiveConfig.CASSANDRA_DESIRED_NUM_PARTITION_CONFIG;
 import static dev.responsive.kafka.api.config.ResponsiveConfig.SUBPARTITION_HASHER_CONFIG;
 
 import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting;
@@ -65,7 +65,7 @@ public class SubPartitioner implements TablePartitioner<Bytes, Integer> {
       final ResponsiveConfig config,
       final String changelogTopicName
   ) {
-    final int requestedNumSubPartitions = config.getInt(STORAGE_DESIRED_NUM_PARTITION_CONFIG);
+    final int requestedNumSubPartitions = config.getInt(CASSANDRA_DESIRED_NUM_PARTITION_CONFIG);
 
     final int factor = (requestedNumSubPartitions == ResponsiveConfig.NO_SUBPARTITIONS)
         ? 1 : (int) Math.ceil((double) requestedNumSubPartitions / numKafkaPartitions);
@@ -79,9 +79,9 @@ public class SubPartitioner implements TablePartitioner<Bytes, Integer> {
                   + "for table %s (remote partitions must be a multiple of the kafka partitions). "
                   + "The remote store is already initialized with %d partitions - it is backwards "
                   + "incompatible to change this. Please set %s to %d.",
-              STORAGE_DESIRED_NUM_PARTITION_CONFIG, requestedNumSubPartitions, numKafkaPartitions,
+              CASSANDRA_DESIRED_NUM_PARTITION_CONFIG, requestedNumSubPartitions, numKafkaPartitions,
               changelogTopicName, computedRemoteNum, tableName,
-              actualRemoteCount.getAsInt(), STORAGE_DESIRED_NUM_PARTITION_CONFIG,
+              actualRemoteCount.getAsInt(), CASSANDRA_DESIRED_NUM_PARTITION_CONFIG,
               actualRemoteCount.getAsInt()));
     }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/metrics/exporter/otel/OtelMetricsService.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/metrics/exporter/otel/OtelMetricsService.java
@@ -60,15 +60,15 @@ public class OtelMetricsService implements MetricsExportService  {
   ) {
     final OtlpGrpcMetricExporterBuilder builder = OtlpGrpcMetricExporter.builder();
 
-    final String apiKey = config.getString(ResponsiveConfig.METRICS_API_KEY_CONFIG);
-    final Password secret = config.getPassword(ResponsiveConfig.METRICS_SECRET_CONFIG);
+    final String apiKey = config.getString(ResponsiveConfig.PLATFORM_API_KEY_CONFIG);
+    final Password secret = config.getPassword(ResponsiveConfig.PLATFORM_API_SECRET_CONFIG);
     if (secret == null ^ apiKey == null) {
       throw new IllegalArgumentException(String.format(
           "Invalid configuration, if configured to report metrics using %s, "
               + "then values for both %s and %s must be provided.",
           ResponsiveConfig.METRICS_ENABLED_CONFIG,
-          ResponsiveConfig.METRICS_API_KEY_CONFIG,
-          ResponsiveConfig.METRICS_SECRET_CONFIG
+          ResponsiveConfig.PLATFORM_API_KEY_CONFIG,
+          ResponsiveConfig.PLATFORM_API_SECRET_CONFIG
       ));
     } else if (secret != null) {
       builder.addHeader(ApiKeyHeaders.API_KEY_METADATA_KEY, apiKey);

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/utils/SessionUtil.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/utils/SessionUtil.java
@@ -56,18 +56,19 @@ public final class SessionUtil {
       final InetSocketAddress address,
       final String datacenter,
       final String keyspace,
-      @Nullable final String clientId,
-      @Nullable final String clientSecret,
+      @Nullable final String username,
+      @Nullable final String password,
       final int maxConcurrentRequests
   ) {
     final CqlSessionBuilder sessionBuilder = CqlSession.builder()
         .addContactPoint(address)
         .withLocalDatacenter(datacenter);
 
-    if (clientId != null && clientSecret != null) {
-      sessionBuilder.withAuthCredentials(clientId, clientSecret);
-    } else if (clientId == null ^ clientSecret == null) {
-      throw new IllegalArgumentException("Must specify both or neither clientId and clientSecret.");
+    if (username != null && password != null) {
+      sessionBuilder.withAuthCredentials(username, password);
+    } else if (username == null ^ password == null) {
+      throw new IllegalArgumentException(
+          "Must specify both or neither Cassandra username and password.");
     }
 
     return sessionBuilder
@@ -105,7 +106,8 @@ public final class SessionUtil {
           hostname
       );
     } else if (clientId == null ^ clientSecret == null) {
-      throw new IllegalArgumentException("Must specify both or neither clientId and clientSecret.");
+      throw new IllegalArgumentException(
+          "Must specify both or neither Mongo username and password.");
     } else {
       // TODO(agavra): TestContainers uses a different connection string, for now
       // we just assume that all non authenticated usage is via test containers

--- a/kafka-client/src/test/java/dev/responsive/kafka/api/ResponsiveKafkaStreamsTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/api/ResponsiveKafkaStreamsTest.java
@@ -17,7 +17,8 @@
 package dev.responsive.kafka.api;
 
 import static dev.responsive.kafka.api.config.ResponsiveConfig.COMPATIBILITY_MODE_CONFIG;
-import static dev.responsive.kafka.api.config.ResponsiveConfig.TENANT_ID_CONFIG;
+import static dev.responsive.kafka.api.config.ResponsiveConfig.RESPONSIVE_ENV_CONFIG;
+import static dev.responsive.kafka.api.config.ResponsiveConfig.RESPONSIVE_ORG_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG;
@@ -119,7 +120,8 @@ class ResponsiveKafkaStreamsTest {
     properties.put(DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.LongSerde.class.getName());
     properties.put(DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.LongSerde.class.getName());
 
-    properties.put(TENANT_ID_CONFIG, "test");
+    properties.put(RESPONSIVE_ORG_CONFIG, "responsive");
+    properties.put(RESPONSIVE_ENV_CONFIG, "test");
   }
 
   @SuppressWarnings("resource")

--- a/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveKeyValueStoreIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveKeyValueStoreIntegrationTest.java
@@ -16,7 +16,6 @@
 
 package dev.responsive.kafka.integration;
 
-import static dev.responsive.kafka.api.config.ResponsiveConfig.REQUEST_TIMEOUT_MS_CONFIG;
 import static dev.responsive.kafka.testutils.IntegrationTestUtils.pipeRecords;
 import static dev.responsive.kafka.testutils.IntegrationTestUtils.startAppAndAwaitRunning;
 import static org.apache.kafka.clients.CommonClientConfigs.SESSION_TIMEOUT_MS_CONFIG;
@@ -213,7 +212,6 @@ public class ResponsiveKeyValueStoreIntegrationTest {
     properties.put(NUM_STREAM_THREADS_CONFIG, 1);
     properties.put(COMMIT_INTERVAL_MS_CONFIG, 1); // commit as often as possible
 
-    properties.put(consumerPrefix(REQUEST_TIMEOUT_MS_CONFIG), 5_000);
     properties.put(consumerPrefix(SESSION_TIMEOUT_MS_CONFIG), 5_000 - 1);
 
     properties.put(consumerPrefix(MAX_POLL_RECORDS_CONFIG), 1);

--- a/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveKeyValueStoreRestoreIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveKeyValueStoreRestoreIntegrationTest.java
@@ -16,9 +16,9 @@
 
 package dev.responsive.kafka.integration;
 
-import static dev.responsive.kafka.api.config.ResponsiveConfig.CLIENT_ID_CONFIG;
-import static dev.responsive.kafka.api.config.ResponsiveConfig.CLIENT_SECRET_CONFIG;
-import static dev.responsive.kafka.api.config.ResponsiveConfig.STORAGE_HOSTNAME_CONFIG;
+import static dev.responsive.kafka.api.config.ResponsiveConfig.MONGO_ENDPOINT_CONFIG;
+import static dev.responsive.kafka.api.config.ResponsiveConfig.MONGO_PASSWORD_CONFIG;
+import static dev.responsive.kafka.api.config.ResponsiveConfig.MONGO_USERNAME_CONFIG;
 import static dev.responsive.kafka.testutils.IntegrationTestUtils.getCassandraValidName;
 import static dev.responsive.kafka.testutils.IntegrationTestUtils.pipeInput;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.ISOLATION_LEVEL_CONFIG;
@@ -413,13 +413,13 @@ public class ResponsiveKeyValueStoreRestoreIntegrationTest {
           throw new IllegalArgumentException("Unexpected type " + type);
       }
     } else if (EXTENSION.backend == StorageBackend.MONGO_DB) {
-      final var hostname = config.getString(STORAGE_HOSTNAME_CONFIG);
-      final String clientId = config.getString(CLIENT_ID_CONFIG);
-      final Password clientSecret = config.getPassword(CLIENT_SECRET_CONFIG);
+      final var hostname = config.getString(MONGO_ENDPOINT_CONFIG);
+      final String user = config.getString(MONGO_USERNAME_CONFIG);
+      final Password pass = config.getPassword(MONGO_PASSWORD_CONFIG);
       final var mongoClient = SessionUtil.connect(
           hostname,
-          clientId,
-          clientSecret == null ? null : clientSecret.value()
+          user,
+          pass == null ? null : pass.value()
       );
       table = new MongoKVTable(
           mongoClient,

--- a/kafka-client/src/test/java/dev/responsive/kafka/integration/TablePartitionerIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/integration/TablePartitionerIntegrationTest.java
@@ -16,7 +16,7 @@
 
 package dev.responsive.kafka.integration;
 
-import static dev.responsive.kafka.api.config.ResponsiveConfig.STORAGE_DESIRED_NUM_PARTITION_CONFIG;
+import static dev.responsive.kafka.api.config.ResponsiveConfig.CASSANDRA_DESIRED_NUM_PARTITION_CONFIG;
 import static dev.responsive.kafka.api.config.ResponsiveConfig.STORE_FLUSH_RECORDS_TRIGGER_CONFIG;
 import static dev.responsive.kafka.api.config.ResponsiveConfig.SUBPARTITION_HASHER_CONFIG;
 import static dev.responsive.kafka.api.config.ResponsiveConfig.responsiveConfig;
@@ -132,7 +132,7 @@ public class TablePartitionerIntegrationTest {
     final CqlSession session = CqlSession.builder()
         .addContactPoint(cassandra.getContactPoint())
         .withLocalDatacenter(cassandra.getLocalDatacenter())
-        .withKeyspace("responsive_clients") // NOTE: this keyspace is expected to exist
+        .withKeyspace("responsive_itests") // NOTE: this keyspace is expected to exist
         .build();
     client = new CassandraClient(session, responsiveConfig(responsiveProps));
   }
@@ -384,7 +384,7 @@ public class TablePartitionerIntegrationTest {
     properties.put(consumerPrefix(ConsumerConfig.METADATA_MAX_AGE_CONFIG), "1000");
     properties.put(consumerPrefix(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG), "earliest");
 
-    properties.put(STORAGE_DESIRED_NUM_PARTITION_CONFIG, 32);
+    properties.put(CASSANDRA_DESIRED_NUM_PARTITION_CONFIG, 32);
     properties.put(STORE_FLUSH_RECORDS_TRIGGER_CONFIG, FLUSH_THRESHOLD);
     properties.put(SUBPARTITION_HASHER_CONFIG, LongBytesHasher.class);
 

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/CassandraClientTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/CassandraClientTest.java
@@ -47,9 +47,10 @@ class CassandraClientTest {
     final CassandraClient client = new CassandraClient(
         session,
         ResponsiveConfig.loggedConfig(Map.of(
-            ResponsiveConfig.TENANT_ID_CONFIG, "ignored",
-            ResponsiveConfig.STORAGE_HOSTNAME_CONFIG, "ignored",
-            ResponsiveConfig.STORAGE_PORT_CONFIG, 0
+            ResponsiveConfig.RESPONSIVE_ORG_CONFIG, "ignored",
+            ResponsiveConfig.RESPONSIVE_ENV_CONFIG, "ignored",
+            ResponsiveConfig.CASSANDRA_HOSTNAME_CONFIG, "ignored",
+            ResponsiveConfig.CASSANDRA_PORT_CONFIG, 0
         ))
     );
     when(session.execute(statementCaptor.capture())).thenReturn(null);
@@ -68,9 +69,10 @@ class CassandraClientTest {
     final CassandraClient client = new CassandraClient(
         session,
         ResponsiveConfig.loggedConfig(Map.of(
-            ResponsiveConfig.TENANT_ID_CONFIG, "ignored",
-            ResponsiveConfig.STORAGE_HOSTNAME_CONFIG, "ignored",
-            ResponsiveConfig.STORAGE_PORT_CONFIG, 0
+            ResponsiveConfig.RESPONSIVE_ORG_CONFIG, "ignored",
+            ResponsiveConfig.RESPONSIVE_ENV_CONFIG, "ignored",
+            ResponsiveConfig.CASSANDRA_HOSTNAME_CONFIG, "ignored",
+            ResponsiveConfig.CASSANDRA_PORT_CONFIG, 0
         ))
     );
     when(session.prepare((SimpleStatement) statementCaptor.capture())).thenReturn(null);
@@ -89,9 +91,10 @@ class CassandraClientTest {
     final CassandraClient client = new CassandraClient(
         session,
         ResponsiveConfig.loggedConfig(Map.of(
-            ResponsiveConfig.TENANT_ID_CONFIG, "ignored",
-            ResponsiveConfig.STORAGE_HOSTNAME_CONFIG, "ignored",
-            ResponsiveConfig.STORAGE_PORT_CONFIG, 0
+            ResponsiveConfig.RESPONSIVE_ORG_CONFIG, "ignored",
+            ResponsiveConfig.RESPONSIVE_ENV_CONFIG, "ignored",
+            ResponsiveConfig.CASSANDRA_HOSTNAME_CONFIG, "ignored",
+            ResponsiveConfig.CASSANDRA_PORT_CONFIG, 0
         ))
     );
     when(session.prepare((SimpleStatement) statementCaptor.capture())).thenReturn(null);
@@ -110,9 +113,10 @@ class CassandraClientTest {
     final CassandraClient client = new CassandraClient(
         session,
         ResponsiveConfig.loggedConfig(Map.of(
-            ResponsiveConfig.TENANT_ID_CONFIG, "ignored",
-            ResponsiveConfig.STORAGE_HOSTNAME_CONFIG, "ignored",
-            ResponsiveConfig.STORAGE_PORT_CONFIG, 0,
+            ResponsiveConfig.RESPONSIVE_ORG_CONFIG, "ignored",
+            ResponsiveConfig.RESPONSIVE_ENV_CONFIG, "ignored",
+            ResponsiveConfig.CASSANDRA_HOSTNAME_CONFIG, "ignored",
+            ResponsiveConfig.CASSANDRA_PORT_CONFIG, 0,
             ResponsiveConfig.READ_CONSISTENCY_LEVEL_CONFIG, "ALL"
         ))
     );
@@ -132,9 +136,10 @@ class CassandraClientTest {
     final CassandraClient client = new CassandraClient(
         session,
         ResponsiveConfig.loggedConfig(Map.of(
-            ResponsiveConfig.TENANT_ID_CONFIG, "ignored",
-            ResponsiveConfig.STORAGE_HOSTNAME_CONFIG, "ignored",
-            ResponsiveConfig.STORAGE_PORT_CONFIG, 0,
+            ResponsiveConfig.RESPONSIVE_ORG_CONFIG, "ignored",
+            ResponsiveConfig.RESPONSIVE_ENV_CONFIG, "ignored",
+            ResponsiveConfig.CASSANDRA_HOSTNAME_CONFIG, "ignored",
+            ResponsiveConfig.CASSANDRA_PORT_CONFIG, 0,
             ResponsiveConfig.WRITE_CONSISTENCY_LEVEL_CONFIG, "ALL"
         ))
     );

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/CassandraFactTableIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/CassandraFactTableIntegrationTest.java
@@ -61,7 +61,7 @@ class CassandraFactTableIntegrationTest {
     session = CqlSession.builder()
         .addContactPoint(cassandra.getContactPoint())
         .withLocalDatacenter(cassandra.getLocalDatacenter())
-        .withKeyspace("responsive_clients") // NOTE: this keyspace is expected to exist
+        .withKeyspace("responsive_itests") // NOTE: this keyspace is expected to exist
         .build();
     client = new CassandraClient(session, ResponsiveConfig.responsiveConfig(responsiveProps));
   }

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/CassandraKVTableIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/CassandraKVTableIntegrationTest.java
@@ -16,7 +16,7 @@
 
 package dev.responsive.kafka.internal.db;
 
-import static dev.responsive.kafka.api.config.ResponsiveConfig.STORAGE_DESIRED_NUM_PARTITION_CONFIG;
+import static dev.responsive.kafka.api.config.ResponsiveConfig.CASSANDRA_DESIRED_NUM_PARTITION_CONFIG;
 import static dev.responsive.kafka.testutils.IntegrationTestUtils.copyConfigWithOverrides;
 import static java.util.Collections.singletonMap;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -65,14 +65,14 @@ public class CassandraKVTableIntegrationTest {
     final CqlSession session = CqlSession.builder()
         .addContactPoint(cassandra.getContactPoint())
         .withLocalDatacenter(cassandra.getLocalDatacenter())
-        .withKeyspace("responsive_clients") // NOTE: this keyspace is expected to exist
+        .withKeyspace("responsive_itests") // NOTE: this keyspace is expected to exist
         .build();
     client = new CassandraClient(session, config);
 
     final String name = info.getTestMethod().orElseThrow().getName();
     final ResponsiveConfig partitionerConfig = copyConfigWithOverrides(
         config,
-        singletonMap(STORAGE_DESIRED_NUM_PARTITION_CONFIG, NUM_SUBPARTITIONS_TOTAL)
+        singletonMap(CASSANDRA_DESIRED_NUM_PARTITION_CONFIG, NUM_SUBPARTITIONS_TOTAL)
     );
     final var partitioner = SubPartitioner.create(
         OptionalInt.empty(),

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/mongo/MongoKVTableTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/mongo/MongoKVTableTest.java
@@ -16,7 +16,7 @@
 
 package dev.responsive.kafka.internal.db.mongo;
 
-import static dev.responsive.kafka.api.config.ResponsiveConfig.STORAGE_HOSTNAME_CONFIG;
+import static dev.responsive.kafka.api.config.ResponsiveConfig.MONGO_ENDPOINT_CONFIG;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
@@ -54,7 +54,7 @@ class MongoKVTableTest {
   ) {
     name = info.getDisplayName().replace("()", "");
 
-    final String mongoConnection = (String) props.get(STORAGE_HOSTNAME_CONFIG);
+    final String mongoConnection = (String) props.get(MONGO_ENDPOINT_CONFIG);
     client = SessionUtil.connect(mongoConnection, null, null);
   }
 

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/mongo/MongoSessionTableTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/mongo/MongoSessionTableTest.java
@@ -16,7 +16,7 @@
 
 package dev.responsive.kafka.internal.db.mongo;
 
-import static dev.responsive.kafka.api.config.ResponsiveConfig.STORAGE_HOSTNAME_CONFIG;
+import static dev.responsive.kafka.api.config.ResponsiveConfig.MONGO_ENDPOINT_CONFIG;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.mongodb.client.MongoClient;
@@ -57,7 +57,7 @@ class MongoSessionTableTest {
   ) {
     name = info.getDisplayName().replace("()", "");
 
-    final String mongoConnection = (String) props.get(STORAGE_HOSTNAME_CONFIG);
+    final String mongoConnection = (String) props.get(MONGO_ENDPOINT_CONFIG);
     client = SessionUtil.connect(mongoConnection, null, null);
   }
 

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/mongo/MongoWindowTableTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/mongo/MongoWindowTableTest.java
@@ -16,7 +16,7 @@
 
 package dev.responsive.kafka.internal.db.mongo;
 
-import static dev.responsive.kafka.api.config.ResponsiveConfig.STORAGE_HOSTNAME_CONFIG;
+import static dev.responsive.kafka.api.config.ResponsiveConfig.MONGO_ENDPOINT_CONFIG;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.mongodb.client.MongoClient;
@@ -56,7 +56,7 @@ class MongoWindowTableTest {
   ) {
     name = info.getDisplayName().replace("()", "");
 
-    final String mongoConnection = (String) props.get(STORAGE_HOSTNAME_CONFIG);
+    final String mongoConnection = (String) props.get(MONGO_ENDPOINT_CONFIG);
     client = SessionUtil.connect(mongoConnection, null, null);
   }
 

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/partitioning/SubPartitionerTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/partitioning/SubPartitionerTest.java
@@ -16,7 +16,7 @@
 
 package dev.responsive.kafka.internal.db.partitioning;
 
-import static dev.responsive.kafka.api.config.ResponsiveConfig.STORAGE_DESIRED_NUM_PARTITION_CONFIG;
+import static dev.responsive.kafka.api.config.ResponsiveConfig.CASSANDRA_DESIRED_NUM_PARTITION_CONFIG;
 import static dev.responsive.kafka.api.config.ResponsiveConfig.SUBPARTITION_HASHER_CONFIG;
 import static dev.responsive.kafka.testutils.IntegrationTestUtils.dummyConfig;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -150,7 +150,7 @@ class SubPartitionerTest {
 
   private ResponsiveConfig responsiveConfig(final int desiredNumSubPartitions) {
     return dummyConfig(Map.of(
-        STORAGE_DESIRED_NUM_PARTITION_CONFIG, desiredNumSubPartitions,
+        CASSANDRA_DESIRED_NUM_PARTITION_CONFIG, desiredNumSubPartitions,
         SUBPARTITION_HASHER_CONFIG, SingleByteHasher.class
     ));
   }

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/CommitBufferTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/CommitBufferTest.java
@@ -173,7 +173,7 @@ public class CommitBufferTest {
     session = CqlSession.builder()
         .addContactPoint(cassandra.getContactPoint())
         .withLocalDatacenter(cassandra.getLocalDatacenter())
-        .withKeyspace("responsive_clients") // NOTE: this keyspace is expected to exist
+        .withKeyspace("responsive_itests") // NOTE: this keyspace is expected to exist
         .build();
     client = new CassandraClient(session, config);
     sessionClients = new SessionClients(

--- a/kafka-client/src/test/java/dev/responsive/kafka/testutils/IntegrationTestUtils.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/testutils/IntegrationTestUtils.java
@@ -73,19 +73,21 @@ public final class IntegrationTestUtils {
 
   public static ResponsiveConfig dummyConfig() {
     final Properties props = new Properties();
-    props.put(ResponsiveConfig.STORAGE_DATACENTER_CONFIG, "responsive");
-    props.put(ResponsiveConfig.STORAGE_HOSTNAME_CONFIG, "localhost");
-    props.put(ResponsiveConfig.STORAGE_PORT_CONFIG, 666);
-    props.put(ResponsiveConfig.TENANT_ID_CONFIG, "responsive-test");
+    props.put(ResponsiveConfig.CASSANDRA_DATACENTER_CONFIG, "responsive");
+    props.put(ResponsiveConfig.CASSANDRA_HOSTNAME_CONFIG, "localhost");
+    props.put(ResponsiveConfig.CASSANDRA_PORT_CONFIG, 666);
+    props.put(ResponsiveConfig.RESPONSIVE_ORG_CONFIG, "responsive");
+    props.put(ResponsiveConfig.RESPONSIVE_ENV_CONFIG, "itest");
     return ResponsiveConfig.responsiveConfig(props);
   }
 
   public static ResponsiveConfig dummyConfig(final Map<?, ?> overrides) {
     final Properties props = new Properties();
-    props.put(ResponsiveConfig.STORAGE_DATACENTER_CONFIG, "responsive");
-    props.put(ResponsiveConfig.STORAGE_HOSTNAME_CONFIG, "localhost");
-    props.put(ResponsiveConfig.STORAGE_PORT_CONFIG, 666);
-    props.put(ResponsiveConfig.TENANT_ID_CONFIG, "TTD");
+    props.put(ResponsiveConfig.CASSANDRA_DATACENTER_CONFIG, "responsive");
+    props.put(ResponsiveConfig.CASSANDRA_HOSTNAME_CONFIG, "localhost");
+    props.put(ResponsiveConfig.CASSANDRA_PORT_CONFIG, 666);
+    props.put(ResponsiveConfig.RESPONSIVE_ORG_CONFIG, "responsive");
+    props.put(ResponsiveConfig.RESPONSIVE_ENV_CONFIG, "ttd");
     props.putAll(overrides);
     return ResponsiveConfig.responsiveConfig(props);
   }

--- a/kafka-client/src/test/java/dev/responsive/kafka/testutils/ResponsiveExtension.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/testutils/ResponsiveExtension.java
@@ -16,14 +16,16 @@
 
 package dev.responsive.kafka.testutils;
 
-import static dev.responsive.kafka.api.config.ResponsiveConfig.REMOTE_TABLE_CHECK_INTERVAL_MS_CONFIG;
+import static dev.responsive.kafka.api.config.ResponsiveConfig.CASSANDRA_CHECK_INTERVAL_MS;
+import static dev.responsive.kafka.api.config.ResponsiveConfig.CASSANDRA_DATACENTER_CONFIG;
+import static dev.responsive.kafka.api.config.ResponsiveConfig.CASSANDRA_DESIRED_NUM_PARTITION_CONFIG;
+import static dev.responsive.kafka.api.config.ResponsiveConfig.CASSANDRA_HOSTNAME_CONFIG;
+import static dev.responsive.kafka.api.config.ResponsiveConfig.CASSANDRA_PORT_CONFIG;
+import static dev.responsive.kafka.api.config.ResponsiveConfig.MONGO_ENDPOINT_CONFIG;
+import static dev.responsive.kafka.api.config.ResponsiveConfig.RESPONSIVE_ENV_CONFIG;
+import static dev.responsive.kafka.api.config.ResponsiveConfig.RESPONSIVE_ORG_CONFIG;
 import static dev.responsive.kafka.api.config.ResponsiveConfig.STORAGE_BACKEND_TYPE_CONFIG;
-import static dev.responsive.kafka.api.config.ResponsiveConfig.STORAGE_DATACENTER_CONFIG;
-import static dev.responsive.kafka.api.config.ResponsiveConfig.STORAGE_DESIRED_NUM_PARTITION_CONFIG;
-import static dev.responsive.kafka.api.config.ResponsiveConfig.STORAGE_HOSTNAME_CONFIG;
-import static dev.responsive.kafka.api.config.ResponsiveConfig.STORAGE_PORT_CONFIG;
 import static dev.responsive.kafka.api.config.ResponsiveConfig.TASK_ASSIGNOR_CLASS_OVERRIDE;
-import static dev.responsive.kafka.api.config.ResponsiveConfig.TENANT_ID_CONFIG;
 import static dev.responsive.kafka.api.config.ResponsiveConfig.loggedConfig;
 import static org.apache.kafka.clients.CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG;
 import static org.apache.kafka.streams.StreamsConfig.InternalConfig.INTERNAL_TASK_ASSIGNOR_CLASS;
@@ -115,23 +117,24 @@ public class ResponsiveExtension implements BeforeAllCallback, AfterAllCallback,
       return admin;
     } else if (isContainerConfig(parameterContext)) {
       final Map<String, Object> map = new HashMap<>(Map.of(
-          TENANT_ID_CONFIG, "responsive_clients",
+          RESPONSIVE_ORG_CONFIG, "responsive",
+          RESPONSIVE_ENV_CONFIG, "itests",
           INTERNAL_TASK_ASSIGNOR_CLASS, TASK_ASSIGNOR_CLASS_OVERRIDE,
           BOOTSTRAP_SERVERS_CONFIG, kafka.getBootstrapServers(),
-          STORAGE_DESIRED_NUM_PARTITION_CONFIG, -1,
-          REMOTE_TABLE_CHECK_INTERVAL_MS_CONFIG, 100
+          CASSANDRA_DESIRED_NUM_PARTITION_CONFIG, -1,
+          CASSANDRA_CHECK_INTERVAL_MS, 100
       ));
 
       switch (backend) {
         case CASSANDRA:
           map.put(STORAGE_BACKEND_TYPE_CONFIG, StorageBackend.CASSANDRA.name());
-          map.put(STORAGE_HOSTNAME_CONFIG, cassandra.getContactPoint().getHostName());
-          map.put(STORAGE_PORT_CONFIG, cassandra.getContactPoint().getPort());
-          map.put(STORAGE_DATACENTER_CONFIG, cassandra.getLocalDatacenter());
+          map.put(CASSANDRA_HOSTNAME_CONFIG, cassandra.getContactPoint().getHostName());
+          map.put(CASSANDRA_PORT_CONFIG, cassandra.getContactPoint().getPort());
+          map.put(CASSANDRA_DATACENTER_CONFIG, cassandra.getLocalDatacenter());
           break;
         case MONGO_DB:
           map.put(STORAGE_BACKEND_TYPE_CONFIG, StorageBackend.MONGO_DB.name());
-          map.put(STORAGE_HOSTNAME_CONFIG, mongo.getConnectionString());
+          map.put(MONGO_ENDPOINT_CONFIG, mongo.getConnectionString());
           break;
         default:
           throw new IllegalStateException("Unexpected value: " + backend);

--- a/kafka-client/src/test/resources/CassandraDockerInit.cql
+++ b/kafka-client/src/test/resources/CassandraDockerInit.cql
@@ -1,4 +1,4 @@
-CREATE KEYSPACE IF NOT EXISTS responsive_clients
+CREATE KEYSPACE IF NOT EXISTS responsive_itests
   WITH REPLICATION = {
    'class' : 'SimpleStrategy',
    'replication_factor' : 1

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/api/ResponsiveTopologyTestDriver.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/api/ResponsiveTopologyTestDriver.java
@@ -34,7 +34,8 @@ import org.apache.kafka.streams.TopologyDescription;
 import org.apache.kafka.streams.TopologyTestDriver;
 
 public class ResponsiveTopologyTestDriver extends TopologyTestDriver {
-  public static final String RESPONSIVE_TTD_ID = "Responsive_TopologyTestDriver";
+  public static final String RESPONSIVE_TTD_ORG = "Responsive";
+  public static final String RESPONSIVE_TTD_ENV = "TopologyTestDriver";
 
   private final TTDCassandraClient client;
 
@@ -156,11 +157,15 @@ public class ResponsiveTopologyTestDriver extends TopologyTestDriver {
     final Properties props = new Properties();
     props.putAll(userProps);
 
-    props.put(ResponsiveConfig.TENANT_ID_CONFIG, RESPONSIVE_TTD_ID);
+    props.put(ResponsiveConfig.RESPONSIVE_ORG_CONFIG, RESPONSIVE_TTD_ORG);
+    props.put(ResponsiveConfig.RESPONSIVE_ENV_CONFIG, RESPONSIVE_TTD_ENV);
     props.put(ResponsiveConfig.STORE_FLUSH_INTERVAL_TRIGGER_MS_CONFIG, 0);
 
     props.putIfAbsent(StreamsConfig.CACHE_MAX_BYTES_BUFFERING_CONFIG, 0);
-    props.putIfAbsent(StreamsConfig.APPLICATION_ID_CONFIG, RESPONSIVE_TTD_ID);
+    props.putIfAbsent(
+        StreamsConfig.APPLICATION_ID_CONFIG,
+        RESPONSIVE_TTD_ORG + "-" + RESPONSIVE_TTD_ENV
+    );
     return props;
   }
 


### PR DESCRIPTION
## Motivation

This PR attempts to clean up a bunch of configurations, most importantly along these two principles:

1. Any shared configurations between operator and `ResponsiveConfig` should have the same name
2. MongoDB/Cassandra configurations are no longer shared and are made explicit.

## Details
### Config Change Overview

The following configurations were modified:

| old config | new config |
|------------|-------------|
| `responsive.storage.hostname` | `responsive.mongo.endpoint` for `MONGO_DB` stores and `repsonsive.cassandra.hostname` for `CASSANDRA` stores |
| `responsive.storage.port` | `responsive.cassandra.port` (Mongo stores do not require specifying a port) |
| `responsive.storage.datacenter` | `responsive.cassandra.datacenter` (Mongo stores do not require specifying a datacenter) |
| `responsive.tenant.id` | This configuration was deprecated in favor of `responsive.org` and `responsive.env`, which together make up the tenant id (which was previously only used to determine the Cassandra keyspace) |
| | |
| `responsive.client.id` | This was replaced with `responsive.cassandra.username` and `responsive.mongo.username` for Cassandra/Mongo stores respectively |
| `responsive.client.secret` | This was replaced with `responsive.cassandra.password` and `responsive.mongo.password` for Cassandra/Mongo stores respectively |
| `responsive.storage.desired.num.partitions` | This was renamed `responsive.cassandra.desired.num.partitions` as it only applied to Cassandra |
| | |
| `responsive.metrics.api.key` | This has been renamed `responsive.platform.api.key` to align with the operator convention |
| `responsive.metrics.secret` | This has been renamed `responsive.platform.api.secret` to align with the operator convention |

### Removed Configurations

The following configurations were removed entirely:
- `responsive.connection.bundle` used for DataStax astra, which we do not support
- `responsive.request.timeout.ms` was unused and removed

## Review Note

This will not pass CI/CD since the smoke test will fail. After merging this we will need to make corresponding changes in our smoke test configuration.