### PR TITLE
add actions api to controller and implement operator side

### DIFF
--- a/controller-api/src/main/proto/responsive/controller/v1/controller.proto
+++ b/controller-api/src/main/proto/responsive/controller/v1/controller.proto
@@ -12,6 +12,8 @@ service Controller {
   rpc UpsertPolicy(UpsertPolicyRequest) returns (SimpleResponse) {}
   rpc CurrentState(CurrentStateRequest) returns (SimpleResponse) {}
   rpc GetTargetState(EmptyRequest) returns (GetTargetStateResponse) {}
+  rpc GetCurrentActions(EmptyRequest) returns (GetCurrentActionsResponse) {}
+  rpc UpdateActionStatus(UpdateActionStatusRequest) returns (SimpleResponse)  {}
   rpc ListApplications(EmptyUnspecificRequest) returns (ListApplicationsResponse) {}
 }
 
@@ -55,6 +57,43 @@ message GetTargetStateResponse {
   string error = 1;
   ApplicationState state = 2;
   int64 last_eval_time_ms = 3;
+}
+
+message GetCurrentActionsResponse {
+  repeated Action actions = 1;
+  int64 last_eval_time_ms = 2;
+}
+
+message UpdateActionStatusRequest {
+  string application_id = 1;
+  string action_id = 2;
+  ActionStatus status = 3;
+}
+
+message ActionStatus {
+  enum Status {
+    COMPLETED = 0;
+    FAILED = 1;
+  }
+  Status status = 1;
+  string details = 2;
+}
+
+message Action {
+  string id = 1;
+
+  message ScaleApplication {
+    uint32 replicas = 1;
+  }
+
+  message RestartPod {
+    string pod_id = 1;
+  }
+
+  oneof action {
+    ScaleApplication scale_application = 2;
+    RestartPod restart_pod = 3;
+  }
 }
 
 // TODO(rohan): move these to a common proto file. this file is just the grpc api

--- a/operator/src/main/java/dev/responsive/controller/client/ControllerClient.java
+++ b/operator/src/main/java/dev/responsive/controller/client/ControllerClient.java
@@ -16,9 +16,12 @@
 
 package dev.responsive.controller.client;
 
+import java.util.List;
+import responsive.controller.v1.controller.proto.ControllerOuterClass.Action;
 import responsive.controller.v1.controller.proto.ControllerOuterClass.ApplicationState;
 import responsive.controller.v1.controller.proto.ControllerOuterClass.CurrentStateRequest;
 import responsive.controller.v1.controller.proto.ControllerOuterClass.EmptyRequest;
+import responsive.controller.v1.controller.proto.ControllerOuterClass.UpdateActionStatusRequest;
 import responsive.controller.v1.controller.proto.ControllerOuterClass.UpsertPolicyRequest;
 
 /**
@@ -42,4 +45,8 @@ public interface ControllerClient {
    * @return the target application state that the operator should resolve
    */
   ApplicationState getTargetState(final EmptyRequest request);
+
+  List<Action> getCurrentActions(final EmptyRequest request);
+
+  void updateActionStatus(final UpdateActionStatusRequest request);
 }

--- a/operator/src/main/java/dev/responsive/controller/client/grpc/ControllerGrpcClient.java
+++ b/operator/src/main/java/dev/responsive/controller/client/grpc/ControllerGrpcClient.java
@@ -26,11 +26,13 @@ import io.grpc.ManagedChannel;
 import io.grpc.Metadata;
 import io.grpc.TlsChannelCredentials;
 import io.grpc.stub.MetadataUtils;
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import responsive.controller.v1.controller.proto.ControllerGrpc;
 import responsive.controller.v1.controller.proto.ControllerOuterClass;
