### PR TITLE
Add per-key backpressure mechanism and unit tests for SchedulingQueue

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/AsyncProcessor.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/AsyncProcessor.java
@@ -16,6 +16,7 @@
 
 package dev.responsive.kafka.api.async.internals;
 
+import static dev.responsive.kafka.api.config.ResponsiveConfig.ASYNC_SCHEDULING_QUEUE_SIZE_CONFIG;
 import static dev.responsive.kafka.internal.config.InternalSessionConfigs.loadAsyncThreadPoolRegistry;
 
 import dev.responsive.kafka.api.async.AsyncProcessorSupplier;
@@ -29,6 +30,7 @@ import dev.responsive.kafka.api.async.internals.queues.SchedulingQueue;
 import dev.responsive.kafka.api.async.internals.stores.AbstractAsyncStoreBuilder;
 import dev.responsive.kafka.api.async.internals.stores.AsyncKeyValueStore;
 import dev.responsive.kafka.api.async.internals.stores.StreamThreadFlushListeners.AsyncFlushListener;
+import dev.responsive.kafka.api.config.ResponsiveConfig;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -65,10 +67,6 @@ public class AsyncProcessor<KIn, VIn, KOut, VOut>
 
   private final Map<String, AbstractAsyncStoreBuilder<?, ?, ?>> connectedStoreBuilders;
 
-  // Owned and solely accessed by this StreamThread, stashes waiting events that are blocked
-  // on previous events with the same key that are still in flight
-  private final SchedulingQueue<KIn> schedulingQueue = new SchedulingQueue<>();
-
   // Owned and solely accessed by this StreamThread, simply keeps track of the events
   // that are waiting to be scheduled or are currently "in flight", ie all events
   // for which we received an input record but have not yet finished processing either
@@ -93,7 +91,8 @@ public class AsyncProcessor<KIn, VIn, KOut, VOut>
   private TaskId taskId;
 
   private AsyncThreadPool threadPool;
-  private FinalizingQueue finalizableRecords;
+  private FinalizingQueue finalizingQueue;
+  private SchedulingQueue<KIn> schedulingQueue;
 
   // the context passed to us in init, ie the one created for this task and owned by Kafka Streams
   private ProcessingContext taskContext;
@@ -195,14 +194,18 @@ public class AsyncProcessor<KIn, VIn, KOut, VOut>
     this.userContext = new AsyncUserProcessorContext<>(streamThreadName, taskContext, logPrefix);
     userContext.setDelegateForStreamThread(streamThreadContext);
 
-    this.finalizableRecords = new FinalizingQueue(logPrefix);
+    final ResponsiveConfig configs = ResponsiveConfig.responsiveConfig(userContext.appConfigs());
+    final long schedulingQueueSize = configs.getLong(ASYNC_SCHEDULING_QUEUE_SIZE_CONFIG);
+
+    this.schedulingQueue = new SchedulingQueue<>(logPrefix, schedulingQueueSize);
+    this.finalizingQueue = new FinalizingQueue(logPrefix);
 
     this.threadPool = getAsyncThreadPool(internalContext, streamThreadName);
     this.threadPool.addProcessor(
         asyncProcessorName,
         taskId.partition(),
         userContext,
-        finalizableRecords
+        finalizingQueue
     );
   }
 
@@ -252,8 +255,12 @@ public class AsyncProcessor<KIn, VIn, KOut, VOut>
 
   private void processNewAsyncEvent(final AsyncEvent event) {
     pendingEvents.add(event);
-    schedulingQueue.offer(event);
 
+    if (schedulingQueue.isFull()) {
+      backOffSchedulingQueue();
+    }
+
+    schedulingQueue.offer(event);
     executeAvailableEvents();
   }
 
@@ -332,19 +339,54 @@ public class AsyncProcessor<KIn, VIn, KOut, VOut>
 
       // Need to finalize at least one event per iteration, otherwise there's no
       // point returning to the scheduling queue since nothing new was unblocked
