### PR TITLE
WIP: add wrapper around AsyncProcessor to enable async processing engine only with async threads configured

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/api/async/AsyncFixedKeyProcessorSupplier.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/async/AsyncFixedKeyProcessorSupplier.java
@@ -16,10 +16,9 @@
 
 package dev.responsive.kafka.api.async;
 
-import static dev.responsive.kafka.api.async.internals.AsyncProcessor.createAsyncFixedKeyProcessor;
 import static dev.responsive.kafka.api.async.internals.AsyncUtils.initializeAsyncBuilders;
 
-import dev.responsive.kafka.api.async.internals.AsyncProcessor;
+import dev.responsive.kafka.api.async.internals.MaybeAsyncProcessor;
 import dev.responsive.kafka.api.async.internals.stores.AbstractAsyncStoreBuilder;
 import java.util.HashSet;
 import java.util.Map;
@@ -75,8 +74,8 @@ public class AsyncFixedKeyProcessorSupplier<KIn, VIn, VOut>
   }
 
   @Override
-  public AsyncProcessor<KIn, VIn, KIn, VOut> get() {
-    return createAsyncFixedKeyProcessor(userProcessorSupplier.get(), asyncStoreBuilders);
+  public MaybeAsyncProcessor<KIn, VIn, KIn, VOut> get() {
+    return MaybeAsyncProcessor.createFixedKeyProcessor(userProcessorSupplier.get(), asyncStoreBuilders);
   }
 
   @Override

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/async/AsyncProcessorSupplier.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/async/AsyncProcessorSupplier.java
@@ -16,10 +16,10 @@
 
 package dev.responsive.kafka.api.async;
 
-import static dev.responsive.kafka.api.async.internals.AsyncProcessor.createAsyncProcessor;
 import static dev.responsive.kafka.api.async.internals.AsyncUtils.initializeAsyncBuilders;
 
 import dev.responsive.kafka.api.async.internals.AsyncProcessor;
+import dev.responsive.kafka.api.async.internals.MaybeAsyncProcessor;
 import dev.responsive.kafka.api.async.internals.stores.AbstractAsyncStoreBuilder;
 import java.util.HashSet;
 import java.util.Map;
@@ -155,8 +155,8 @@ public final class AsyncProcessorSupplier<KIn, VIn, KOut, VOut>
   }
 
   @Override
