### PR TITLE
Expand Async integration test with upstream and downstream stateful processors

### DIFF
--- a/kafka-client/src/test/java/dev/responsive/kafka/async/AsyncProcessorIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/async/AsyncProcessorIntegrationTest.java
@@ -162,11 +162,12 @@ public class AsyncProcessorIntegrationTest {
                 ResponsiveKeyValueParams.fact(IN_KV_STORE)),
             IN_KV_STORE)
         .processValues(
-            new SimpleStatefulProcessorSupplier(
-                this::computeNewValueForAsyncProcessor,
-                ResponsiveKeyValueParams.fact(ASYNC_KV_STORE),
-                processed
-            ),
+            createAsyncProcessorSupplier(
+                new SimpleStatefulProcessorSupplier(
+                    this::computeNewValueForAsyncProcessor,
+                    ResponsiveKeyValueParams.fact(ASYNC_KV_STORE),
+                    processed
+                )),
             Named.as("AsyncProcessor"),
             ASYNC_KV_STORE)
         .processValues(

--- a/kafka-client/src/test/java/dev/responsive/kafka/async/AsyncProcessorIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/async/AsyncProcessorIntegrationTest.java
@@ -22,7 +22,6 @@ import static dev.responsive.kafka.testutils.IntegrationTestUtils.createTopicsAn
 import static dev.responsive.kafka.testutils.IntegrationTestUtils.pipeRecords;
 import static dev.responsive.kafka.testutils.IntegrationTestUtils.readOutput;
 import static dev.responsive.kafka.testutils.IntegrationTestUtils.startAppAndAwaitRunning;
-import static java.lang.Integer.valueOf;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
 import static org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG;
@@ -42,9 +41,9 @@ import dev.responsive.kafka.api.ResponsiveKafkaStreams;
 import dev.responsive.kafka.api.config.ResponsiveConfig;
 import dev.responsive.kafka.api.config.StorageBackend;
 import dev.responsive.kafka.api.stores.ResponsiveKeyValueParams;
-import dev.responsive.kafka.testutils.SimpleStatefulProcessorSupplier;
 import dev.responsive.kafka.testutils.ResponsiveConfigParam;
 import dev.responsive.kafka.testutils.ResponsiveExtension;
+import dev.responsive.kafka.testutils.SimpleStatefulProcessorSupplier;
 import dev.responsive.kafka.testutils.SimpleStatefulProcessorSupplier.SimpleProcessorOutput;
 import java.time.Duration;
 import java.util.HashMap;

--- a/kafka-client/src/test/java/dev/responsive/kafka/testutils/SimpleStatefulProcessor.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/testutils/SimpleStatefulProcessor.java
@@ -65,28 +65,6 @@ public class SimpleStatefulProcessor implements FixedKeyProcessor<String, String
     this.streamThreadName = Thread.currentThread().getName();
   }
 