-      final int numFinalized = drainFinalizingQueue();
-      if (numFinalized == 0) {
-        try {
-          final AsyncEvent finalizableEvent = finalizableRecords.waitForFinalizableEvent();
-          completePendingEvent(finalizableEvent);
-        } catch (final Exception e) {
-          log.error("Exception caught while waiting for an event to finalize", e);
-          throw new StreamsException("Failed to flush async processor", e, taskId);
-        }
-      }
+      final int numFinalized = finalizeAtLeastOneEvent();
       log.debug("Scheduled {} events and finalized {} events",
-                numScheduled, numFinalized == 0 ? 1 : numFinalized
+                numScheduled, numFinalized
       );
+    }
+  }
+
+  /**
+   * Blocking API that guarantees at least one event has been finalized.
+   * <p>
+   * Drains the finalizing queue to complete any/all events that were already
+   * processed and waiting to be finalized. If no events are ready for
+   * finalization when this method is called, it will block until the next
+   * one becomes available and will finalize that event.
+   *
+   * @return the number of events that were finalized
+   */
+  private int finalizeAtLeastOneEvent() {
+    final int numFinalized = drainFinalizingQueue();
+    if (numFinalized == 0) {
+      try {
+        final AsyncEvent finalizableEvent = finalizingQueue.waitForFinalizableEvent();
+        completePendingEvent(finalizableEvent);
+      } catch (final Exception e) {
+        log.error("Exception caught while waiting for an event to finalize", e);
+        throw new StreamsException("Failed to flush async processor", e, taskId);
+      }
+    }
+    return numFinalized == 0 ? 1 : numFinalized;
+  }
+
+  /**
+   * Executes async events that are in-flight until the SchedulingQueue has
+   * adequate space for new events.
+   * <p>
+   * Applies backpressure before proceeding with a new AsyncEvent ie adding it
+   * to the SchedulingQueue. This method waits for new events to finish being
+   * processed by the async threads and handed back to the StreamThread for
+   * finalization, thus freeing up blocked record(s) that were waiting in the
+   * SchedulingQueue and can be moved to the ProcessingQueue for processing.
+   */
+  private void backOffSchedulingQueue() {
+    while (schedulingQueue.isFull()) {
+      drainSchedulingQueue();
+
+      if (schedulingQueue.isFull()) {
+        finalizeAtLeastOneEvent();
+      }
     }
   }
 
