### PR TITLE
Use TimestampedKeyValueStore in AsyncProcessorIntegrationTest

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/stores/AsyncTimestampedKeyValueStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/stores/AsyncTimestampedKeyValueStore.java
@@ -1,0 +1,18 @@
+package dev.responsive.kafka.api.async.internals.stores;
+
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.TimestampedKeyValueStore;
+import org.apache.kafka.streams.state.ValueAndTimestamp;
+
+public class AsyncTimestampedKeyValueStore<KS, VS>
+    extends AsyncKeyValueStore<KS, ValueAndTimestamp<VS>>
+    implements TimestampedKeyValueStore<KS, VS>
+{
+  public AsyncTimestampedKeyValueStore(
+      final String name,
+      final int partition,
+      final KeyValueStore<?, ?> userDelegate
+  ) {
+    super(name, partition, userDelegate);
+  }
+}

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/stores/AsyncTimestampedKeyValueStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/stores/AsyncTimestampedKeyValueStore.java
@@ -6,8 +6,8 @@ import org.apache.kafka.streams.state.ValueAndTimestamp;
 
 public class AsyncTimestampedKeyValueStore<KS, VS>
     extends AsyncKeyValueStore<KS, ValueAndTimestamp<VS>>
-    implements TimestampedKeyValueStore<KS, VS>
-{
+    implements TimestampedKeyValueStore<KS, VS> {
+
   public AsyncTimestampedKeyValueStore(
       final String name,
       final int partition,
@@ -15,4 +15,5 @@ public class AsyncTimestampedKeyValueStore<KS, VS>
   ) {
     super(name, partition, userDelegate);
   }
+
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/stores/ResponsiveKeyValueBytesStoreSupplier.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/stores/ResponsiveKeyValueBytesStoreSupplier.java
@@ -17,6 +17,7 @@
 package dev.responsive.kafka.api.stores;
 
 import dev.responsive.kafka.internal.stores.ResponsiveKeyValueStore;
+import dev.responsive.kafka.internal.stores.ResponsiveTimestampedKeyValueStore;
 import java.util.Locale;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
@@ -26,8 +27,14 @@ public class ResponsiveKeyValueBytesStoreSupplier implements KeyValueBytesStoreS
 
   private final ResponsiveKeyValueParams params;
 
+  private boolean isTimestamped;
+
   public ResponsiveKeyValueBytesStoreSupplier(final ResponsiveKeyValueParams params) {
     this.params = params;
+  }
+
+  public void asTimestamped() {
+    this.isTimestamped = true;
   }
 
   @Override
@@ -37,7 +44,11 @@ public class ResponsiveKeyValueBytesStoreSupplier implements KeyValueBytesStoreS
 
   @Override
   public KeyValueStore<Bytes, byte[]> get() {
-    return new ResponsiveKeyValueStore(params);
+    if (isTimestamped) {
+      return new ResponsiveTimestampedKeyValueStore(params);
+    } else {
+      return new ResponsiveKeyValueStore(params);
+    }
   }
 
   @Override

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/stores/ResponsiveStores.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/stores/ResponsiveStores.java
@@ -153,6 +153,14 @@ public final class ResponsiveStores {
       final Serde<K> keySerde,
       final Serde<V> valueSerde
   ) {
+    if (storeSupplier instanceof ResponsiveKeyValueBytesStoreSupplier) {
+      ((ResponsiveKeyValueBytesStoreSupplier) storeSupplier).asTimestamped();
+    } else {
+      throw new IllegalArgumentException(
+          "Must supply a Responsive StoreSupplier via one of the ResponsiveStores APIs"
+      );
+    }
+
     return new ResponsiveStoreBuilder<>(
         StoreType.TIMESTAMPED_KEY_VALUE,
         storeSupplier,

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveTimestampedKeyValueStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveTimestampedKeyValueStore.java
@@ -1,0 +1,22 @@
+package dev.responsive.kafka.internal.stores;
+
+import dev.responsive.kafka.api.stores.ResponsiveKeyValueParams;
+import org.apache.kafka.streams.state.TimestampedBytesStore;
+
+public class ResponsiveTimestampedKeyValueStore
+    extends ResponsiveKeyValueStore implements TimestampedBytesStore {
+
+
+  public ResponsiveTimestampedKeyValueStore(
+      final ResponsiveKeyValueParams params
+  ) {
+    super(params);
+  }
+
+  public ResponsiveTimestampedKeyValueStore(
+      final ResponsiveKeyValueParams params,
+      final KVOperationsProvider opsProvider
+  ) {
+    super(params, opsProvider);
+  }
+}

--- a/kafka-client/src/test/java/dev/responsive/kafka/async/AsyncProcessorIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/async/AsyncProcessorIntegrationTest.java
@@ -67,7 +67,6 @@ import org.apache.kafka.streams.processor.api.FixedKeyProcessor;
 import org.apache.kafka.streams.processor.api.FixedKeyProcessorContext;
 import org.apache.kafka.streams.processor.api.FixedKeyProcessorSupplier;
 import org.apache.kafka.streams.processor.api.FixedKeyRecord;
-import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.StoreBuilder;
 import org.apache.kafka.streams.state.TimestampedKeyValueStore;
 import org.apache.kafka.streams.state.ValueAndTimestamp;


### PR DESCRIPTION
Forgot to merge this with the async POC branch before merging that PR, so here's a quick followup that makes sure we actually use the TimestampedKeyValueStore in the async integration test.

I needed to make a few small changes to the way we build the normal (non-async) state stores for this to work, mot notably adding a ResponsiveTimestampedKeyValueStore that implements the TimestampedBytesStore marker interface in Streams. We actually had this a while back but I took it out to simplify things because we didn't strictly need it for plain Streams. Well, now we need it for the async processing stuff.

(If you're curious why we need it now, it's because we override the actual builder that adds the various store layers so that we can stick in our special async flushing layer to the async stores. And the Streams builder we override does some fancy magic to wrap stores that don't implement the TimestampedBytesStore in a timestamping-layer. So we could either re-implement this fancy/hacky magic in our builder, which is a non-trivial amount of extra code, or we could just have an actual timestamped version of our own KV store, which is actually very little extra code since it just has to add the marker interface but can otherwise simply extend the non-timestamped store. Also it's probably the right thing to do anyway)