+import responsive.controller.v1.controller.proto.ControllerOuterClass.UpdateActionStatusRequest;
 import responsive.platform.auth.ApiKeyHeaders;
 
 public class ControllerGrpcClient implements ControllerClient {
@@ -100,6 +102,20 @@ public class ControllerGrpcClient implements ControllerClient {
       throw new RuntimeException(rsp.getError());
     }
     return rsp.getState();
+  }
+
+  @Override
+  public List<ControllerOuterClass.Action> getCurrentActions(
+      final ControllerOuterClass.EmptyRequest request) {
+    final var rsp = stub.withDeadlineAfter(5, TimeUnit.SECONDS)
+        .getCurrentActions(request);
+    return rsp.getActionsList();
+  }
+
+  @Override
+  public void updateActionStatus(final UpdateActionStatusRequest request) {
+    // todo: make sure this doesn't return an error and only throws
+    stub.withDeadlineAfter(5, TimeUnit.SECONDS).updateActionStatus(request);
   }
 
   private void throwOnError(final ControllerOuterClass.SimpleResponse rsp) {

--- a/operator/src/main/java/dev/responsive/k8s/controller/ControllerProtoFactories.java
+++ b/operator/src/main/java/dev/responsive/k8s/controller/ControllerProtoFactories.java
@@ -44,6 +44,22 @@ public final class ControllerProtoFactories {
         .build();
   }
 
+  public static ControllerOuterClass.UpdateActionStatusRequest updateActionStatusRequest(
+      final String environment,
+      final ResponsivePolicy policy,
+      final String actionId,
+      final ControllerOuterClass.ActionStatus.Status status,
+      final String reason
+  ) {
+    return ControllerOuterClass.UpdateActionStatusRequest.newBuilder()
+        .setApplicationId(getFullApplicationName(environment, policy))
+        .setActionId(actionId)
+        .setStatus(ControllerOuterClass.ActionStatus.newBuilder()
+            .setStatus(status)
+            .setDetails(reason))
+        .build();
+  }
+
   public static ControllerOuterClass.EmptyRequest emptyRequest(
       final String environment,
       final ResponsivePolicy policy

--- a/operator/src/main/java/dev/responsive/k8s/operator/reconciler/ActionsWithTimestamp.java
+++ b/operator/src/main/java/dev/responsive/k8s/operator/reconciler/ActionsWithTimestamp.java
@@ -17,26 +17,38 @@
 package dev.responsive.k8s.operator.reconciler;
 
 import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import responsive.controller.v1.controller.proto.ControllerOuterClass;
 
-class TargetStateWithTimestamp {
+class ActionsWithTimestamp {
   private final Instant timestamp;
   private final Optional<ControllerOuterClass.ApplicationState> targetState;
+  private final List<ControllerOuterClass.Action> actions;
 
-  TargetStateWithTimestamp(final ControllerOuterClass.ApplicationState targetState) {
-    this(Instant.now(), Optional.of(targetState));
+  ActionsWithTimestamp(
+      final Optional<ControllerOuterClass.ApplicationState> targetState,
+      final List<ControllerOuterClass.Action> actions
+  ) {
+    this(Instant.now(), targetState, actions);
   }
 
-  TargetStateWithTimestamp() {
-    this(Instant.now(), Optional.empty());
+  ActionsWithTimestamp(final List<ControllerOuterClass.Action> actions) {
+    this(Instant.now(), Optional.empty(), actions);
   }
 
-  TargetStateWithTimestamp(final Instant timestamp,
-                           final Optional<ControllerOuterClass.ApplicationState> targetState) {
+  ActionsWithTimestamp() {
+    this(Instant.now(), Optional.empty(), Collections.emptyList());
+  }
+
+  ActionsWithTimestamp(final Instant timestamp,
+                       final Optional<ControllerOuterClass.ApplicationState> targetState,
+                       final List<ControllerOuterClass.Action> actions) {
     this.timestamp = Objects.requireNonNull(timestamp);
     this.targetState = Objects.requireNonNull(targetState);
+    this.actions = List.copyOf(Objects.requireNonNull(actions));
   }
 
   public Instant getTimestamp() {
@@ -47,6 +59,10 @@ class TargetStateWithTimestamp {
     return targetState;
   }
 
+  public List<ControllerOuterClass.Action> getActions() {
+    return actions;
+  }
+
   @Override
   public boolean equals(final Object o) {
     if (this == o) {
@@ -55,7 +71,7 @@ class TargetStateWithTimestamp {
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    final TargetStateWithTimestamp that = (TargetStateWithTimestamp) o;
+    final ActionsWithTimestamp that = (ActionsWithTimestamp) o;
     return Objects.equals(timestamp, that.timestamp)
         && Objects.equals(targetState, that.targetState);
   }

--- a/operator/src/main/java/dev/responsive/k8s/operator/reconciler/KafkaStreamsPolicyPlugin.java
+++ b/operator/src/main/java/dev/responsive/k8s/operator/reconciler/KafkaStreamsPolicyPlugin.java
@@ -105,8 +105,9 @@ public class KafkaStreamsPolicyPlugin implements PolicyPlugin {
     LOG.info("target state for app {} {}", appName, targetState);
 
     if (targetState.getTargetState().isPresent()) {
-      LOG.info(
-          "we were not able to get a target state from controller, so don't try to reconcile one");
+      LOG.debug(
+          "we were not able to get a target state from controller, either due to error or"
+              + "there not being a current target. so don't try to reconcile one");
       maybeScaleApplication(
           targetState.getTargetState().get().getKafkaStreamsState().getReplicas(),
           managedApp,

--- a/operator/src/main/java/dev/responsive/k8s/operator/reconciler/ResponsivePolicyReconciler.java
+++ b/operator/src/main/java/dev/responsive/k8s/operator/reconciler/ResponsivePolicyReconciler.java
@@ -86,7 +86,7 @@ public class ResponsivePolicyReconciler implements
           ControllerProtoFactories.emptyRequest(environment, policy)));
     } catch (final StatusRuntimeException e) {
       if (e.getStatus().getCode().equals(Status.NOT_FOUND.getCode())) {
-        LOG.info("no target state found");
+        LOG.debug("no target state found");
         return Optional.empty();
       }
       throw e;

--- a/operator/src/test/java/dev/responsive/k8s/operator/reconciler/ResponsivePolicyReconcilerTest.java
+++ b/operator/src/test/java/dev/responsive/k8s/operator/reconciler/ResponsivePolicyReconcilerTest.java
@@ -146,7 +146,7 @@ class ResponsivePolicyReconcilerTest {
     when(controllerClient.getTargetState(any())).thenThrow(new RuntimeException("oops"));
 
     // when:
-    final var ret = (Optional<TargetStateWithTimestamp>) source.getSecondaryResource(resource);
+    final var ret = (Optional<ActionsWithTimestamp>) source.getSecondaryResource(resource);
 
     // then:
     assertThat(ret.isPresent(), is(true));


### PR DESCRIPTION
This patch makes two related changes:

First, it adds APIs to the controller for serving and reporting the status of actions. The controller will use actions rather than target state to sync down commands. Actions are more flexible:
1. a given action only needs to specify the target state that pertains to the given action, rather than all target state.
2. actions don't need to be target-state based, but can be more traditional "commands", e.g. restart pod X

Second, it updates the operator to use the new actions APIs.