@@ -418,8 +460,8 @@ public class AsyncProcessor<KIn, VIn, KOut, VOut>
    */
   private int drainFinalizingQueue() {
     int count = 0;
-    while (!finalizableRecords.isEmpty()) {
-      final AsyncEvent event = finalizableRecords.nextFinalizableEvent();
+    while (!finalizingQueue.isEmpty()) {
+      final AsyncEvent event = finalizingQueue.nextFinalizableEvent();
       completePendingEvent(event);
       ++count;
     }
@@ -477,7 +519,7 @@ public class AsyncProcessor<KIn, VIn, KOut, VOut>
     event.transitionToDone();
 
     pendingEvents.remove(event);
-    schedulingQueue.unblockKey(event.inputKey());
+    schedulingQueue.unblockKey(event.inputRecordKey());
   }
 
   /**

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/queues/FinalizingQueue.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/queues/FinalizingQueue.java
@@ -77,12 +77,12 @@ public class FinalizingQueue implements ReadOnlyFinalizingQueue, WriteOnlyFinali
   }
 
   /**
-   * See {@link ReadOnlyFinalizingQueue#waitForFinalizableEvent()}
+   * See {@link ReadOnlyFinalizingQueue#waitForNextFinalizableEvent()}
    * <p>
    * Note: blocking API
    */
   @Override
-  public AsyncEvent waitForFinalizableEvent() throws InterruptedException {
+  public AsyncEvent waitForNextFinalizableEvent() throws InterruptedException {
     return finalizableRecords.take();
   }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/queues/FinalizingQueue.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/queues/FinalizingQueue.java
@@ -68,6 +68,8 @@ public class FinalizingQueue implements ReadOnlyFinalizingQueue, WriteOnlyFinali
 
   /**
    * See {@link ReadOnlyFinalizingQueue#nextFinalizableEvent()}
+   * <p>
+   * Note: non-blocking API
    */
   @Override
   public AsyncEvent nextFinalizableEvent() {
@@ -76,6 +78,8 @@ public class FinalizingQueue implements ReadOnlyFinalizingQueue, WriteOnlyFinali
 
   /**
    * See {@link ReadOnlyFinalizingQueue#waitForFinalizableEvent()}
+   * <p>
+   * Note: blocking API
    */
   @Override
   public AsyncEvent waitForFinalizableEvent() throws InterruptedException {

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/queues/ReadOnlyFinalizingQueue.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/queues/ReadOnlyFinalizingQueue.java
@@ -50,7 +50,7 @@ public interface ReadOnlyFinalizingQueue {
    *         onr is available. Guaranteed to never return null
    * @throws InterruptedException if interrupted while blocking
    */
-  AsyncEvent waitForFinalizableEvent() throws InterruptedException;
+  AsyncEvent waitForNextFinalizableEvent() throws InterruptedException;
 
   /**
    * @return true if there are no currently-available events that are

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/queues/SchedulingQueue.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/queues/SchedulingQueue.java
@@ -21,6 +21,8 @@ import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
 import java.util.Queue;
+import org.apache.kafka.common.utils.LogContext;
+import org.slf4j.Logger;
 
 /**
  * A non-blocking queue for async events waiting to be passed from the StreamThread to
@@ -37,8 +39,18 @@ import java.util.Queue;
  */
 public class SchedulingQueue<KIn> {
 
-  private final Map<KIn, KeyStatus> blockedEvents = new HashMap<>();
+  private final Logger log;
+
+  private final Map<KIn, KeyEventQueue> blockedEvents = new HashMap<>();
   private final Queue<AsyncEvent> processableEvents = new LinkedList<>();
+
+  private final long maxSize; // upper bound on queue size to apply backpressure
+  private long currentSize = 0;
+
+  public SchedulingQueue(final String logPrefix, final long maxSize) {
+    this.log = new LogContext(logPrefix).logger(SchedulingQueue.class);
+    this.maxSize = maxSize;
+  }
 
   /**
    * Mark the given key as unblocked and free up the next record with
@@ -46,12 +58,12 @@ public class SchedulingQueue<KIn> {
    * Called upon the finalization of an async event with the given input key
    */
   public void unblockKey(final KIn key) {
-    final KeyStatus keyStatus = getOrCreateKeyStatus(key);
-    if (!keyStatus.isBlocked()) {
+    final KeyEventQueue keyEventQueue = getOrCreateKeyStatus(key);
+    if (!keyEventQueue.isBlocked()) {
       throw new IllegalStateException("Attempted to unblock a key but it was not blocked");
     }
 
-    final AsyncEvent nextProcessableEvent = keyStatus.scheduleNextEvent();
+    final AsyncEvent nextProcessableEvent = keyEventQueue.scheduleNextEvent();
     if (nextProcessableEvent != null) {
       // If there are blocked events waiting, promote one but don't unblock
       processableEvents.offer(nextProcessableEvent);
@@ -76,6 +88,7 @@ public class SchedulingQueue<KIn> {
    *         or {@code null} if there are no processable records
    */
   public AsyncEvent poll() {
+    --currentSize;
     return processableEvents.poll();
   }
 
@@ -87,17 +100,33 @@ public class SchedulingQueue<KIn> {
   public void offer(
       final AsyncEvent event
   ) {
-    final KeyStatus keyStatus = getOrCreateKeyStatus(event.inputKey());
-    if (keyStatus.isBlocked()) {
-      keyStatus.addBlockedEvent(event);
+    if (isFull()) {
+      log.error("Tried to offer new event but the SchedulingQueue's current size {} is equal or "
+                    + "greater than the size limit {}", currentSize, maxSize);
+      throw new IllegalStateException("Attempted to add event while SchedulingQueue was full");
+    }
+
+    final KeyEventQueue keyEventQueue = getOrCreateKeyStatus(event.inputRecordKey());
+    if (keyEventQueue.isBlocked()) {
+      keyEventQueue.addBlockedEvent(event);
     } else {
-      keyStatus.scheduleNewEvent(event);
+      keyEventQueue.scheduleNewEvent(event);
       processableEvents.offer(event);
     }
+
+    ++currentSize;
   }
 
-  private KeyStatus getOrCreateKeyStatus(final KIn key) {
-    return blockedEvents.computeIfAbsent(key, k -> new KeyStatus());
+  public boolean isEmpty() {
+    return currentSize == 0;
+  }
+
+  public boolean isFull() {
+    return currentSize >= maxSize;
+  }
+
+  private KeyEventQueue getOrCreateKeyStatus(final KIn key) {
+    return blockedEvents.computeIfAbsent(key, k -> new KeyEventQueue());
   }
 
   /**
@@ -105,7 +134,7 @@ public class SchedulingQueue<KIn> {
    * of this key, ie whether there is an in-flight event of the same key that
    * is currently blocking other events from being scheduled.
    * <p>
-   * A KeyStatus, and all events with that input key, are considered blocked
+   * A KeyEventQueue, and all events with that input key, are considered blocked
    * if there is an async event currently in-flight with this key. An
    * event is "in-flight" from the moment it leaves the blockedEvents queue
    * until the moment it is finalized and marked done. An event that is in
@@ -114,7 +143,7 @@ public class SchedulingQueue<KIn> {
    * to be "in-flight", and should block any other events with that key from
    * being added to the processableEvents queue.
    */
-  private static class KeyStatus {
+  private static class KeyEventQueue {
     private final Queue<AsyncEvent> blockedEvents = new LinkedList<>();
     private AsyncEvent inFlightEvent;
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
@@ -204,12 +204,22 @@ public class ResponsiveConfig extends AbstractConfig {
   private static final String SUBPARTITION_HASHER_DOC = "Hasher to use for sub-partitioning.";
   private static final Class<?> SUBPARTITION_HASHER_DEFAULT = Murmur3Hasher.class;
 
+
+  // ------------------ Async processing configurations ----------------------
+
   public static final String ASYNC_THREAD_POOL_SIZE_CONFIG = "responsive.async.thread.pool.size";
   private static final int ASYNC_THREAD_POOL_SIZE_DEFAULT = 0;
   private static final String ASYNC_THREAD_POOL_SIZE_DOC = "The number of async processing threads to "
       + "start up for each StreamThread in this app. Setting this to 0 (the default) means async processing "
       + "will not be enabled. Setting this to a positive integer will enable async processing, but only if "
       + "there is at least one AsyncProcessor in the topology. See javadocs for AsyncProcessorSupplier for details.";
+
+  public static final String ASYNC_SCHEDULING_QUEUE_SIZE_CONFIG = "responsive.async.scheduling.queue.size";
+  private static final long ASYNC_SCHEDULING_QUEUE_SIZE_DEFAULT = 1L;
+  private static final String ASYNC_SCHEDULING_QUEUE_SIZE_DOC = "The maximum number of queued-up events that can be "
+      + "waiting to be scheduled on the async processor at a time. This upper bound provides a backpressure mechanism "
+      + "to make sure the StreamThread will back off properly when the async thread pool is struggling to keep up with "
+      + "the rate of input records.";
 
 
   // ------------------ WindowStore configurations ----------------------
@@ -445,6 +455,13 @@ public class ResponsiveConfig extends AbstractConfig {
           atLeast(0),
           Importance.LOW,
           ASYNC_THREAD_POOL_SIZE_DOC
+      ).define(
+          ASYNC_SCHEDULING_QUEUE_SIZE_CONFIG,
+          Type.LONG,
+          ASYNC_SCHEDULING_QUEUE_SIZE_DEFAULT,
+          atLeast(0),
+          Importance.LOW,
+          ASYNC_SCHEDULING_QUEUE_SIZE_DOC
       ).define(
           MONGO_WINDOWED_KEY_TIMESTAMP_FIRST_CONFIG,
           Type.BOOLEAN,

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
@@ -459,7 +459,7 @@ public class ResponsiveConfig extends AbstractConfig {
           ASYNC_THREAD_POOL_SIZE_DOC
       ).define(
           ASYNC_MAX_EVENTS_PER_KEY_CONFIG,
-          Type.LONG,
+          Type.INT,
           ASYNC_MAX_EVENTS_PER_KEY_DEFAULT,
           Importance.LOW,
           ASYNC_MAX_EVENTS_PER_KEY_DOC

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
@@ -214,12 +214,14 @@ public class ResponsiveConfig extends AbstractConfig {
       + "will not be enabled. Setting this to a positive integer will enable async processing, but only if "
       + "there is at least one AsyncProcessor in the topology. See javadocs for AsyncProcessorSupplier for details.";
 
-  public static final String ASYNC_SCHEDULING_QUEUE_SIZE_CONFIG = "responsive.async.scheduling.queue.size";
-  private static final long ASYNC_SCHEDULING_QUEUE_SIZE_DEFAULT = 1L;
-  private static final String ASYNC_SCHEDULING_QUEUE_SIZE_DOC = "The maximum number of queued-up events that can be "
-      + "waiting to be scheduled on the async processor at a time. This upper bound provides a backpressure mechanism "
-      + "to make sure the StreamThread will back off properly when the async thread pool is struggling to keep up with "
-      + "the rate of input records.";
+  public static final String ASYNC_MAX_EVENTS_PER_KEY_CONFIG = "responsive.async.max.events.per.key";
+  private static final int ASYNC_MAX_EVENTS_PER_KEY_DEFAULT = 5;
+  private static final String ASYNC_MAX_EVENTS_PER_KEY_DOC = "The maximum number of pending events at a time for "
+      + "a given key. This puts a limit on how many events for each key can be either currently processing or awaiting "
+      + "processing by the async thread pool. Since all events with the same key must be processed in offset order, this"
+      + "config can be used to limit how many events will have to be processed serially in order to flush the processor, "
+      + "for example during a commit or before closing the task. If you experience long flushes or StreamThreads "
+      + "dropping out of the consumer group due to missing the max.poll.interval.ms, consider lowering this value";
 
 
   // ------------------ WindowStore configurations ----------------------
@@ -456,12 +458,11 @@ public class ResponsiveConfig extends AbstractConfig {
           Importance.LOW,
           ASYNC_THREAD_POOL_SIZE_DOC
       ).define(
-          ASYNC_SCHEDULING_QUEUE_SIZE_CONFIG,
+          ASYNC_MAX_EVENTS_PER_KEY_CONFIG,
           Type.LONG,
-          ASYNC_SCHEDULING_QUEUE_SIZE_DEFAULT,
-          atLeast(0),
+          ASYNC_MAX_EVENTS_PER_KEY_DEFAULT,
           Importance.LOW,
-          ASYNC_SCHEDULING_QUEUE_SIZE_DOC
+          ASYNC_MAX_EVENTS_PER_KEY_DOC
       ).define(
           MONGO_WINDOWED_KEY_TIMESTAMP_FIRST_CONFIG,
           Type.BOOLEAN,

--- a/kafka-client/src/test/java/dev/responsive/kafka/async/internals/queues/SchedulingQueueTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/async/internals/queues/SchedulingQueueTest.java
@@ -61,7 +61,7 @@ public class SchedulingQueueTest {
     queue.unblockKey("A");
 
     // Then:
-    assertThat(queue.poll().inputRecord(), is(new KeyValue<>("A", "a2"))); // only queued event is still blocked
+    assertThat(queue.poll().inputRecord(), is(new KeyValue<>("A", "a2")));
   }
 
   @Test
@@ -177,7 +177,7 @@ public class SchedulingQueueTest {
 
     // When:
     queue.poll();
-    
+
     // Then:
     assertThat(queue.isFull(), is(false));
   }

--- a/kafka-client/src/test/java/dev/responsive/kafka/async/internals/queues/SchedulingQueueTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/async/internals/queues/SchedulingQueueTest.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2024 Responsive Computing, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package dev.responsive.kafka.async.internals.queues;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+
+import dev.responsive.kafka.api.async.internals.queues.SchedulingQueue;
+import dev.responsive.kafka.testutils.AsyncTestEvent;
+import org.apache.kafka.streams.KeyValue;
+import org.junit.Test;
+
+public class SchedulingQueueTest {
+
+  private static final String LOG_PREFIX = "test";
+  private static final long DEFAULT_QUEUE_SIZE = Long.MAX_VALUE;
+
+  private final SchedulingQueue<String> queue = new SchedulingQueue<>(
+      LOG_PREFIX, DEFAULT_QUEUE_SIZE
+  );
+
+  @Test
+  public void shouldReturnNullWhenSameKeyEventIsInFlight() {
+    // Given:
+    queue.offer(new AsyncTestEvent("A", "a1"));
+    queue.offer(new AsyncTestEvent("A", "a2"));
+
+    // When:
+    queue.poll(); // in-flight record
+
+    // Then:
+    assertNull(queue.poll());
+  }
+
+  @Test
+  public void shouldReturnBlockedEventAfterKeyIsUnblocked() {
+    // Given:
+    queue.offer(new AsyncTestEvent("A", "a1"));
+    queue.offer(new AsyncTestEvent("A", "a2"));
+
+    queue.poll(); // remove 1st event but don't unblock it yet
+    assertNull(queue.poll()); // only queued event is still blocked
+
+    // When:
+    queue.unblockKey("A");
+
+    // Then:
+    assertThat(queue.poll().inputRecord(), is(new KeyValue<>("A", "a2"))); // only queued event is still blocked
+  }
+
+  @Test
+  public void shouldReturnOnlyUnblockedEventsInFIFOOrder() {
+    // Given:
+    queue.offer(new AsyncTestEvent("foo", "f1"));
+    queue.offer(new AsyncTestEvent("foo", "f2"));
+    queue.offer(new AsyncTestEvent("bar", "b1"));
+    queue.offer(new AsyncTestEvent("bar", "b2"));
+    queue.offer(new AsyncTestEvent("cat", "c1"));
+    queue.offer(new AsyncTestEvent("cat", "c2"));
+
+    // Then:
+    assertThat(queue.poll().inputRecord(), is(new KeyValue<>("foo", "f1")));
+    assertThat(queue.poll().inputRecord(), is(new KeyValue<>("bar", "b1")));
+    assertThat(queue.poll().inputRecord(), is(new KeyValue<>("cat", "c1")));
+    assertNull(queue.poll());
+  }
+
+  @Test
+  public void shouldReturnEventsInUnblockingOrder() {
+    // Given:
+    queue.offer(new AsyncTestEvent("A", "a1"));
+    queue.offer(new AsyncTestEvent("B", "b1"));
+    queue.offer(new AsyncTestEvent("C", "c1"));
+
+    queue.poll();
+    queue.poll();
+    queue.poll();
+    assertThat(queue.isEmpty(), is(true));
+
+    // When:
+    queue.offer(new AsyncTestEvent("A", "a2"));
+    queue.offer(new AsyncTestEvent("B", "b2"));
+    queue.offer(new AsyncTestEvent("C", "c2"));
+
+    queue.unblockKey("C");
+    queue.unblockKey("B");
+    queue.unblockKey("A");
+
+    // Then:
+    assertThat(queue.poll().inputRecord(), is(new KeyValue<>("C", "c2")));
+    assertThat(queue.poll().inputRecord(), is(new KeyValue<>("B", "b2")));
+    assertThat(queue.poll().inputRecord(), is(new KeyValue<>("A", "a2")));
+    assertNull(queue.poll());
+  }
+
+  @Test
+  public void shouldReturnNullWhenNothingAdded() {
+    // Given:
+
+    // Then:
+    assertNull(queue.poll());
+  }
+
+  @Test
+  public void shouldReturnNullAfterAllEventsPolled() {
+    // Given:
+    queue.offer(new AsyncTestEvent("A", "a1"));
+    queue.offer(new AsyncTestEvent("A", "a2"));
+    queue.offer(new AsyncTestEvent("B", "b1"));
+
+    // When:
+    queue.poll(); // polls a1
+    queue.poll(); // polls b1
+    queue.unblockKey("A");
+    queue.poll(); // polls a2
+
+    // Then:
+    assertNull(queue.poll());
+  }
+
+  @Test
+  public void shouldReturnTrueFromIsFullWhenAtMaxSizeWithAllSameKey() {
+    // Given:
+    final long maxEvents = 3;
+    final SchedulingQueue<String> queue = new SchedulingQueue<>(LOG_PREFIX, maxEvents);
+
+    // When:
+    queue.offer(new AsyncTestEvent("A", "a1"));
+    queue.offer(new AsyncTestEvent("A", "a2"));
+    queue.offer(new AsyncTestEvent("A", "a3"));
+
+    // Then:
+    assertThat(queue.isFull(), is(true));
+  }
+
+  @Test
+  public void shouldReturnTrueFromIsFullWhenAtMaxSizeWithAllDifferentKeys() {
+    // Given:
+    final long maxEvents = 3;
+    final SchedulingQueue<String> queue = new SchedulingQueue<>(LOG_PREFIX, maxEvents);
+
+    // When:
+    queue.offer(new AsyncTestEvent("A", "a1"));
+    queue.offer(new AsyncTestEvent("B", "b1"));
+    queue.offer(new AsyncTestEvent("C", "c1"));
+
+    // Then:
+    assertThat(queue.isFull(), is(true));
+  }
+
+  @Test
+  public void shouldReturnFalseFromIsFullWhenEventisPolled() {
+    // Given:
+    final long maxEvents = 3;
+    final SchedulingQueue<String> queue = new SchedulingQueue<>(LOG_PREFIX, maxEvents);
+
+    queue.offer(new AsyncTestEvent("A", "a1"));
+    queue.offer(new AsyncTestEvent("A", "a2"));
+    queue.offer(new AsyncTestEvent("B", "b1"));
+    assertThat(queue.isFull(), is(true));
+
+    // When:
+    queue.poll();
+    
+    // Then:
+    assertThat(queue.isFull(), is(false));
+  }
+
+  @Test
+  public void shouldThrowWhenAddingToFullQueue() {
+    // Given
+    final long maxEvents = 1;
+    final SchedulingQueue<String> queue = new SchedulingQueue<>(LOG_PREFIX, maxEvents);
+    queue.offer(new AsyncTestEvent("A", "a1"));
+
+    assertThrows(IllegalStateException.class, () -> queue.offer(new AsyncTestEvent("A", "a2")));
+  }
+
+  @Test
+  public void shouldThrowWhenUnblockingKeyThatIsNotBlocked() {
+    assertThrows(IllegalStateException.class, () -> queue.unblockKey("A"));
+  }
+
+}

--- a/kafka-client/src/test/java/dev/responsive/kafka/testutils/AsyncTestEvent.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/testutils/AsyncTestEvent.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2024 Responsive Computing, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package dev.responsive.kafka.testutils;
+
+import dev.responsive.kafka.api.async.internals.events.AsyncEvent;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.processor.api.Record;
+import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
+
+/**
+ * Simple utility wrapper for creating AsyncEvents with only the parameters
+ * the test is actually concerned with, and everything else stubbed in
+ */
+public class AsyncTestEvent extends AsyncEvent {
+
+  public AsyncTestEvent(
+      final String key,
+      final String value
+  ) {
+    this(key, value, 0);
+  }
+
+  public AsyncTestEvent(
+      final String key,
+      final String value,
+      final int partition
+  ) {
+    this(key, value, partition, "topic");
+  }
+
+  public AsyncTestEvent(
+      final String key,
+      final String value,
+      final int partition,
+      final String topic
+  ) {
+    this(key, value, partition, topic, 0L, 0L);
+  }
+
+  public AsyncTestEvent(
+      final String key,
+      final String value,
+      final int partition,
+      final String topic,
+      final long timestamp,
+      final long offset
+  ) {
+    super(
+        String.format("event <%s, %s>[%d]", key, value, partition),
+        new Record<>(key, value, timestamp),
+        partition,
+        new ProcessorRecordContext(
+            timestamp,
+            offset,
+            partition,
+            topic,
+            new RecordHeaders()
+        ),
+        0L,
+        0L,
+        () -> {}
+    );
+  }
+}

--- a/kafka-client/src/test/java/dev/responsive/kafka/testutils/AsyncTestEvent.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/testutils/AsyncTestEvent.java
@@ -18,7 +18,6 @@ package dev.responsive.kafka.testutils;
 
 import dev.responsive.kafka.api.async.internals.events.AsyncEvent;
 import org.apache.kafka.common.header.internals.RecordHeaders;
-import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
 


### PR DESCRIPTION
Introduced a new config for the max size of the per-key queues that make up the SchedulingQueue. 

We can follow up with the last config which controls the overall number of pending events (see #2 of [this comment](https://github.com/responsivedev/responsive-pub/pull/281#discussion_r1573018556))