### PR TITLE
Add controller apis for action management

### DIFF
--- a/controller-api/src/main/proto/responsive/controller/internal/v1/controller.proto
+++ b/controller-api/src/main/proto/responsive/controller/internal/v1/controller.proto
@@ -22,14 +22,15 @@ message PolicyState {
   int64 transition_time = 4;
   responsive.controller.v1.controller.proto.ApplicationPolicySpec policy = 5;
   responsive.controller.v1.controller.proto.ApplicationState current_state = 6;
-  Action ongoing_action = 7;
+  responsive.controller.v1.controller.proto.Action ongoing_action = 7;
   int64 last_eval_time = 8;
+  repeated CompletedAction action_log = 9;
 }
 
-message Action {
-  oneof action {
-    ChangeApplicationState change_application_state = 1;
-  }
+message CompletedAction {
+  int64 completed_time = 1;
+  responsive.controller.v1.controller.proto.Action action = 2;
+  responsive.controller.v1.controller.proto.ActionStatus status = 3;
 }
 
 message ChangeApplicationState {

--- a/controller-api/src/main/proto/responsive/controller/internal/v1/internal.proto
+++ b/controller-api/src/main/proto/responsive/controller/internal/v1/internal.proto
@@ -8,10 +8,30 @@ import "responsive/controller/v1/controller.proto";
 service Internal {
   rpc DumpState(DumpStateRequest) returns (EmptyResponse) {}
   rpc GetPolicy(GetPolicyRequest) returns (GetPolicyResponse) {}
+  rpc CreateAction(InternalCreateActionRequest) returns (InternalCreateActionResponse) {}
+  rpc GetActionStatus(InternalGetActionStatusRequest) returns (InternalGetActionStatusResponse) {}
 }
 
 message DumpStateRequest {
   optional string path = 1;
+}
+
+message InternalCreateActionRequest {
+  responsive.controller.internal.v1.controller.proto.ApplicationId application_id = 1;
+  responsive.controller.v1.controller.proto.Action action = 2;
+}
+
+message InternalCreateActionResponse {
+  responsive.controller.v1.controller.proto.Action action = 1;
+}
+
+message InternalGetActionStatusRequest {
+  responsive.controller.internal.v1.controller.proto.ApplicationId application_id = 1;
+  string ation_id = 2;
+}
+
+message InternalGetActionStatusResponse {
+  responsive.controller.v1.controller.proto.ActionStatus status = 1;
 }
 
 message GetPolicyRequest {

--- a/controller-api/src/main/proto/responsive/controller/v1/controller.proto
+++ b/controller-api/src/main/proto/responsive/controller/v1/controller.proto
@@ -12,6 +12,8 @@ service Controller {
   rpc UpsertPolicy(UpsertPolicyRequest) returns (SimpleResponse) {}
   rpc CurrentState(CurrentStateRequest) returns (SimpleResponse) {}
   rpc GetTargetState(EmptyRequest) returns (GetTargetStateResponse) {}
+  rpc CreateAction(CreateActionRequest) returns (CreateActionResponse) {}
+  rpc GetActionStatus(GetActionStatusRequest) returns (GetActionStatusResponse) {}
   rpc GetCurrentActions(EmptyRequest) returns (GetCurrentActionsResponse) {}
   rpc UpdateActionStatus(UpdateActionStatusRequest) returns (SimpleResponse)  {}
   rpc ListApplications(EmptyUnspecificRequest) returns (ListApplicationsResponse) {}
@@ -59,6 +61,24 @@ message GetTargetStateResponse {
   int64 last_eval_time_ms = 3;
 }
 
+message CreateActionRequest {
+  string application_id = 1;
+  Action action = 2;
+}
+
+message CreateActionResponse {
+  Action action = 1;
+}
+
+message GetActionStatusRequest {
+  string application_id = 1;
+  string action_id = 2;
+}
+
+message GetActionStatusResponse {
+  ActionStatus status = 1;
+}
+
 message GetCurrentActionsResponse {
   repeated Action actions = 1;
   int64 last_eval_time_ms = 2;
@@ -74,6 +94,7 @@ message ActionStatus {
   enum Status {
     COMPLETED = 0;
     FAILED = 1;
+    PENDING = 2;
   }
   Status status = 1;
   string details = 2;


### PR DESCRIPTION
This patch adds controller APIs for action management. We can
use these APIs to manually create and check the status of actions.

Builds on #275 