### PR TITLE
Handle TaskMigratedException and clean up Throwables

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/FatalAsyncException.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/FatalAsyncException.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 Responsive Computing, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package dev.responsive.kafka.api.async.internals;
+
+public class FatalAsyncException extends RuntimeException {
+
+  private static final long serialVersionUID = -4075437528263657236L;
+
+  public FatalAsyncException(final Throwable fatalException) {
+    super(fatalException);
+  }
+
+  public FatalAsyncException(final String message, final Throwable fatalException) {
+    super(message, fatalException);
+  }
+
+}

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/queues/FinalizingQueue.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/queues/FinalizingQueue.java
@@ -16,6 +16,7 @@
 
 package dev.responsive.kafka.api.async.internals.queues;
 
+import dev.responsive.kafka.api.async.internals.FatalAsyncException;
 import dev.responsive.kafka.api.async.internals.events.AsyncEvent;
 import java.util.concurrent.BlockingDeque;
 import java.util.concurrent.LinkedBlockingDeque;
@@ -100,9 +101,13 @@ public class FinalizingQueue implements ReadOnlyFinalizingQueue, WriteOnlyFinali
    * Note: blocking API
    */
   @Override
-  public AsyncEvent waitForNextFinalizableEvent(long timeout, TimeUnit unit)
-      throws InterruptedException {
-    return finalizableRecords.poll(timeout, unit);
+  public AsyncEvent waitForNextFinalizableEvent(long timeout, TimeUnit unit) {
+    try {
+      return finalizableRecords.poll(timeout, unit);
+    } catch (final InterruptedException e) {
+      log.error("Fatally interrupted while waiting for finalizable event", e);
+      throw new FatalAsyncException("Interrupted while waiting for finalizable event", e);
+    }
   }
 
   /**

--- a/kafka-client/src/test/java/dev/responsive/kafka/api/async/internals/AsyncThreadPoolTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/api/async/internals/AsyncThreadPoolTest.java
@@ -13,6 +13,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.api.ProcessingContext;
 import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
@@ -104,7 +105,7 @@ class AsyncThreadPoolTest {
     assertThat(other0InFlight.get(eventOtherProcessor).future().isCancelled(), is(false));
   }
 
-  private final class TestTask implements Runnable {
+  private static final class TestTask implements Runnable {
     private final CountDownLatch waitLatch = new CountDownLatch(1);
 
     @Override
@@ -119,13 +120,13 @@ class AsyncThreadPoolTest {
 
   private void schedule(
       final String processor,
-      final int task,
+      final int partition,
       final FinalizingQueue finalizingQueue,
       final AsyncEvent... events
   ) {
     pool.scheduleForProcessing(
         processor,
-        task,
+        new TaskId(0, partition),
         Arrays.asList(events),
         finalizingQueue,
         originalContext,
@@ -138,7 +139,7 @@ class AsyncThreadPoolTest {
         "event",
         new Record<>("k", "v", 0L),
         "async-processor",
-        partition,
+        new TaskId(0, partition),
         recordContext,
         0L,
         0L,

--- a/kafka-client/src/test/java/dev/responsive/kafka/testutils/AsyncTestEvent.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/testutils/AsyncTestEvent.java
@@ -18,6 +18,7 @@ package dev.responsive.kafka.testutils;
 
 import dev.responsive.kafka.api.async.internals.events.AsyncEvent;
 import org.apache.kafka.common.header.internals.RecordHeaders;
+import org.apache.kafka.streams.processor.TaskId;
 import org.apache.kafka.streams.processor.api.Record;
 import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
 
@@ -31,44 +32,44 @@ public class AsyncTestEvent extends AsyncEvent {
       final String key,
       final String value
   ) {
-    this(key, value, 0);
+    this(key, value, new TaskId(0, 0));
   }
 
   public AsyncTestEvent(
       final String key,
       final String value,
-      final int partition
+      final TaskId taskId
   ) {
-    this(key, value, partition, "topic");
+    this(key, value, taskId, "topic");
   }
 
   public AsyncTestEvent(
       final String key,
       final String value,
-      final int partition,
+      final TaskId taskId,
       final String topic
   ) {
-    this(key, value, "async-processor", partition, topic, 0L, 0L);
+    this(key, value, "async-processor", taskId, topic, 0L, 0L);
   }
 
   public AsyncTestEvent(
       final String key,
       final String value,
       final String asyncProcessorName,
-      final int partition,
+      final TaskId taskId,
       final String topic,
       final long timestamp,
       final long offset
   ) {
     super(
-        String.format("event <%s, %s>[%d]", key, value, partition),
+        String.format("event <%s, %s>[%d]", key, value, taskId.partition()),
         new Record<>(key, value, timestamp),
         asyncProcessorName,
-        partition,
+        taskId,
         new ProcessorRecordContext(
             timestamp,
             offset,
-            partition,
+            taskId.partition(),
             topic,
             new RecordHeaders()
         ),


### PR DESCRIPTION
Split up the error handling by separating into StreamsExceptions that arise from processing an event, and fatal exceptions that cover things like errors in the framework itself and checked exceptions.

Modified the async task from a Runnable to a Supplier<StreamsException> so we have a natural way to split up errors based on whether they're "normal" processing errors we can expect and handle (in which case we catch it and return it) vs uncaught/unexpected/checked exceptions that are immediately fatal.

Also split up the error handling path itself, so we don't add processing exceptions to the finalizing queue AND track them as an "uncaught AsyncThreadPool exception", it's either-or. This helps distinguish the fatal errors that should be acted upon immediately vs the non-fatal errors that might just mean rejoining the group (TaskMigratedException) or could, in the future, have some other kind of special error handling