### PR TITLE
handle cancelled tasks in thread pool future handlers

### DIFF
--- a/kafka-client/src/test/java/dev/responsive/kafka/api/async/internals/AsyncThreadPoolTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/api/async/internals/AsyncThreadPoolTest.java
@@ -147,6 +147,26 @@ class AsyncThreadPoolTest {
     assertThat(other0InFlight.get(eventOtherProcessor).future().isCancelled(), is(false));
   }
 
+  @Test
+  public void shouldNotRaiseFatalExceptionOnCancellation() {
+    // given:
+    final var task1 = new TestTask();
+    final var event1 = newEvent(task1, 0);
+    schedule("processor", 0, finalizingQueue0, event1);
+
+    // when:
+    pool.removeProcessor("processor", 0);
+
+    // then:
+    for (final var t : List.of(task1)) {
+      t.waitLatch.countDown();
+    }
+    assertThat(
+        pool.checkUncaughtExceptions("processor", 0),
+        is(Optional.empty())
+    );
+  }
+
   private static final class TestTask implements Runnable {
     private final CountDownLatch waitLatch = new CountDownLatch(1);
 


### PR DESCRIPTION
We shouldn't record a CancellationException as a fatal async exception. The Async Thread Pool's future handler is called with a CancellationException whenever a task is cancelled, which is done on the normal path when a task is closed dirty. If we record the exception, then the next time the task is assigned we will immediately throw.