### PR TITLE
clear recorded offsets on unsubscribe and handlePartitionsLost

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/ResponsiveConsumer.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/ResponsiveConsumer.java
@@ -115,6 +115,7 @@ public class ResponsiveConsumer<K, V> extends DelegatingConsumer<K, V> {
 
   @Override
   public void unsubscribe() {
+    listeners.forEach(Listener::onUnsubscribe);
     super.unsubscribe();
   }
 
@@ -194,6 +195,9 @@ public class ResponsiveConsumer<K, V> extends DelegatingConsumer<K, V> {
     }
 
     default void onCommit(final Map<TopicPartition, OffsetAndMetadata> offsets) {
+    }
+
+    default void onUnsubscribe() {
     }
 
     default void onClose() {

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/clients/ResponsiveConsumerTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/clients/ResponsiveConsumerTest.java
@@ -21,7 +21,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 
-import dev.responsive.kafka.internal.clients.ResponsiveConsumer;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.List;


### PR DESCRIPTION
This patch clears all recorded offsets in OffsetRecorder when Consumer.unsubscribe or RebalanceListener.handlePartitionsLost are called. In both cases, we know streams is reinitializing so we should clear any offsets we have recorded. If we don't clear them, then when streams finishes reinitializing and goes to do its first commit, it will try to find stores for those partitions and commit those offsets