### PR TITLE
make sure to throw processing exceptions before prep finalize

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/AsyncProcessor.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/AsyncProcessor.java
@@ -628,17 +628,17 @@ public class AsyncProcessor<KIn, VIn, KOut, VOut>
           taskId.toString()));
     }
 
-    final var toClose = streamThreadContext.prepareToFinalizeEvent(event);
-
+    // Make sure to check for a failed event before preparing finalization. prepareToFinalizeEvent
+    // is only able to handle successfully processed events.
     final Optional<Throwable> processingException = event.processingException();
-    if (processingException.isEmpty()) {
-      event.transitionToFinalizing();
-    } else {
+    if (!processingException.isEmpty()) {
       pendingEvents.remove(event);
       event.transitionToDone();
       throw processingException.get();
     }
 
+    final var toClose = streamThreadContext.prepareToFinalizeEvent(event);
+    event.transitionToFinalizing();
     return toClose;
   }
 


### PR DESCRIPTION
Make sure that when finalizing a record, we throw processing exceptions before preping the event for finalization. Also updates the test to check that the causing exception for injected exceptions is the injected exception.

Before this patch, all exceptions would result in an IllegalStateException due to event state machine violation.