### PR TITLE
couple tweaks to support safe concurrent access to stores

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/InjectedStoreArgs.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/InjectedStoreArgs.java
@@ -1,0 +1,17 @@
+package dev.responsive.kafka.internal.stores;
+
+import java.util.Optional;
+import java.util.function.Supplier;
+
+public class InjectedStoreArgs {
+
+  private Supplier<Long> recordTimestampClock;
+
+  public Optional<Supplier<Long>> recordTimestampClock() {
+    return Optional.ofNullable(recordTimestampClock);
+  }
+
+  public void injectRecordTimestampClock(final Supplier<Long> recordTimestampClock) {
+    this.recordTimestampClock = recordTimestampClock;
+  }
+}

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/PartitionedOperations.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/PartitionedOperations.java
@@ -42,10 +42,12 @@ import dev.responsive.kafka.internal.utils.TableName;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collection;
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.OptionalLong;
 import java.util.concurrent.TimeoutException;
+import java.util.function.Supplier;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.utils.Bytes;
@@ -238,14 +240,14 @@ public class PartitionedOperations implements KeyValueOperations {
       // is fresher than the starting timestamp
       return;
     }
-    buffer.put(key, value, context.timestamp());
+    buffer.put(key, value, currentRecordTimestamp());
   }
 
   @Override
   public byte[] delete(final Bytes key) {
     // single writer prevents races (see putIfAbsent)
     final byte[] old = get(key);
-    buffer.tombstone(key, context.timestamp());
+    buffer.tombstone(key, currentRecordTimestamp());
 
     return old;
   }
@@ -338,11 +340,20 @@ public class PartitionedOperations implements KeyValueOperations {
     buffer.restoreBatch(records);
   }
 
+  private long currentRecordTimestamp() {
+    final InjectedStoreArgs injectedStoreArgs = registration.injectedStoreArgs();
+    final Optional<Supplier<Long>> injectedClock = injectedStoreArgs.recordTimestampClock();
+    if (injectedClock.isPresent()) {
+      return injectedClock.get().get();
+    }
+    return context.timestamp();
+  }
+
   private long minValidTimestamp() {
     // TODO: unwrapping the ttl from Duration to millis is somewhat heavy for the hot path
     return params
         .timeToLive()
-        .map(ttl -> context.timestamp() - ttl.toMillis())
+        .map(ttl -> currentRecordTimestamp() - ttl.toMillis())
         .orElse(-1L);
   }
 
@@ -353,7 +364,7 @@ public class PartitionedOperations implements KeyValueOperations {
     if (startingTimestamp > 0) {
       // we are bootstrapping a store. Only apply the write if the timestamp
       // is fresher than the starting timestamp
-      return context.timestamp() < startingTimestamp;
+      return currentRecordTimestamp() < startingTimestamp;
     }
     return false;
   }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/PartitionedOperations.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/PartitionedOperations.java
@@ -42,7 +42,6 @@ import dev.responsive.kafka.internal.utils.TableName;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collection;
-import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.OptionalLong;

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveStoreRegistration.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveStoreRegistration.java
@@ -18,7 +18,6 @@ package dev.responsive.kafka.internal.stores;
 
 import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.function.Consumer;
 import org.apache.kafka.common.TopicPartition;

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveStoreRegistration.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveStoreRegistration.java
@@ -18,6 +18,7 @@ package dev.responsive.kafka.internal.stores;
 
 import com.datastax.oss.driver.shaded.guava.common.annotations.VisibleForTesting;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.function.Consumer;
 import org.apache.kafka.common.TopicPartition;
@@ -32,6 +33,7 @@ public final class ResponsiveStoreRegistration {
   private final TopicPartition changelogTopicPartition;
   private final Consumer<Long> onCommit;
   private final String threadId;
+  private final InjectedStoreArgs injectedStoreArgs = new InjectedStoreArgs();
 
   private final OptionalLong startOffset; // stored offset during init, (where restore should start)
 
@@ -68,6 +70,10 @@ public final class ResponsiveStoreRegistration {
 
   public Consumer<Long> onCommit() {
     return onCommit;
+  }
+
+  public InjectedStoreArgs injectedStoreArgs() {
+    return injectedStoreArgs;
   }
 
   public String threadId() {

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/SizeTrackingBuffer.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/SizeTrackingBuffer.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.NavigableMap;
 import java.util.Objects;
 import java.util.TreeMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 
 public class SizeTrackingBuffer<K extends Comparable<K>> {
   private final NavigableMap<K, Result<K>> buffer;
@@ -32,7 +33,7 @@ public class SizeTrackingBuffer<K extends Comparable<K>> {
 
   public SizeTrackingBuffer(final KeySpec<K> extractor) {
     this.extractor = Objects.requireNonNull(extractor);
-    buffer = new TreeMap<>();
+    buffer = new ConcurrentSkipListMap<>();
     reader = Collections.unmodifiableNavigableMap(buffer);
   }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/SizeTrackingBuffer.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/SizeTrackingBuffer.java
@@ -22,7 +22,6 @@ import dev.responsive.kafka.internal.utils.Result;
 import java.util.Collections;
 import java.util.NavigableMap;
 import java.util.Objects;
-import java.util.TreeMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 
 public class SizeTrackingBuffer<K extends Comparable<K>> {

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/PartitionedOperationsTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/PartitionedOperationsTest.java
@@ -77,6 +77,7 @@ class PartitionedOperationsTest {
         true,
         MIGRATE_START_TTL.toEpochMilli()
     );
+    when(registration.injectedStoreArgs()).thenReturn(new InjectedStoreArgs());
   }
 
   @Test


### PR DESCRIPTION
This patch adds support for concurrent access to stores. After this change, we should be able to concurrently issue read calls to stores while other reads are happening, or while the main stream thread is doing put/delete or flushing.

First, we add a mechanism for injecting values into the store that can only be computed after the store has been initialized. We need to do this because the stores depend on some info that is made available only from the call to , which is kind of a quirk in streams (ideally, these things are just parameters to put/get/etc). In particular in today's implementation we depend on the processor context supplied in init to get the record's timestamp which we need for expiry calculation. This patch supports reading this from a reference to  in the store registration. When an async getter is reading the store, it can inject the appropriate context.

Second, we use a concurrent map for the commit buffer's store of uncommitted records