### PR TITLE
Dont finalize an async event if it failed to process.

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/AsyncThreadPool.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/AsyncThreadPool.java
@@ -166,8 +166,10 @@ public class AsyncThreadPool {
 
       future
           .whenComplete((r, t) -> {
-            inFlightForTask.remove(event);
-            finalizingQueue.addFinalizableEvent(event);
+            if (t == null) {
+              inFlightForTask.remove(event);
+              finalizingQueue.addFinalizableEvent(event);
+            }
           })
           .exceptionally(processingException -> {
             inFlightEvent.setError(processingException);


### PR DESCRIPTION
Dont finalize an async event if it failed to process. We should only call addFinalizableEvent for successfully processed events. Failed events should be called with addFailedEvent, and be transition to FAILED state.