### PR TITLE
operator side changes for restarting a pod

### DIFF
--- a/operator/src/main/helm/templates/appclusterrole.yaml
+++ b/operator/src/main/helm/templates/appclusterrole.yaml
@@ -17,3 +17,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - '*'
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+  - delete

--- a/operator/src/main/java/dev/responsive/k8s/operator/reconciler/ManagedDeployment.java
+++ b/operator/src/main/java/dev/responsive/k8s/operator/reconciler/ManagedDeployment.java
@@ -42,6 +42,15 @@ public class ManagedDeployment extends ManagedApplication {
   }
 
   @Override
+  public void restartPod(final String podId, final Context<ResponsivePolicy> context) {
+    final var deployment = context.getClient().apps().deployments()
+        .inNamespace(namespace)
+        .withName(appName);
+    final var podSelector = deployment.get().getSpec().getSelector();
+    findPod(podId, context, namespace, podSelector).delete();
+  }
+
+  @Override
   public String appType() {
     return "Deployment";
   }

--- a/operator/src/main/java/dev/responsive/k8s/operator/reconciler/ManagedStatefulSet.java
+++ b/operator/src/main/java/dev/responsive/k8s/operator/reconciler/ManagedStatefulSet.java
@@ -42,6 +42,15 @@ public class ManagedStatefulSet extends ManagedApplication {
   }
 
   @Override
+  public void restartPod(final String podId, final Context<ResponsivePolicy> context) {
+    final var sts = context.getClient().apps().statefulSets()
+        .inNamespace(namespace)
+        .withName(appName);
+    final var podSelector = sts.get().getSpec().getSelector();
+    findPod(podId, context, namespace, podSelector).delete();
+  }
+
+  @Override
   public String appType() {
     return "StatefulSet";
   }


### PR DESCRIPTION
This patch implements the operator changes required to execute an action that restarts a given pod.

Builds on #274 