### PR TITLE
Disable async processing when thread pool size is 0 via static gate

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/api/async/AsyncFixedKeyProcessorSupplier.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/async/AsyncFixedKeyProcessorSupplier.java
@@ -19,7 +19,7 @@ package dev.responsive.kafka.api.async;
 import static dev.responsive.kafka.api.async.internals.AsyncProcessor.createAsyncFixedKeyProcessor;
 import static dev.responsive.kafka.api.async.internals.AsyncUtils.initializeAsyncBuilders;
 
-import dev.responsive.kafka.api.async.internals.AsyncProcessor;
+import dev.responsive.kafka.api.async.internals.AsyncProcessingGate;
 import dev.responsive.kafka.api.async.internals.stores.AbstractAsyncStoreBuilder;
 import java.util.HashSet;
 import java.util.Map;
@@ -75,12 +75,22 @@ public class AsyncFixedKeyProcessorSupplier<KIn, VIn, VOut>
   }
 
   @Override
-  public AsyncProcessor<KIn, VIn, KIn, VOut> get() {
-    return createAsyncFixedKeyProcessor(userProcessorSupplier.get(), asyncStoreBuilders);
+  public FixedKeyProcessor<KIn, VIn, VOut> get() {
+    if (AsyncProcessingGate.asyncEnabled()) {
+      return createAsyncFixedKeyProcessor(userProcessorSupplier.get(), asyncStoreBuilders);
+    } else {
+      return userProcessorSupplier.get();
+    }
   }
 
   @Override
   public Set<StoreBuilder<?>> stores() {
-    return new HashSet<>(asyncStoreBuilders.values());
+    if (AsyncProcessingGate.asyncEnabled()) {
+      return new HashSet<>(asyncStoreBuilders.values());
+    } else {
+      return userProcessorSupplier.stores();
+    }
   }
+
+
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/async/AsyncProcessorSupplier.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/async/AsyncProcessorSupplier.java
@@ -19,6 +19,7 @@ package dev.responsive.kafka.api.async;
 import static dev.responsive.kafka.api.async.internals.AsyncProcessor.createAsyncProcessor;
 import static dev.responsive.kafka.api.async.internals.AsyncUtils.initializeAsyncBuilders;
 
+import dev.responsive.kafka.api.async.internals.AsyncProcessingGate;
 import dev.responsive.kafka.api.async.internals.AsyncProcessor;
 import dev.responsive.kafka.api.async.internals.stores.AbstractAsyncStoreBuilder;
 import java.util.HashSet;
@@ -155,13 +156,21 @@ public final class AsyncProcessorSupplier<KIn, VIn, KOut, VOut>
   }
 
   @Override
-  public AsyncProcessor<KIn, VIn, KOut, VOut> get() {
-    return createAsyncProcessor(userProcessorSupplier.get(), asyncStoreBuilders);
+  public Processor<KIn, VIn, KOut, VOut> get() {
+    if (AsyncProcessingGate.asyncEnabled()) {
+      return createAsyncProcessor(userProcessorSupplier.get(), asyncStoreBuilders);
+    } else {
+      return userProcessorSupplier.get();
+    }
   }
 
   @Override
   public Set<StoreBuilder<?>> stores() {
-    return new HashSet<>(asyncStoreBuilders.values());
+    if (AsyncProcessingGate.asyncEnabled()) {
+      return new HashSet<>(asyncStoreBuilders.values());
+    } else {
+      return userProcessorSupplier.stores();
+    }
   }
 
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/AsyncProcessingGate.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/AsyncProcessingGate.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2024 Responsive Computing, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package dev.responsive.kafka.api.async.internals;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Super hacky way to communicate whether async processing is enabled based on the configured
+ * async thread pool size.
+ * We have to use a static map to get this information from the ResponsiveConfig passed into
+ * ResponsiveKafkaStreams to the async processor supplier *before* any state stores are built.
+ * Unfortunately Kafka Streams does not pass in the app configs to any processor, supplier, or
+ * state store constructors -- configs only become available to these elements when #init is called.
+ */
+public final class AsyncProcessingGate {
+
+  private static final AtomicBoolean ASYNC_ENABLED = new AtomicBoolean(false);
+
+  public static void maybeEnableAsyncProcessing(final int numAsyncThreads) {
+    if (numAsyncThreads > 0) {
+      ASYNC_ENABLED.set(true);
+    }
+  }
+
+  public static void closeAsyncProcessing() {
+    ASYNC_ENABLED.set(false);
+  }
+
+  public static boolean asyncEnabled() {
+    return ASYNC_ENABLED.get();
+  }
+
+}


### PR DESCRIPTION
Alternative to [pull/306](https://github.com/responsivedev/responsive-pub/pull/306)

Unfortunately the approach taken in the above PR gets considerably messier than the first draft showed, since we need to "shut off" the async store wrappers in addition to just the async processor itself. And unfortunately, we can't delay that until #init -- at least not as easily. 

This PR is definitely very hacky and probably not a great long-term solution for a real product -- but it does solve the immediate problem in a quick and neat way.