### PR TITLE
bump AK to 3.7 and default DSL stores to Responsive

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveKafkaStreams.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveKafkaStreams.java
@@ -34,6 +34,7 @@ import static org.apache.kafka.streams.StreamsConfig.NUM_STREAM_THREADS_CONFIG;
 import dev.responsive.kafka.api.async.internals.AsyncThreadPoolRegistry;
 import dev.responsive.kafka.api.config.CompatibilityMode;
 import dev.responsive.kafka.api.config.ResponsiveConfig;
+import dev.responsive.kafka.api.stores.ResponsiveDslStoreSuppliers;
 import dev.responsive.kafka.internal.clients.ResponsiveKafkaClientSupplier;
 import dev.responsive.kafka.internal.config.ConfigUtils;
 import dev.responsive.kafka.internal.config.InternalSessionConfigs;
@@ -271,7 +272,6 @@ public class ResponsiveKafkaStreams extends KafkaStreams {
   ) {
     final Properties propsWithOverrides = new Properties();
 
-
     final InternalSessionConfigs.Builder internalConfBuilder = new InternalSessionConfigs.Builder()
         .withSessionClients(sessionClients)
         .withStoreRegistry(storeRegistry)
@@ -312,6 +312,11 @@ public class ResponsiveKafkaStreams extends KafkaStreams {
       LOG.error(errorMsg);
       throw new ConfigException(errorMsg);
     }
+
+    propsWithOverrides.putIfAbsent(
+        StreamsConfig.DSL_STORE_SUPPLIERS_CLASS_CONFIG,
+        ResponsiveDslStoreSuppliers.class.getCanonicalName()
+    );
 
     return propsWithOverrides;
   }

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveKafkaStreams.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveKafkaStreams.java
@@ -315,7 +315,7 @@ public class ResponsiveKafkaStreams extends KafkaStreams {
 
     propsWithOverrides.putIfAbsent(
         StreamsConfig.DSL_STORE_SUPPLIERS_CLASS_CONFIG,
-        ResponsiveDslStoreSuppliers.class.getCanonicalName()
+        ResponsiveDslStoreSuppliers.class.getName()
     );
 
     return propsWithOverrides;

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/stores/ResponsiveDslStoreSuppliers.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/stores/ResponsiveDslStoreSuppliers.java
@@ -49,7 +49,7 @@ public class ResponsiveDslStoreSuppliers implements DslStoreSuppliers {
     return ResponsiveStores.sessionStoreSupplier(
         ResponsiveSessionParams.session(
             dslSessionParams.name(),
-            dslSessionParams.retentionPeriod().toMillis()
+            dslSessionParams.retentionPeriod()
         )
     );
   }

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/stores/ResponsiveDslStoreSuppliers.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/stores/ResponsiveDslStoreSuppliers.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.kafka.api.stores;
+
+import org.apache.kafka.streams.state.DslKeyValueParams;
+import org.apache.kafka.streams.state.DslSessionParams;
+import org.apache.kafka.streams.state.DslStoreSuppliers;
+import org.apache.kafka.streams.state.DslWindowParams;
+import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
+import org.apache.kafka.streams.state.SessionBytesStoreSupplier;
+import org.apache.kafka.streams.state.WindowBytesStoreSupplier;
+
+public class ResponsiveDslStoreSuppliers implements DslStoreSuppliers {
+
+  @Override
+  public KeyValueBytesStoreSupplier keyValueStore(final DslKeyValueParams dslKeyValueParams) {
+    return ResponsiveStores.keyValueStore(
+        ResponsiveKeyValueParams.keyValue(dslKeyValueParams.name())
+    );
+  }
+
+  @Override
+  public WindowBytesStoreSupplier windowStore(final DslWindowParams dslWindowParams) {
+    return ResponsiveStores.windowStoreSupplier(
+        ResponsiveWindowParams.window(
+            dslWindowParams.name(),
+            dslWindowParams.windowSize(),
+            dslWindowParams.retentionPeriod().minus(dslWindowParams.windowSize())
+        )
+    );
+  }
+
+  @Override
+  public SessionBytesStoreSupplier sessionStore(final DslSessionParams dslSessionParams) {
+    return ResponsiveStores.sessionStoreSupplier(
+        ResponsiveSessionParams.session(
+            dslSessionParams.name(),
+            dslSessionParams.retentionPeriod().toMillis()
+        )
+    );
+  }
+}

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/stores/ResponsiveSessionParams.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/stores/ResponsiveSessionParams.java
@@ -44,9 +44,9 @@ public final class ResponsiveSessionParams {
 
   public static ResponsiveSessionParams session(
       final String name,
-      final long retentionPeriodMs
+      final Duration retention
   ) {
-    return new ResponsiveSessionParams(name, SessionSchema.SESSION, retentionPeriodMs);
+    return new ResponsiveSessionParams(name, SessionSchema.SESSION, retention.toMillis());
   }
 
   public static ResponsiveSessionParams session(

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/stores/ResponsiveStores.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/stores/ResponsiveStores.java
@@ -317,6 +317,19 @@ public final class ResponsiveStores {
   }
 
   /**
+   * See for example {@link Stores#inMemorySessionStore(String, Duration)}
+   *
+   * @param params the {@link ResponsiveSessionParams} for this store
+   * @return a supplier for a session store with the given options
+   *         that uses Responsive's storage for its backend
+   */
+  public static SessionBytesStoreSupplier sessionStoreSupplier(
+      final ResponsiveSessionParams params
+  ) {
+    return new ResponsiveSessionStoreSupplier(params);
+  }
+
+  /**
    * Create a {@link StoreBuilder} that can be used to build a Responsive
    * {@link SessionStore} and connect it via the Processor API. If using the DSL, use
    * {@link #sessionMaterialized} instead.

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/DelegatingConsumer.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/DelegatingConsumer.java
@@ -34,6 +34,7 @@ import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
 
 public abstract class DelegatingConsumer<K, V> implements Consumer<K, V> {
 
@@ -291,5 +292,10 @@ public abstract class DelegatingConsumer<K, V> implements Consumer<K, V> {
   @Override
   public void wakeup() {
     delegate.wakeup();
+  }
+
+  @Override
+  public Uuid clientInstanceId(final Duration duration) {
+    return delegate.clientInstanceId(duration);
   }
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/ResponsiveConsumer.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/ResponsiveConsumer.java
@@ -28,6 +28,7 @@ import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.OffsetCommitCallback;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.utils.LogContext;
 import org.slf4j.Logger;
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/ResponsiveConsumer.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/ResponsiveConsumer.java
@@ -28,7 +28,6 @@ import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.OffsetCommitCallback;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.utils.LogContext;
 import org.slf4j.Logger;
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/ResponsiveProducer.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/ResponsiveProducer.java
@@ -34,6 +34,7 @@ import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.errors.ProducerFencedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -144,6 +145,11 @@ public class ResponsiveProducer<K, V> implements Producer<K, V> {
   @Override
   public Map<MetricName, ? extends Metric> metrics() {
     return wrapped.metrics();
+  }
+
+  @Override
+  public Uuid clientInstanceId(final Duration duration) {
+    return wrapped.clientInstanceId(duration);
   }
 
   @Override

--- a/kafka-client/src/test/java/dev/responsive/kafka/integration/MinimalIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/integration/MinimalIntegrationTest.java
@@ -37,8 +37,6 @@ import static org.hamcrest.Matchers.hasItems;
 
 import dev.responsive.kafka.api.ResponsiveKafkaStreams;
 import dev.responsive.kafka.api.config.StorageBackend;
-import dev.responsive.kafka.api.stores.ResponsiveKeyValueParams;
-import dev.responsive.kafka.api.stores.ResponsiveStores;
 import dev.responsive.kafka.testutils.ResponsiveConfigParam;
 import dev.responsive.kafka.testutils.ResponsiveExtension;
 import java.time.Duration;

--- a/kafka-client/src/test/java/dev/responsive/kafka/integration/MinimalIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/integration/MinimalIntegrationTest.java
@@ -56,6 +56,7 @@ import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.Named;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
@@ -138,7 +139,7 @@ public class MinimalIntegrationTest {
     final KStream<Long, Long> input = builder.stream(inputTopic());
     input
         .groupByKey()
-        .count(ResponsiveStores.materialized(ResponsiveKeyValueParams.keyValue("countStore")))
+        .count(Named.as("count"))
         .toStream()
         .to(outputTopic());
 

--- a/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveKafkaStreamsIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveKafkaStreamsIntegrationTest.java
@@ -80,7 +80,7 @@ public class ResponsiveKafkaStreamsIntegrationTest {
   ) throws InterruptedException, ExecutionException {
     // add displayName to name to account for parameterized tests
     name = info.getTestMethod().orElseThrow().getName() + "-" + new Random().nextInt();
-    this.mongo= mongo;
+    this.mongo = mongo;
 
     this.responsiveProps.putAll(responsiveProps);
 

--- a/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveKafkaStreamsIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveKafkaStreamsIntegrationTest.java
@@ -20,17 +20,19 @@ import static dev.responsive.kafka.testutils.IntegrationTestUtils.pipeTimestampe
 import static dev.responsive.kafka.testutils.IntegrationTestUtils.startAppAndAwaitRunning;
 import static org.apache.kafka.streams.StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.is;
 
 import dev.responsive.kafka.api.ResponsiveKafkaStreams;
 import dev.responsive.kafka.api.config.StorageBackend;
-import dev.responsive.kafka.api.stores.ResponsiveKeyValueParams;
-import dev.responsive.kafka.api.stores.ResponsiveStores;
+import dev.responsive.kafka.internal.utils.SessionUtil;
 import dev.responsive.kafka.testutils.IntegrationTestUtils;
 import dev.responsive.kafka.testutils.KeyValueTimestamp;
 import dev.responsive.kafka.testutils.ResponsiveConfigParam;
 import dev.responsive.kafka.testutils.ResponsiveExtension;
-import dev.responsive.kafka.testutils.StoreComparatorSuppliers;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -43,21 +45,21 @@ import java.util.concurrent.TimeUnit;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.clients.producer.KafkaProducer;
-import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.kstream.KStream;
-import org.apache.kafka.streams.kstream.Materialized;
-import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
-import org.apache.kafka.streams.state.KeyValueStore;
-import org.apache.kafka.streams.state.internals.RocksDBKeyValueBytesStoreSupplier;
+import org.apache.kafka.streams.kstream.Named;
+import org.bson.types.Binary;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.testcontainers.containers.MongoDBContainer;
 
-public class ResponsiveKeyValueStoreIntegrationTest {
+public class ResponsiveKafkaStreamsIntegrationTest {
 
+  public static final String COUNT_TABLE_NAME = "count";
   @RegisterExtension
   static ResponsiveExtension EXTENSION = new ResponsiveExtension(StorageBackend.MONGO_DB);
 
@@ -67,15 +69,18 @@ public class ResponsiveKeyValueStoreIntegrationTest {
   private final Map<String, Object> responsiveProps = new HashMap<>();
 
   private String name;
+  private MongoDBContainer mongo;
 
   @BeforeEach
   public void before(
       final TestInfo info,
       final Admin admin,
+      final MongoDBContainer mongo,
       @ResponsiveConfigParam final Map<String, Object> responsiveProps
   ) throws InterruptedException, ExecutionException {
     // add displayName to name to account for parameterized tests
     name = info.getTestMethod().orElseThrow().getName() + "-" + new Random().nextInt();
+    this.mongo= mongo;
 
     this.responsiveProps.putAll(responsiveProps);
 
@@ -96,42 +101,14 @@ public class ResponsiveKeyValueStoreIntegrationTest {
     return name + "." + OUTPUT_TOPIC;
   }
 
-  /*
-   * This test makes sure that the default RocksDB state store and the responsive state
-   * store consistently show identical internal behavior.
-   * We do not check the output topic but rather use the StoreComparator to ensure that
-   * they return identical results from each method invoked on them.
-   */
   @Test
-  public void shouldMatchRocksDB() throws Exception {
-    final KeyValueBytesStoreSupplier rocksDbStore =
-        new RocksDBKeyValueBytesStoreSupplier(name, false);
-
-    final KeyValueBytesStoreSupplier responsiveStore =
-        ResponsiveStores.keyValueStore(ResponsiveKeyValueParams.keyValue(name));
-
-    final StoreComparatorSuppliers.CompareFunction compare =
-        (String method, Object[] args, Object actual, Object truth) -> {
-          final String reason = method + " should yield identical results.";
-          assertThat(reason, actual, Matchers.equalTo(truth));
-        };
-
-    final Materialized<String, String, KeyValueStore<Bytes, byte[]>> combinedStore =
-        Materialized.as(new StoreComparatorSuppliers.MultiKeyValueStoreSupplier(
-            rocksDbStore, responsiveStore, compare
-        ));
-
-    // Start from timestamp of 0L to get predictable results
+  public void shouldDefaultToResponsiveStoresWhenUsingDsl() throws Exception {
+    // Given:
     final List<KeyValueTimestamp<String, String>> inputEvents = Arrays.asList(
         new KeyValueTimestamp<>("key", "a", 0L),
-        new KeyValueTimestamp<>("key", "c", 1_000L),
         new KeyValueTimestamp<>("key", "b", 2_000L),
-        new KeyValueTimestamp<>("key", "d", 3_000L),
-        new KeyValueTimestamp<>("key", "b", 3_000L),
-        new KeyValueTimestamp<>("key", null, 4_000L),
-        new KeyValueTimestamp<>("key2", "e", 4_000L),
-        new KeyValueTimestamp<>("key2", "b", 5_000L),
-        new KeyValueTimestamp<>("STOP", "b", 18_000L)
+        new KeyValueTimestamp<>("key", "c", 3_000L),
+        new KeyValueTimestamp<>("STOP", "ignored", 18_000L)
     );
     final CountDownLatch outputLatch = new CountDownLatch(1);
 
@@ -139,7 +116,7 @@ public class ResponsiveKeyValueStoreIntegrationTest {
     final KStream<String, String> input = builder.stream(inputTopic());
     input
         .groupByKey()
-        .aggregate(() -> "", (k, v1, agg) -> agg + v1, combinedStore)
+        .count(Named.as(COUNT_TABLE_NAME))
         .toStream()
         .peek((k, v) -> {
           if (k.equals("STOP")) {
@@ -166,6 +143,28 @@ public class ResponsiveKeyValueStoreIntegrationTest {
           outputLatch.await(maxWait, TimeUnit.MILLISECONDS),
           Matchers.equalTo(true)
       );
+    }
+
+    // Then:
+    try (
+        final var mongoClient = SessionUtil.connect(mongo.getConnectionString(), null, null);
+        final var deserializer = new StringDeserializer();
+    ) {
+      final List<String> dbs = new ArrayList<>();
+      mongoClient.listDatabaseNames().into(dbs);
+      assertThat(dbs, hasItem("kstream_aggregate_state_store_0000000001"));
+
+      final var db = mongoClient.getDatabase("kstream_aggregate_state_store_0000000001");
+      final var collection = db.getCollection("kv_data");
+      final long numDocs = collection.countDocuments();
+      assertThat(numDocs, is(2L));
+
+      final List<String> keys = new ArrayList<>();
+      collection.find()
+          .map(doc -> doc.get("_id", Binary.class).getData())
+          .map(doc -> deserializer.deserialize("", doc))
+          .into(keys);
+      assertThat(keys, hasItems("key", "STOP"));
     }
   }
 

--- a/kafka-client/src/test/java/dev/responsive/kafka/testutils/IntegrationTestUtils.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/testutils/IntegrationTestUtils.java
@@ -46,8 +46,6 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.serialization.LongDeserializer;
-import org.apache.kafka.common.serialization.LongSerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;

--- a/kafka-client/src/test/java/dev/responsive/kafka/testutils/IntegrationTestUtils.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/testutils/IntegrationTestUtils.java
@@ -1,6 +1,18 @@
 package dev.responsive.kafka.testutils;
 
+import static org.apache.kafka.clients.CommonClientConfigs.SESSION_TIMEOUT_MS_CONFIG;
 import static org.apache.kafka.clients.consumer.ConsumerConfig.ISOLATION_LEVEL_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.MAX_POLL_RECORDS_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.APPLICATION_ID_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.COMMIT_INTERVAL_MS_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.NUM_STREAM_THREADS_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.consumerPrefix;
 
 import dev.responsive.kafka.api.ResponsiveKafkaStreams;
 import dev.responsive.kafka.api.config.ResponsiveConfig;
@@ -34,6 +46,11 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.LongDeserializer;
+import org.apache.kafka.common.serialization.LongSerializer;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.streams.KafkaClientSupplier;
 import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.KafkaStreams.State;
@@ -366,6 +383,29 @@ public final class IntegrationTestUtils {
     } finally {
       lock.unlock();
     }
+  }
+
+  public static Map<String, Object> getDefaultMutablePropertiesWithStringSerdes(
+      final Map<String, Object> responsiveProps,
+      final String name
+  ) {
+    final Map<String, Object> properties = new HashMap<>(responsiveProps);
+    properties.put(APPLICATION_ID_CONFIG, name);
+    properties.put(NUM_STREAM_THREADS_CONFIG, 1);
+    properties.put(COMMIT_INTERVAL_MS_CONFIG, 1); // commit as often as possible
+
+    properties.put(consumerPrefix(SESSION_TIMEOUT_MS_CONFIG), 5_000 - 1);
+    properties.put(consumerPrefix(MAX_POLL_RECORDS_CONFIG), 1);
+    properties.put(ResponsiveConfig.STORE_FLUSH_RECORDS_TRIGGER_CONFIG, 1);
+
+    properties.put(KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    properties.put(VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    properties.put(KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+    properties.put(VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+    properties.put(DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.StringSerde.class.getName());
+    properties.put(DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.StringSerde.class.getName());
+
+    return properties;
   }
 
   private IntegrationTestUtils() {

--- a/kafka-client/src/test/java/dev/responsive/kafka/testutils/ResponsiveExtension.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/testutils/ResponsiveExtension.java
@@ -89,6 +89,7 @@ public class ResponsiveExtension implements BeforeAllCallback, AfterAllCallback,
   @Override
   public void afterAll(final ExtensionContext context) throws Exception {
     cassandra.stop();
+    mongo.stop();
     kafka.stop();
     admin.close();
   }
@@ -100,6 +101,7 @@ public class ResponsiveExtension implements BeforeAllCallback, AfterAllCallback,
   ) throws ParameterResolutionException {
     return parameterContext.getParameter().getType().equals(CassandraContainer.class)
         || parameterContext.getParameter().getType().equals(KafkaContainer.class)
+        || parameterContext.getParameter().getType().equals(MongoDBContainer.class)
         || parameterContext.getParameter().getType().equals(Admin.class)
         || isContainerConfig(parameterContext);
   }
@@ -111,6 +113,8 @@ public class ResponsiveExtension implements BeforeAllCallback, AfterAllCallback,
   ) throws ParameterResolutionException {
     if (parameterContext.getParameter().getType() == CassandraContainer.class) {
       return cassandra;
+    } else if (parameterContext.getParameter().getType() == MongoDBContainer.class) {
+      return mongo;
     } else if (parameterContext.getParameter().getType() == KafkaContainer.class) {
       return kafka;
     } else if (parameterContext.getParameter().getType() == Admin.class) {

--- a/kafka-client/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadIntegrationTest.java
+++ b/kafka-client/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadIntegrationTest.java
@@ -270,12 +270,13 @@ public class GlobalStreamThreadIntegrationTest {
     final Time time = new SystemTime();
     final InternalTopologyBuilder builder = new InternalTopologyBuilder();
     builder.addGlobalStore(
-        new KeyValueStoreBuilder<>(
-            storeSupplier,
-            new ByteArraySerde(),
-            new ByteArraySerde(),
-            time
-        ).withLoggingDisabled(),
+        new StoreBuilderWrapper(
+          new KeyValueStoreBuilder<>(
+              storeSupplier,
+              new ByteArraySerde(),
+              new ByteArraySerde(),
+              time).withLoggingDisabled()
+        ),
         "global",
         null,
         null,

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -45,7 +45,7 @@ dependencyResolutionManagement {
     versionCatalogs {
         create("libs") {
             version("jackson", "2.14.2")
-            version("kafka", "3.6.0")
+            version("kafka", "3.7.0")
             version("scylla", "4.15.0.0")
             version("javaoperatorsdk", "4.3.0")
             version("grpc", "1.52.1")


### PR DESCRIPTION
This PR allows users to literally migrate with a single line code change by automatically configuring `ResponsiveKafkaStreams` to use the new `ResponsiveDslStoreSuppliers` class. The main change in this PR is in `kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveKafkaStreams.java`. In order to use this we have to depend on apache kafka 3.7.

This PR also wires in Session stores, which previously did not have an equivalent store supplier in `Stores` static class. 

For testing, you can see that the new test doesn't specify any `Materialized` or `Stores` but it automatically populated data in MongoDB. The one drawback of this approach is that it risks collisions with names of stores in the same MongoDB instance. We need to figure out how to prevent that (perhaps by prepending the applicationID to the db name).