### PR TITLE
Metrics Exporting: Compress data on its way to the collector

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/metrics/exporter/otel/OtelMetricsService.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/metrics/exporter/otel/OtelMetricsService.java
@@ -75,6 +75,7 @@ public class OtelMetricsService implements MetricsExportService  {
       builder.addHeader(ApiKeyHeaders.SECRET_METADATA_KEY, secret.value());
     }
 
+    builder.setCompression("gzip");
     builder.setEndpoint(config.getString(ResponsiveConfig.CONTROLLER_ENDPOINT_CONFIG));
 
     final var exporter = builder.build();


### PR DESCRIPTION
I was able to get the rough estimate of bytes over the wire by overwriting the default GrpcExporter: 70KB. The exporter exports the metrics every 10 seconds at the moment, leading to **18.7 GB / month / node**. I was able to confirm the order of magnitude with `netstat` statistics, which gave me something closer to 77 KB / 10s. 

This change turns on `gzip` compression at the exporter level, which reduces the over-the-wire bytes from 77 KB / 10s to about *17 KB / 10s*, a *78%* reduction to *4.5 GB / month / node*.