-  private static String computeNewValue(
-      final String processorIdString,
-      final boolean isDownstreamProcessor,
-      final ValueAndTimestamp<String> oldValAndTimestamp,
-      final FixedKeyRecord<String, String> inputRecord
-  ) {
-    // If this is the first time seeing this key, we need to "start" the chain
-    if (oldValAndTimestamp == null) {
-      if (isDownstreamProcessor) {
-        // If this is a downstream processor then we're actually continuing the chain,
-        // not starting it, so just connect to the upstream chain by starting with a "--"
-        return String.format("--%s%s", inputRecord.key(), processorIdString, inputRecord.value());
-      } else {
-        // If this is the "first" processor in a chain, always start by appending the key
-        return String.format("%s:%s%s", inputRecord.key(), processorIdString, inputRecord.value());
-      }
-    }
-
-    final String oldValue = oldValAndTimestamp.value();
-    return String.format("%s%s%s", oldValue, processorIdString, inputRecord.value());
-  }
-
   @Override
   public void init(final FixedKeyProcessorContext<String, String> context) {
     this.context = context;

--- a/kafka-client/src/test/java/dev/responsive/kafka/testutils/SimpleStatefulProcessor.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/testutils/SimpleStatefulProcessor.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
  * <p>
  * See also: {@link SimpleStatefulProcessorSupplier}
  */
-@SuppressWarnings("checkstyle:linelngth")
+@SuppressWarnings("checkstyle:linelength")
 public class SimpleStatefulProcessor implements FixedKeyProcessor<String, String, String> {
 
   private final Logger log = LoggerFactory.getLogger(SimpleStatefulProcessor.class);

--- a/kafka-client/src/test/java/dev/responsive/kafka/testutils/SimpleStatefulProcessor.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/testutils/SimpleStatefulProcessor.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright 2024 Responsive Computing, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package dev.responsive.kafka.testutils;
+
+import dev.responsive.kafka.testutils.SimpleStatefulProcessorSupplier.SimpleProcessorOutput;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiFunction;
+import org.apache.kafka.streams.processor.api.FixedKeyProcessor;
+import org.apache.kafka.streams.processor.api.FixedKeyProcessorContext;
+import org.apache.kafka.streams.processor.api.FixedKeyRecord;
+import org.apache.kafka.streams.state.TimestampedKeyValueStore;
+import org.apache.kafka.streams.state.ValueAndTimestamp;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A simple fixed-key, string-typed, stateful processor that logs all records and actions
+ * at DEBUG and has some built in optional utilities for observing results such as counting
+ * the number of input records processed or storing the latest output values in a map.
+ * <p>
+ * See also: {@link SimpleStatefulProcessorSupplier}
+ */
+@SuppressWarnings("checkstyle:linelngth")
+public class SimpleStatefulProcessor implements FixedKeyProcessor<String, String, String> {
+
+  private final Logger log = LoggerFactory.getLogger(SimpleStatefulProcessor.class);
+
+  private final BiFunction<ValueAndTimestamp<String>, FixedKeyRecord<String, String>, SimpleProcessorOutput> computeOutput;
+
+  private final AtomicInteger processed;
+  private final Map<String, String> latestValues;
+
+  private final String storeName;
+  private final String streamThreadName;
+  private int partition;
+
+  private FixedKeyProcessorContext<String, String> context;
+  private TimestampedKeyValueStore<String, String> kvStore;
+
+  public SimpleStatefulProcessor(
+      final BiFunction<ValueAndTimestamp<String>, FixedKeyRecord<String, String>, SimpleProcessorOutput> computeOutput,
+      final String storeName,
+      final AtomicInteger processed,
+      final Map<String, String> latestValues
+  ) {
+    this.computeOutput = computeOutput;
+    this.storeName = storeName;
+    this.processed = processed;
+    this.latestValues = latestValues;
+    this.streamThreadName = Thread.currentThread().getName();
+  }
+
+  private static String computeNewValue(
+      final String processorIdString,
+      final boolean isDownstreamProcessor,
+      final ValueAndTimestamp<String> oldValAndTimestamp,
+      final FixedKeyRecord<String, String> inputRecord
+  ) {
+    // If this is the first time seeing this key, we need to "start" the chain
+    if (oldValAndTimestamp == null) {
+      if (isDownstreamProcessor) {
+        // If this is a downstream processor then we're actually continuing the chain,
+        // not starting it, so just connect to the upstream chain by starting with a "--"
+        return String.format("--%s%s", inputRecord.key(), processorIdString, inputRecord.value());
+      } else {
+        // If this is the "first" processor in a chain, always start by appending the key
+        return String.format("%s:%s%s", inputRecord.key(), processorIdString, inputRecord.value());
+      }
+    }
+
+    final String oldValue = oldValAndTimestamp.value();
+    return String.format("%s%s%s", oldValue, processorIdString, inputRecord.value());
+  }
+
+  @Override
+  public void init(final FixedKeyProcessorContext<String, String> context) {
+    this.context = context;
+    this.kvStore = context.getStateStore(storeName);
+    this.partition = context.taskId().partition();
+
+    log.debug("stream-thread [{}][{}] Initialized processor with store {}",
+              streamThreadName, partition, storeName);
+  }
+
+  @Override
+  public void process(final FixedKeyRecord<String, String> record) {
+    log.debug("stream-thread [{}][{}] Processing input record: <{}, {}>",
+              streamThreadName, partition, record.key(), record.value());
+
+    final ValueAndTimestamp<String> oldValAndTimestamp = kvStore.get(record.key());
+
+    final SimpleProcessorOutput output = computeOutput.apply(oldValAndTimestamp, record);
+
+    kvStore.put(record.key(), ValueAndTimestamp.make(output.storedValue, record.timestamp()));
+    context.forward(record.withValue(output.forwardedValue));
+
+    log.debug("stream-thread [{}][{}] Computed output: <{}, {}>",
+              streamThreadName, partition, record.key(), output);
+
+    processed.incrementAndGet();
+    latestValues.put(record.key(), output.forwardedValue);
+  }
+
+  @Override
+  public void close() {
+    log.debug("stream-thread [{}][{}] Closed processor with store {}",
+              streamThreadName, partition, storeName);
+  }
+
+}

--- a/kafka-client/src/test/java/dev/responsive/kafka/testutils/SimpleStatefulProcessorSupplier.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/testutils/SimpleStatefulProcessorSupplier.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2024 Responsive Computing, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package dev.responsive.kafka.testutils;
+
+import dev.responsive.kafka.api.stores.ResponsiveKeyValueParams;
+import dev.responsive.kafka.api.stores.ResponsiveStores;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiFunction;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.processor.api.FixedKeyProcessor;
+import org.apache.kafka.streams.processor.api.FixedKeyProcessorSupplier;
+import org.apache.kafka.streams.processor.api.FixedKeyRecord;
+import org.apache.kafka.streams.state.StoreBuilder;
+import org.apache.kafka.streams.state.ValueAndTimestamp;
+
+/**
+ * A simple fixed-key, String-typed, stateful processor that appends
+ * incoming records and stores this list of received records in a 
+ * timestamped kv store.
+ * <p>
+ * Allows for passing in an optional counter to keep track of the number
+ * of records processed and an optional map to track the latest value
+ * computed per key.
+ * <p>
+ * See also: {@link SimpleStatefulProcessor}
+ */
+@SuppressWarnings("checkstyle:linelength")
+public class SimpleStatefulProcessorSupplier
+    implements FixedKeyProcessorSupplier<String, String, String> {
+
+  /**
+   * A simple container class for the outputs of a {@link SimpleStatefulProcessor},
+   * specifically the value to be forwarded downstream and the value to be stored
+   * in the local processor state store. These can be different or the same value.
+   */
+  public static class SimpleProcessorOutput {
+    public final String forwardedValue;
+    public final String storedValue;
+    
+    public SimpleProcessorOutput(final String forwardedValue, final String storedValue) {
+      this.forwardedValue = forwardedValue;
+      this.storedValue = storedValue;
+    }
+
+    public SimpleProcessorOutput(final String outputValue) {
+      this(outputValue, outputValue);
+    }
+    
+  }
+  
+  private final BiFunction<ValueAndTimestamp<String>, FixedKeyRecord<String, String>, SimpleProcessorOutput> computeOutput;
+  
+  private final AtomicInteger processed;
+  private final Map<String, String> latestValues;
+  
+  private final String storeName;
+  private final Set<StoreBuilder<?>> storeBuilders;
+
+  /**
+   * @param computeOutput a simple function that computes the output from the input record and old value
+   * @param params        the params to use to build a Responsive timestamped key-value store
+   */
+  public SimpleStatefulProcessorSupplier(
+      final BiFunction<ValueAndTimestamp<String>, FixedKeyRecord<String, String>, SimpleProcessorOutput> computeOutput,
+      final ResponsiveKeyValueParams params
+  ) {
+    this(computeOutput, params, new AtomicInteger(), new HashMap<>());
+  }
+
+  /**
+   * @param computeOutput a simple function that computes the output from the input record and old value
+   * @param params        the params to use to build a Responsive timestamped key-value store
+   * @param processed     optional counter that can be used to monitor number of input records
+   */
+  public SimpleStatefulProcessorSupplier(
+      final BiFunction<ValueAndTimestamp<String>, FixedKeyRecord<String, String>, SimpleProcessorOutput> computeOutput,
+      final ResponsiveKeyValueParams params,
+      final AtomicInteger processed
+  ) {
+    this(computeOutput, params, processed, new ConcurrentHashMap<>());
+  }
+
+  /**
+   * @param computeOutput a simple function that computes the output from the input record and old value
+   * @param params        the params to use to build a Responsive timestamped key-value store
+   * @param latestValues  optional map to track latest value computed for each key
+   */
+  public SimpleStatefulProcessorSupplier(
+      final BiFunction<ValueAndTimestamp<String>, FixedKeyRecord<String, String>, SimpleProcessorOutput> computeOutput,
+      final ResponsiveKeyValueParams params,
+      final Map<String, String> latestValues
+  ) {
+    this(computeOutput, params, new AtomicInteger(), latestValues);
+  }
+
+  /**
+   * @param computeOutput a simple function that computes the output from the input record and old value
+   * @param params        the params to use to build a Responsive timestamped key-value store
+   * @param processed     optional counter that can be used to monitor number of input records
+   * @param latestValues  optional map to track latest value computed for each key
+   */
+  public SimpleStatefulProcessorSupplier(
+      final BiFunction<ValueAndTimestamp<String>, FixedKeyRecord<String, String>, SimpleProcessorOutput> computeOutput,
+      final ResponsiveKeyValueParams params,
+      final AtomicInteger processed,
+      final Map<String, String> latestValues
+  ) {
+    this.computeOutput = computeOutput;
+    this.storeName = params.name().kafkaName();
+    this.processed = processed;
+    this.latestValues = latestValues;
+    this.storeBuilders = Collections.singleton(ResponsiveStores.timestampedKeyValueStoreBuilder(
+        ResponsiveStores.keyValueStore(params),
+        Serdes.String(),
+        Serdes.String()));
+  }
+  
+  @Override
+  public FixedKeyProcessor<String, String, String> get() {
+    return new SimpleStatefulProcessor(
+        computeOutput,
+        storeName, 
+        processed, 
+        latestValues
+    );
+  }
+  
+  @Override
+  public Set<StoreBuilder<?>> stores() {
+    return storeBuilders;
+  }
+  
+}


### PR DESCRIPTION
Tried to flush out the bug with not resetting the processor context after forwarding records but unfortunately(?) this test does seem to still be passing. Will try playing around with some of the parameters to see if I can hit it, but in the meantime, here's the expanded test.

Also has some refactoring/utilities lined up for some of the other testing I've been working on