-  public AsyncProcessor<KIn, VIn, KOut, VOut> get() {
-    return createAsyncProcessor(userProcessorSupplier.get(), asyncStoreBuilders);
+  public MaybeAsyncProcessor<KIn, VIn, KOut, VOut> get() {
+    return MaybeAsyncProcessor.createProcessor(userProcessorSupplier.get(), asyncStoreBuilders);
   }
 
   @Override

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/AsyncProcessor.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/AsyncProcessor.java
@@ -69,12 +69,7 @@ import org.slf4j.Logger;
  * -Coordinates the handoff of records between the StreamThread and AyncThreads
  * -The starting and ending point of all async events -- see {@link AsyncEvent}
  */
-public class AsyncProcessor<KIn, VIn, KOut, VOut>
-    implements Processor<KIn, VIn, KOut, VOut>, FixedKeyProcessor<KIn, VIn, VOut> {
-
-  // Exactly one of these is non-null and the other is null
-  private final Processor<KIn, VIn, KOut, VOut> userProcessor;
-  private final FixedKeyProcessor<KIn, VIn, VOut> userFixedKeyProcessor;
+public class AsyncProcessor<KIn, VIn, KOut, VOut> {
 
   private final Map<String, AbstractAsyncStoreBuilder<?, ?, ?>> connectedStoreBuilders;
 
@@ -84,12 +79,36 @@ public class AsyncProcessor<KIn, VIn, KOut, VOut>
   // the stream thread should access this.
   private final Map<AsyncEvent, Object> pendingEvents = new ConcurrentHashMap<>();
 
+  private final String logPrefix;
+  private final Logger log;
+
+  private final String streamThreadName;
+  private final String asyncProcessorName;
+  private final TaskId taskId;
+
+  private final AsyncThreadPool threadPool;
+  private final SchedulingQueue<KIn> schedulingQueue;
+  private final FinalizingQueue finalizingQueue;
+
+  private final Cancellable punctuator;
+
+  // the context passed to us in init, ie the one created for this task and owned by Kafka Streams
+  private final ProcessingContext taskContext;
+
+  // the async context owned by the StreamThread that is running this processor/task
+  private final StreamThreadProcessorContext<KOut, VOut> streamThreadContext;
+
+  // the context we pass in to the user so it routes to the actual context based on calling thread
+  private final AsyncUserProcessorContext<KOut, VOut> userContext;
+
+  private boolean hasProcessedSomething = false;
 
   // This is set at most once. When its set, the thread should immediately throw, and no longer
   // try to process further events for this processor. This minimizes the chance of producing
   // bad results, particularly with ALOS.
   private FatalAsyncException fatalException = null;
 
+<<<<<<< Updated upstream
   // Everything below this line is effectively final and just has to be initialized in #init //
 
   private String logPrefix;
@@ -120,70 +139,15 @@ public class AsyncProcessor<KIn, VIn, KOut, VOut>
   public static <KIn, VIn, KOut, VOut> AsyncProcessor<KIn, VIn, KOut, VOut> createAsyncProcessor(
       final Processor<KIn, VIn, KOut, VOut> userProcessor,
       final Map<String, AbstractAsyncStoreBuilder<?, ?, ?>> connectedStoreBuilders
+=======
+  public AsyncProcessor(
+      final Map<String, AbstractAsyncStoreBuilder<?, ?, ?>> connectedStoreBuilders,
+      final InternalProcessorContext<KOut, VOut> internalContext,
+      final Runnable userInit
+>>>>>>> Stashed changes
   ) {
-    return new AsyncProcessor<>(userProcessor, null, connectedStoreBuilders);
-  }
-
-  public static <KIn, VIn, VOut> AsyncProcessor<KIn, VIn, KIn, VOut> createAsyncFixedKeyProcessor(
-      final FixedKeyProcessor<KIn, VIn, VOut> userProcessor,
-      final Map<String, AbstractAsyncStoreBuilder<?, ?, ?>> connectedStoreBuilders
-  ) {
-    return new AsyncProcessor<>(null, userProcessor, connectedStoreBuilders);
-  }
-
-  // Note: the constructor will be called from the main application thread (ie the
-  // one that creates/starts the KafkaStreams object) so we have to delay the creation
-  // of most objects until #init since (a) that will be invoked by the actual
-  // StreamThread processing this, and (b) we need the context supplied to init for
-  // some of the setup
-  private AsyncProcessor(
-      final Processor<KIn, VIn, KOut, VOut> userProcessor,
-      final FixedKeyProcessor<KIn, VIn, VOut> userFixedKeyProcessor,
-      final Map<String, AbstractAsyncStoreBuilder<?, ?, ?>> connectedStoreBuilders
-  ) {
-    this.userProcessor = userProcessor;
-    this.userFixedKeyProcessor = userFixedKeyProcessor;
     this.connectedStoreBuilders = connectedStoreBuilders;
 
-    if (userProcessor == null && userFixedKeyProcessor == null) {
-      throw new IllegalStateException("Both the Processor and FixedKeyProcessor were null");
-    } else if (userProcessor != null && userFixedKeyProcessor != null) {
-      throw new IllegalStateException("Both the Processor and FixedKeyProcessor were non-null");
-    }
-  }
-
-  @Override
-  public void init(final ProcessorContext<KOut, VOut> context) {
-
-    initFields((InternalProcessorContext<KOut, VOut>) context);
-
-    userProcessor.init(userContext);
-
-    completeInitialization();
-  }
-
-  // Note: we have to cast and suppress warnings in this version of #init but
-  // not the other due to the KOut parameter being squashed into KIn in the
-  // fixed-key version of the processor. However, we know this cast is safe,
-  // since by definition KIn and KOut are the same type
-  @SuppressWarnings("unchecked")
-  @Override
-  public void init(final FixedKeyProcessorContext<KIn, VOut> context) {
-
-    initFields((InternalProcessorContext<KOut, VOut>) context);
-
-    userFixedKeyProcessor.init((FixedKeyProcessorContext<KIn, VOut>) userContext);
-
-    completeInitialization();
-  }
-
-  /**
-   * Performs the first half of initialization by setting all the class fields
-   * that have to wait for the context to be passed in to #init to be initialized.
-   */
-  private void initFields(
-      final InternalProcessorContext<KOut, VOut> internalContext
-  ) {
     this.taskContext = internalContext;
 
     this.streamThreadName = Thread.currentThread().getName();
@@ -235,6 +199,11 @@ public class AsyncProcessor<KIn, VIn, KOut, VOut>
         PunctuationType.WALL_CLOCK_TIME,
         this::punctuate
     );
+
+    // calls #init on the user's processor
+    userInit.run();
+
+    completeInitialization();
   }
 
   /**
@@ -278,8 +247,7 @@ public class AsyncProcessor<KIn, VIn, KOut, VOut>
     }
   }
 
-  @Override
-  public void process(final Record<KIn, VIn> record) {
+  public void process(final Record<KIn, VIn> record, final Runnable userProcess) {
     assertQueuesEmptyOnFirstProcess();
 
     final AsyncEvent newEvent = new AsyncEvent(
@@ -290,15 +258,18 @@ public class AsyncProcessor<KIn, VIn, KOut, VOut>
         extractRecordContext(taskContext),
         taskContext.currentStreamTimeMs(),
         taskContext.currentSystemTimeMs(),
+<<<<<<< Updated upstream
         () -> userProcessor.process(record),
         List.of(metricsRecorder::recordStateTransition)
+=======
+        userProcess
+>>>>>>> Stashed changes
     );
 
     processNewAsyncEvent(newEvent);
   }
 
-  @Override
-  public void process(final FixedKeyRecord<KIn, VIn> record) {
+  public void process(final FixedKeyRecord<KIn, VIn> record, final Runnable userProcess) {
     assertQueuesEmptyOnFirstProcess();
 
     final AsyncEvent newEvent = new AsyncEvent(
@@ -309,8 +280,12 @@ public class AsyncProcessor<KIn, VIn, KOut, VOut>
         extractRecordContext(taskContext),
         taskContext.currentStreamTimeMs(),
         taskContext.currentSystemTimeMs(),
+<<<<<<< Updated upstream
         () -> userFixedKeyProcessor.process(record),
         List.of(metricsRecorder::recordStateTransition)
+=======
+        userProcess
+>>>>>>> Stashed changes
     );
 
     processNewAsyncEvent(newEvent);
@@ -351,8 +326,13 @@ public class AsyncProcessor<KIn, VIn, KOut, VOut>
     return ((InternalProcessorContext<KOut, VOut>) context).recordContext();
   }
 
+<<<<<<< Updated upstream
   @Override
   public void close() {
+=======
+  public void close(final Runnable userClose) {
+
+>>>>>>> Stashed changes
     if (!isCleared()) {
       // This doesn't necessarily indicate an issue; it just should only ever
       // happen if the task is closed dirty, but unfortunately we can't tell
@@ -369,11 +349,7 @@ public class AsyncProcessor<KIn, VIn, KOut, VOut>
     punctuator.cancel();
     threadPool.removeProcessor(asyncProcessorName, taskId.partition());
 
-    if (userProcessor != null) {
-      userProcessor.close();
-    } else {
-      userFixedKeyProcessor.close();
-    }
+    userClose.run();
   }
 
   private static void registerFlushListenerForStoreBuilders(

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/MaybeAsyncProcessor.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/MaybeAsyncProcessor.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2024 Responsive Computing, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package dev.responsive.kafka.api.async.internals;
+
+import static dev.responsive.kafka.api.config.ResponsiveConfig.ASYNC_THREAD_POOL_SIZE_CONFIG;
+import static dev.responsive.kafka.api.config.ResponsiveConfig.responsiveConfig;
+
+import dev.responsive.kafka.api.async.internals.stores.AbstractAsyncStoreBuilder;
+import dev.responsive.kafka.api.config.ResponsiveConfig;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.kafka.streams.processor.api.FixedKeyProcessor;
+import org.apache.kafka.streams.processor.api.FixedKeyProcessorContext;
+import org.apache.kafka.streams.processor.api.FixedKeyRecord;
+import org.apache.kafka.streams.processor.api.Processor;
+import org.apache.kafka.streams.processor.api.ProcessorContext;
+import org.apache.kafka.streams.processor.api.Record;
+import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
+
+/**
+ * This class is in charge of two things:
+ * 1. deduplicating and delegating code between the regular and fixed-key processor versions
+ * 2. disabling async processing altogether if the thread pool size is 0
+ */
+public class MaybeAsyncProcessor<KIn, VIn, KOut, VOut>
+    implements Processor<KIn, VIn, KOut, VOut>, FixedKeyProcessor<KIn, VIn, VOut> {
+
+  // Exactly one of these is non-null and the other is null
+  private final Processor<KIn, VIn, KOut, VOut> userProcessor;
+  private final FixedKeyProcessor<KIn, VIn, VOut> userFixedKeyProcessor;
+
+  private final Map<String, AbstractAsyncStoreBuilder<?, ?, ?>> connectedStoreBuilders;
+
+  private Optional<AsyncProcessor<KIn, VIn, KOut, VOut>> asyncProcessor = null;
+
+  public static <KIn, VIn, KOut, VOut> MaybeAsyncProcessor<KIn, VIn, KOut, VOut> createProcessor(
+      final Processor<KIn, VIn, KOut, VOut> userProcessor,
+      final Map<String, AbstractAsyncStoreBuilder<?, ?, ?>> connectedStoreBuilders
+  ) {
+    return new MaybeAsyncProcessor<>(userProcessor, null, connectedStoreBuilders);
+  }
+
+  public static <KIn, VIn, VOut> MaybeAsyncProcessor<KIn, VIn, KIn, VOut> createFixedKeyProcessor(
+      final FixedKeyProcessor<KIn, VIn, VOut> userProcessor,
+      final Map<String, AbstractAsyncStoreBuilder<?, ?, ?>> connectedStoreBuilders
+  ) {
+    return new MaybeAsyncProcessor<>(null, userProcessor, connectedStoreBuilders);
+  }
+
+  private MaybeAsyncProcessor(
+      final Processor<KIn, VIn, KOut, VOut> userProcessor,
+      final FixedKeyProcessor<KIn, VIn, VOut> userFixedKeyProcessor,
+      final Map<String, AbstractAsyncStoreBuilder<?, ?, ?>> connectedStoreBuilders
+  ) {
+    this.userProcessor = userProcessor;
+    this.userFixedKeyProcessor = userFixedKeyProcessor;
+    this.connectedStoreBuilders = connectedStoreBuilders;
+
+    if (userProcessor == null && userFixedKeyProcessor == null) {
+      throw new IllegalStateException("Both the Processor and FixedKeyProcessor were null");
+    } else if (userProcessor != null && userFixedKeyProcessor != null) {
+      throw new IllegalStateException("Both the Processor and FixedKeyProcessor were non-null");
+    }
+  }
+
+  @Override
+  public void init(final ProcessorContext<KOut, VOut> context) {
+    sharedInit(
+        (InternalProcessorContext<KOut, VOut>) context,
+        () -> userProcessor.init(context)
+    );
+  }
+
+  @Override
+  @SuppressWarnings("unchecked") // needed for fixed-key only since KOut is replaced with KIn
+  public void init(final FixedKeyProcessorContext<KIn, VOut> context) {
+    sharedInit(
+        (InternalProcessorContext<KOut, VOut>) context,
+        () -> userFixedKeyProcessor.init(context)
+    );
+  }
+
+  private void sharedInit(final InternalProcessorContext<KOut, VOut> context, final Runnable userInit) {
+    final int asyncThreadPoolSize =
+        responsiveConfig(context.appConfigs()).getInt(ASYNC_THREAD_POOL_SIZE_CONFIG);
+
+    if (asyncThreadPoolSize > 0) {
+      this.asyncProcessor = Optional.of(new AsyncProcessor<>(connectedStoreBuilders, context, userInit));
+    } else {
+      this.asyncProcessor = Optional.empty();
+      userInit.run();
+    }
+  }
+
+  @Override
+  public void process(final Record<KIn, VIn> record) {
+    final Runnable userProcess = () -> userProcessor.process(record);
+
+    if (asyncProcessor.isPresent()) {
+      asyncProcessor.get().process(record, userProcess);
+    } else {
+      userProcess.run();
+    }
+  }
+
+  @Override
+  public void process(final FixedKeyRecord<KIn, VIn> record) {
+    final Runnable userProcess = () -> userFixedKeyProcessor.process(record);
+
+    if (asyncProcessor.isPresent()) {
+      asyncProcessor.get().process(record, userProcess);
+    } else {
+      userProcess.run();
+    }
+  }
+
+  @Override
+  public void close() {
+    final Runnable userClose;
+    if (userProcessor != null) {
+      userClose = userProcessor::close;
+    } else {
+      userClose = userFixedKeyProcessor::close;
+    }
+
+    if (asyncProcessor.isPresent()) {
+      asyncProcessor.get().close(userClose);
+    } else {
+      userClose.run();
+    }
+  }
+}

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/MaybeAsyncProcessor.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/MaybeAsyncProcessor.java
@@ -20,7 +20,6 @@ import static dev.responsive.kafka.api.config.ResponsiveConfig.ASYNC_THREAD_POOL
 import static dev.responsive.kafka.api.config.ResponsiveConfig.responsiveConfig;
 
 import dev.responsive.kafka.api.async.internals.stores.AbstractAsyncStoreBuilder;
-import dev.responsive.kafka.api.config.ResponsiveConfig;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.kafka.streams.processor.api.FixedKeyProcessor;
@@ -111,7 +110,7 @@ public class MaybeAsyncProcessor<KIn, VIn, KOut, VOut>
     final Runnable userProcess = () -> userProcessor.process(record);
 
     if (asyncProcessor.isPresent()) {
-      asyncProcessor.get().process(record, userProcess);
+      asyncProcessor.get().processRegular(record, userProcess);
     } else {
       userProcess.run();
     }
@@ -122,7 +121,7 @@ public class MaybeAsyncProcessor<KIn, VIn, KOut, VOut>
     final Runnable userProcess = () -> userFixedKeyProcessor.process(record);
 
     if (asyncProcessor.isPresent()) {
-      asyncProcessor.get().process(record, userProcess);
+      asyncProcessor.get().processFixedKey(record, userProcess);
     } else {
       userProcess.run();
     }


### PR DESCRIPTION
Add a wrapper around the AsyncProcessor class and only instantiate it if the user has configured a nonzero thread pool size. This allows turning async on/off with just a config, without needing to add/remove the wrapper around the ProcessorSupplier as well.
