### PR TITLE
wrap thread pool in semaphore to block on full queue

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/AsyncThreadPool.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/AsyncThreadPool.java
@@ -45,7 +45,7 @@ public class AsyncThreadPool {
     final LogContext logPrefix
         = new LogContext(String.format("stream-thread [%s] ", streamThreadName));
     this.log = logPrefix.logger(AsyncThreadPool.class);
-    this.processingQueue = new LinkedBlockingQueue<>(maxQueuedEvents);
+    this.processingQueue = new LinkedBlockingQueue<>();
     this.queueSemaphore = new Semaphore(maxQueuedEvents);
 
     executor = new ThreadPoolExecutor(


### PR DESCRIPTION
By default, the thread pool executor does not block when the queue is full. Moreover, it does not have an option to block. The best it supports is running the task on the main thread. The risk with blocking is that you could deadlock if all your processing threads are blocked. For streams, that's not as much of a concern because the thread will be removed from the group if that happens, and should only happen if the user's processor blocks. On the other hand, running from the main thread is not ideal because you could get unlucky and run a very slow task on the main thread and starve the topology. So instead, we wrap the pool in a semaphore to block before enqueuing a task