### PR TITLE
deal with unexpected async exceptions from pool correctly

### DIFF
--- a/kafka-client/src/test/java/dev/responsive/kafka/api/async/internals/AsyncThreadPoolTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/api/async/internals/AsyncThreadPoolTest.java
@@ -1,17 +1,25 @@
 package dev.responsive.kafka.api.async.internals;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import com.google.common.base.Throwables;
 import dev.responsive.kafka.api.async.internals.contexts.AsyncUserProcessorContext;
 import dev.responsive.kafka.api.async.internals.events.AsyncEvent;
 import dev.responsive.kafka.api.async.internals.metrics.AsyncProcessorMetricsRecorder;
 import dev.responsive.kafka.api.async.internals.queues.FinalizingQueue;
 import dev.responsive.kafka.internal.metrics.ResponsiveMetrics;
+import java.time.Duration;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -80,6 +88,32 @@ class AsyncThreadPoolTest {
       future.get(10, TimeUnit.SECONDS);
     }
     assertThat(finalizingQueue0.waitForNextFinalizableEvent(1, TimeUnit.MINUTES), is(event));
+  }
+
+  @Test
+  public void shouldSetFatalExceptionWhenUnexpectedExceptionThrown() throws InterruptedException {
+    // given:
+    final var exception = new RuntimeException("oops");
+    doThrow(exception).when(userContext).setDelegateForAsyncThread(any());
+    final var task1 = new TestTask();
+    final var event = newEvent(task1, 0);
+
+    // when:
+    schedule("processor", 0, finalizingQueue0, event);
+
+    // then:
+    final Instant start = Instant.now();
+    Optional<Throwable> caught;
+    do {
+      caught = pool.checkUncaughtExceptions("processor", 0);
+      if (caught.isPresent()) {
+        break;
+      }
+      Thread.sleep(100);
+    } while (Duration.between(start, Instant.now()).compareTo(Duration.ofMinutes(1)) < 0);
+    assertThat(caught.isPresent(), is(true));
+    assertThat(caught.get(), instanceOf(FatalAsyncException.class));
+    assertThat(Throwables.getRootCause(caught.get()), is(exception));
   }
 
   @Test

--- a/kafka-client/src/test/java/dev/responsive/kafka/api/async/internals/AsyncThreadPoolTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/api/async/internals/AsyncThreadPoolTest.java
@@ -6,7 +6,6 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import com.google.common.base.Throwables;
 import dev.responsive.kafka.api.async.internals.contexts.AsyncUserProcessorContext;


### PR DESCRIPTION
This patch fixes how we deal with unexpected/fatal exception. Previously we were passing them through a completion stage generated by calling `handle` on the event's future. `handle` will not preserve the result and exception type of the original future. Instead, it's result/exception is the return value or exception thrown by the function passed to `handle`. Therefore unexpected exceptions passed to `handle` were being dropped. Instead, we use `whenComplete` which does preserve the exception.