### PR TITLE
Re-set the internal "leave.group.on.close" config to true

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/ResponsiveKafkaClientSupplier.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/ResponsiveKafkaClientSupplier.java
@@ -159,6 +159,7 @@ public final class ResponsiveKafkaClientSupplier implements KafkaClientSupplier 
     LOG.info("Creating responsive main consumer: {}", clientId);
 
     // Reset the forced override of this config done by Kafka Streams
+    // TODO: remove this and use KafkaStreams#close(closeOptions) once KAFKA-16514 is fixed
     config.put("internal.leave.group.on.close", true);
 
     final String streamThreadName = extractThreadNameFromConsumerClientId(clientId);

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/ResponsiveKafkaClientSupplier.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/ResponsiveKafkaClientSupplier.java
@@ -158,6 +158,9 @@ public final class ResponsiveKafkaClientSupplier implements KafkaClientSupplier 
     final String clientId = (String) config.get(ConsumerConfig.CLIENT_ID_CONFIG);
     LOG.info("Creating responsive main consumer: {}", clientId);
 
+    // Reset the forced override of this config done by Kafka Streams
+    config.put("internal.leave.group.on.close", true);
+
     final String streamThreadName = extractThreadNameFromConsumerClientId(clientId);
     final String threadId = extractThreadId(streamThreadName);
 


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/KAFKA-16514 for some context

This is a temporary solution for us until that ticket is resolved and we can use the actual KafkaStreams#close(closeOptions) API with correct semantics