### PR TITLE
make sure to deregister listener when store init fails

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/stores/AsyncFlushingKeyValueStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/stores/AsyncFlushingKeyValueStore.java
@@ -78,7 +78,15 @@ public class AsyncFlushingKeyValueStore
         flushListener -> flushAsyncProcessor = flushListener
     );
 
-    super.init(context, root);
+    try {
+      super.init(context, root);
+    } catch (final RuntimeException e) {
+      log.error("failed to initialize the wrapped store. Deregistering the store connector as " +
+          "its likely that this store was not registered with streams and close will not be" +
+          " called");
+      flushListeners.unregisterListenerForPartition(partition);
+      throw e;
+    }
   }
 
   @Override

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/stores/AsyncFlushingKeyValueStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/stores/AsyncFlushingKeyValueStore.java
@@ -81,9 +81,9 @@ public class AsyncFlushingKeyValueStore
     try {
       super.init(context, root);
     } catch (final RuntimeException e) {
-      log.error("failed to initialize the wrapped store. Deregistering the store connector as " +
-          "its likely that this store was not registered with streams and close will not be" +
-          " called");
+      log.error("failed to initialize the wrapped store. Deregistering the store connector as "
+          + "its likely that this store was not registered with streams and close will not be"
+          + " called");
       flushListeners.unregisterListenerForPartition(partition);
       throw e;
     }

--- a/kafka-client/src/test/java/dev/responsive/kafka/api/async/internals/stores/AsyncFlushingKeyValueStoreTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/api/async/internals/stores/AsyncFlushingKeyValueStoreTest.java
@@ -18,7 +18,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class AsyncFlushingKeyValueStoreTest {
-  private final TaskId TASK_ID = new TaskId(0, 3);
+  private static final TaskId TASK_ID = new TaskId(0, 3);
 
   @Mock
   private KeyValueStore<Bytes, byte[]> wrapped;

--- a/kafka-client/src/test/java/dev/responsive/kafka/api/async/internals/stores/AsyncFlushingKeyValueStoreTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/api/async/internals/stores/AsyncFlushingKeyValueStoreTest.java
@@ -1,0 +1,57 @@
+package dev.responsive.kafka.api.async.internals.stores;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.processor.StateStoreContext;
+import org.apache.kafka.streams.processor.TaskId;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AsyncFlushingKeyValueStoreTest {
+  private final TaskId TASK_ID = new TaskId(0, 3);
+
+  @Mock
+  private KeyValueStore<Bytes, byte[]> wrapped;
+  @Mock
+  private StreamThreadFlushListeners flushListeners;
+  @Mock
+  private StateStoreContext storeContext;
+  @Mock
+  private StateStore rootStore;
+
+  private AsyncFlushingKeyValueStore asyncFlushingKeyValueStore;
+
+  @BeforeEach
+  public void setUp() {
+    when(storeContext.taskId()).thenReturn(TASK_ID);
+    asyncFlushingKeyValueStore = new AsyncFlushingKeyValueStore(wrapped, flushListeners);
+  }
+
+  @Test
+  public void shouldDeregisterFlushListenerIfWrappedInitThrows() {
+    // given:
+    doThrow(new RuntimeException("oops")).when(wrapped).init(
+        any(StateStoreContext.class),
+        any(StateStore.class)
+    );
+
+    // when:
+    try {
+      asyncFlushingKeyValueStore.init(storeContext, rootStore);
+    } catch (RuntimeException e) {
+      // ignore
+    }
+
+    verify(flushListeners).unregisterListenerForPartition(TASK_ID.partition());
+  }
+}


### PR DESCRIPTION
This patch makes store init more "transactional" by deregistering the flush listener if the wrapped store's init method throws. This way it either succeeds and the listener is registered and the store initialized. Or it fails and there is no listener registered.

If we dont do this, the task for which we threw can never be assigned to this stream thread again as it will always raise an IllegalStateException.