### PR TITLE
add an in-memory responsive store tye

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveKafkaStreams.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveKafkaStreams.java
@@ -457,7 +457,8 @@ public class ResponsiveKafkaStreams extends KafkaStreams {
 
       final var admin = responsiveKafkaClientSupplier.getAdmin(responsiveConfig.originals());
       if (compatibilityMode == CompatibilityMode.METRICS_ONLY) {
-        sessionClients = new SessionClients(Optional.empty(), Optional.empty(), admin);
+        sessionClients = new SessionClients(
+            Optional.empty(), Optional.empty(), false, admin);
         return this;
       }
 
@@ -468,6 +469,7 @@ public class ResponsiveKafkaStreams extends KafkaStreams {
           sessionClients = new SessionClients(
               Optional.empty(),
               Optional.of(cassandraFactory.createClient(cqlSession, responsiveConfig)),
+              false,
               admin
           );
           break;
@@ -490,6 +492,16 @@ public class ResponsiveKafkaStreams extends KafkaStreams {
                   CollectionCreationOptions.fromConfig(responsiveConfig)
               )),
               Optional.empty(),
+              false,
+              admin
+          );
+          break;
+        case IN_MEMORY:
+          LOG.info("using in-memory responsive store");
+          sessionClients = new SessionClients(
+              Optional.empty(),
+              Optional.empty(),
+              true,
               admin
           );
           break;

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/config/StorageBackend.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/config/StorageBackend.java
@@ -20,7 +20,8 @@ import java.util.Arrays;
 
 public enum StorageBackend {
   CASSANDRA,
-  MONGO_DB;
+  MONGO_DB,
+  IN_MEMORY;
 
   public static String[] names() {
     return Arrays.stream(values()).map(Enum::name).toArray(String[]::new);

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/inmemory/InMemoryKVTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/inmemory/InMemoryKVTable.java
@@ -1,0 +1,203 @@
+package dev.responsive.kafka.internal.db.inmemory;
+
+import dev.responsive.kafka.internal.db.KVFlushManager;
+import dev.responsive.kafka.internal.db.RemoteKVTable;
+import dev.responsive.kafka.internal.db.RemoteWriter;
+import dev.responsive.kafka.internal.db.partitioning.TablePartitioner;
+import dev.responsive.kafka.internal.stores.RemoteWriteResult;
+import dev.responsive.kafka.internal.stores.ResponsiveStoreRegistration;
+import dev.responsive.kafka.internal.utils.Iterators;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.ConcurrentNavigableMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.state.KeyValueIterator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class InMemoryKVTable implements RemoteKVTable<Object> {
+  private static final Logger LOG = LoggerFactory.getLogger(InMemoryKVTable.class);
+
+  private int kafkaPartition;
+  private final String name;
+  private final ConcurrentNavigableMap<Bytes, Value> store = new ConcurrentSkipListMap<>();
+
+  public InMemoryKVTable(String name) {
+    this.name = Objects.requireNonNull(name);
+  }
+
+  @Override
+  public KVFlushManager init(int kafkaPartition) {
+    LOG.info("init in-memory kv store {} {}", name, kafkaPartition);
+    this.kafkaPartition = kafkaPartition;
+    return new InMemoryKVFlushManager();
+  }
+
+  @Override
+  public byte[] get(final int kafkaPartition, final Bytes key, final long minValidTs) {
+    checkKafkaPartition(kafkaPartition);
+    final var value = store.get(key);
+    if (value == null) {
+      return null;
+    }
+    if (value.epochMillis() < minValidTs) {
+      return null;
+    }
+    return value.value();
+  }
+
+  @Override
+  public KeyValueIterator<Bytes, byte[]> range(
+      final int kafkaPartition,
+      final Bytes from,
+      final Bytes to,
+      final long minValidTs
+  ) {
+    checkKafkaPartition(kafkaPartition);
+    final var iter = store
+        .tailMap(from, true)
+        .headMap(to, true)
+        .entrySet()
+        .iterator();
+    return iteratorWithTimeFilter(iter, minValidTs);
+  }
+
+  @Override
+  public KeyValueIterator<Bytes, byte[]> all(final int kafkaPartition, final long minValidTs) {
+    checkKafkaPartition(kafkaPartition);
+    final var iter = store.entrySet().iterator();
+    return iteratorWithTimeFilter(iter, minValidTs);
+  }
+
+  @Override
+  public long approximateNumEntries(int kafkaPartition) {
+    checkKafkaPartition(kafkaPartition);
+    return store.size();
+  }
+
+  @Override
+  public String name() {
+    return name;
+  }
+
+  @Override
+  public Object insert(int kafkaPartition, Bytes key, byte[] value, long epochMillis) {
+    checkKafkaPartition(kafkaPartition);
+    return store.put(key, new Value(epochMillis, value));
+  }
+
+  @Override
+  public Object delete(int kafkaPartition, Bytes key) {
+    checkKafkaPartition(kafkaPartition);
+    return store.remove(key);
+  }
+
+  @Override
+  public long fetchOffset(int kafkaPartition) {
+    checkKafkaPartition(kafkaPartition);
+    return ResponsiveStoreRegistration.NO_COMMITTED_OFFSET;
+  }
+
+  private KeyValueIterator<Bytes, byte[]> iteratorWithTimeFilter(
+      final Iterator<Map.Entry<Bytes, Value>> iter,
+      final long minValidTs
+  ) {
+    return Iterators.kv(
+        Iterators.filter(
+            Iterators.kv(iter, e -> new KeyValue<>(e.getKey(), e.getValue())),
+            kv -> kv.value.epochMillis >= minValidTs
+        ),
+        kv -> new KeyValue<>(kv.key, kv.value.value())
+    );
+  }
+
+  public class InMemoryKVFlushManager extends KVFlushManager {
+    private InMemoryKVFlushManager() {
+    }
+
+    @Override
+    public RemoteWriteResult<Integer> updateOffset(long consumedOffset) {
+      return RemoteWriteResult.success(kafkaPartition);
+    }
+
+    @Override
+    public String tableName() {
+      return name;
+    }
+
+    @Override
+    public TablePartitioner<Bytes, Integer> partitioner() {
+      return new TablePartitioner<>() {
+        @Override
+        public Integer tablePartition(int kafkaPartition, Bytes key) {
+          return kafkaPartition;
+        }
+
+        @Override
+        public Integer metadataTablePartition(int kafkaPartition) {
+          return kafkaPartition;
+        }
+      };
+    }
+
+    @Override
+    public RemoteWriter<Bytes, Integer> createWriter(Integer tablePartition) {
+      return new RemoteWriter<>() {
+        @Override
+        public void insert(Bytes key, byte[] value, long epochMillis) {
+          InMemoryKVTable.this.insert(tablePartition, key, value, epochMillis);
+        }
+
+        @Override
+        public void delete(Bytes key) {
+          InMemoryKVTable.this.delete(tablePartition, key);
+        }
+
+        @Override
+        public CompletionStage<RemoteWriteResult<Integer>> flush() {
+          return CompletableFuture.completedFuture(RemoteWriteResult.success(kafkaPartition));
+        }
+      };
+    }
+
+    @Override
+    public String failedFlushInfo(long batchOffset, Integer failedTablePartition) {
+      return "failed flush";
+    }
+
+    @Override
+    public String logPrefix() {
+      return "inmemory";
+    }
+  }
+
+  private void checkKafkaPartition(int kafkaPartition) {
+    if (this.kafkaPartition != kafkaPartition) {
+      throw new IllegalStateException(
+          "unexpected partition: " + kafkaPartition + " for " + this.kafkaPartition);
+    }
+  }
+
+  private static class Value {
+    private final long epochMillis;
+    private final byte[] value;
+
+    public Value(final long epochMillis, final byte[] value) {
+      this.epochMillis = epochMillis;
+      this.value = value;
+    }
+
+    public long epochMillis() {
+      return epochMillis;
+    }
+
+    public byte[] value() {
+      return value;
+    }
+  }
+}

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/PartitionedOperations.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/PartitionedOperations.java
@@ -33,6 +33,7 @@ import dev.responsive.kafka.internal.db.BytesKeySpec;
 import dev.responsive.kafka.internal.db.FlushManager;
 import dev.responsive.kafka.internal.db.RemoteKVTable;
 import dev.responsive.kafka.internal.db.RemoteTableSpecFactory;
+import dev.responsive.kafka.internal.db.inmemory.InMemoryKVTable;
 import dev.responsive.kafka.internal.db.partitioning.SubPartitioner;
 import dev.responsive.kafka.internal.db.partitioning.TablePartitioner;
 import dev.responsive.kafka.internal.metrics.ResponsiveRestoreListener;
@@ -104,6 +105,9 @@ public class PartitionedOperations implements KeyValueOperations {
       case MONGO_DB:
         table = createMongo(params, sessionClients);
         break;
+      case IN_MEMORY:
+        table = createInMemory(params);
+        break;
       default:
         throw new IllegalStateException("Unexpected value: " + sessionClients.storageBackend());
     }
@@ -160,6 +164,10 @@ public class PartitionedOperations implements KeyValueOperations {
         migrationMode,
         startingTimestamp
     );
+  }
+
+  private static RemoteKVTable<?> createInMemory(final ResponsiveKeyValueParams params) {
+    return new InMemoryKVTable(params.name().tableName());
   }
 
   private static RemoteKVTable<?> createCassandra(

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/utils/SessionClients.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/utils/SessionClients.java
@@ -37,6 +37,7 @@ public class SessionClients {
 
   private final Optional<ResponsiveMongoClient> mongoClient;
   private final Optional<CassandraClient> cassandraClient;
+  private final boolean inMemory;
   private final Admin admin;
 
   // These are effectively final, but have to be inserted after the SessionClients is
@@ -47,10 +48,12 @@ public class SessionClients {
   public SessionClients(
       final Optional<ResponsiveMongoClient> mongoClient,
       final Optional<CassandraClient> cassandraClient,
+      final boolean inMemory,
       final Admin admin
   ) {
     this.mongoClient = mongoClient;
     this.cassandraClient = cassandraClient;
+    this.inMemory = inMemory;
     this.admin = admin;
   }
 
@@ -72,6 +75,8 @@ public class SessionClients {
       return StorageBackend.MONGO_DB;
     } else if (cassandraClient.isPresent()) {
       return StorageBackend.CASSANDRA;
+    } else if (inMemory) {
+      return StorageBackend.IN_MEMORY;
     } else {
       throw new IllegalArgumentException("Invalid Shared Clients Configuration. "
           + "If you have configured " + ResponsiveConfig.COMPATIBILITY_MODE_CONFIG

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/inmemory/InMemoryKVTableTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/inmemory/InMemoryKVTableTest.java
@@ -1,0 +1,149 @@
+package dev.responsive.kafka.internal.db.inmemory;
+
+import static dev.responsive.kafka.internal.db.testutils.Matchers.sameKeyValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import dev.responsive.kafka.internal.db.KVFlushManager;
+import dev.responsive.kafka.internal.db.RemoteWriter;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.KeyValue;
+import org.junit.jupiter.api.Test;
+
+class InMemoryKVTableTest {
+  private final InMemoryKVTable table = new InMemoryKVTable("name");
+  private final KVFlushManager flushManager =  table.init(0);
+  private final RemoteWriter<Bytes, Integer> writer = flushManager.createWriter(0);
+
+  @Test
+  public void shouldGetPuts() {
+    // given:
+    writer.insert(Bytes.wrap("key".getBytes()), "val".getBytes(), 100);
+    writer.flush();
+
+    // when/then:
+    assertThat(table.get(0, Bytes.wrap("key".getBytes()), -1), is("val".getBytes()));
+  }
+
+  @Test
+  public void shouldDoRangeScan() {
+    // given:
+    writer.insert(Bytes.wrap("aa".getBytes()), "val0".getBytes(), 100);
+    writer.insert(Bytes.wrap("aaa".getBytes()), "val1".getBytes(), 100);
+    writer.insert(Bytes.wrap("bbbb".getBytes()), "val2".getBytes(), 100);
+    writer.insert(Bytes.wrap("cc".getBytes()), "val3".getBytes(), 100);
+    writer.insert(Bytes.wrap("ccddd".getBytes()), "val4".getBytes(), 100);
+    writer.flush();
+
+    // when:
+    final var iter = table.range(
+        0,
+        Bytes.wrap("aaa".getBytes()),
+        Bytes.wrap("cc".getBytes()),
+        0
+    );
+
+    // then:
+    assertThat(
+        iter.next(),
+        sameKeyValue(new KeyValue<>(Bytes.wrap("aaa".getBytes()), "val1".getBytes()))
+    );
+    assertThat(
+        iter.next(),
+        sameKeyValue(new KeyValue<>(Bytes.wrap("bbbb".getBytes()), "val2".getBytes()))
+    );
+    assertThat(
+        iter.next(),
+        sameKeyValue(new KeyValue<>(Bytes.wrap("cc".getBytes()), "val3".getBytes()))
+    );
+    assertThat(iter.hasNext(), is(false));
+    iter.close();
+  }
+
+  @Test
+  public void shouldDoFullScan() {
+    writer.insert(Bytes.wrap("aaa".getBytes()), "val1".getBytes(), 100);
+    writer.insert(Bytes.wrap("bbbb".getBytes()), "val2".getBytes(), 100);
+    writer.insert(Bytes.wrap("cc".getBytes()), "val3".getBytes(), 100);
+    writer.insert(Bytes.wrap("ccddd".getBytes()), "val4".getBytes(), 100);
+    writer.flush();
+
+    // when:
+    final var iter = table.all(0, -1);
+
+    // then:
+    assertThat(
+        iter.next(),
+        sameKeyValue(new KeyValue<>(Bytes.wrap("aaa".getBytes()), "val1".getBytes()))
+    );
+    assertThat(
+        iter.next(),
+        sameKeyValue(new KeyValue<>(Bytes.wrap("bbbb".getBytes()), "val2".getBytes()))
+    );
+    assertThat(
+        iter.next(),
+        sameKeyValue(new KeyValue<>(Bytes.wrap("cc".getBytes()), "val3".getBytes()))
+    );
+    assertThat(
+        iter.next(),
+        sameKeyValue(new KeyValue<>(Bytes.wrap("ccddd".getBytes()), "val4".getBytes()))
+    );
+    assertThat(iter.hasNext(), is(false));
+    iter.close();
+  }
+
+  @Test
+  public void shouldFilterMinTimestampOnGet() {
+    // given:
+    writer.insert(Bytes.wrap("key".getBytes()), "val".getBytes(), 100);
+    writer.flush();
+
+    // when/then:
+    assertThat(table.get(0, Bytes.wrap("key".getBytes()), 101), is(nullValue()));
+  }
+
+  @Test
+  public void shouldFilterMinTimestampOnRangeScan() {
+    // given:
+    writer.insert(Bytes.wrap("aaa".getBytes()), "val1".getBytes(), 100);
+    writer.insert(Bytes.wrap("bbbb".getBytes()), "val2".getBytes(), 100);
+    writer.insert(Bytes.wrap("cc".getBytes()), "val3".getBytes(), 500);
+    writer.flush();
+
+    // when:
+    final var iter = table.range(
+        0,
+        Bytes.wrap("aaa".getBytes()),
+        Bytes.wrap("cc".getBytes()),
+        300
+    );
+
+    // then:
+    assertThat(
+        iter.next(),
+        sameKeyValue(new KeyValue<>(Bytes.wrap("cc".getBytes()), "val3".getBytes()))
+    );
+    assertThat(iter.hasNext(), is(false));
+    iter.close();
+  }
+
+  @Test
+  public void shouldFilterMinTimestampOnFullScan() {
+    writer.insert(Bytes.wrap("aaa".getBytes()), "val1".getBytes(), 100);
+    writer.insert(Bytes.wrap("bbbb".getBytes()), "val2".getBytes(), 100);
+    writer.insert(Bytes.wrap("cc".getBytes()), "val3".getBytes(), 500);
+    writer.flush();
+
+    // when:
+    final var iter = table.all(0, 300);
+
+    // then:
+    assertThat(
+        iter.next(),
+        sameKeyValue(new KeyValue<>(Bytes.wrap("cc".getBytes()), "val3".getBytes()))
+    );
+    assertThat(iter.hasNext(), is(false));
+    iter.close();
+  }
+}

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/testutils/Matchers.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/testutils/Matchers.java
@@ -1,0 +1,42 @@
+package dev.responsive.kafka.internal.db.testutils;
+
+import java.util.Arrays;
+import org.apache.kafka.streams.KeyValue;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+
+public class Matchers {
+
+
+  private Matchers() {
+  }
+
+  public static <T> Matcher<KeyValue<T, byte[]>> sameKeyValue(final KeyValue<T, byte[]> expected) {
+    return new SameKeyValue<>(expected);
+  }
+
+  private static class SameKeyValue<T> extends BaseMatcher<KeyValue<T, byte[]>> {
+    private final KeyValue<T, byte[]> expected;
+
+    public SameKeyValue(KeyValue<T, byte[]> expected) {
+      this.expected = expected;
+    }
+
+    @Override
+    public boolean matches(Object o) {
+      if (!(o instanceof KeyValue)) {
+        return false;
+      }
+      final KeyValue<?, ?> otherKeyValue = (KeyValue<?, ?>) o;
+      return expected.key.equals(otherKeyValue.key)
+          && otherKeyValue.value instanceof byte[]
+          && Arrays.equals(expected.value, (byte[]) otherKeyValue.value);
+    }
+
+    @Override
+    public void describeTo(Description description) {
+      description.appendValue(expected);
+    }
+  }
+}

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/CommitBufferTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/CommitBufferTest.java
@@ -170,6 +170,7 @@ public class CommitBufferTest {
     sessionClients = new SessionClients(
         Optional.empty(),
         Optional.of(client),
+        false,
         admin
     );
     final var responsiveMetrics = new ResponsiveMetrics(metrics);

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/api/ResponsiveTopologyTestDriver.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/api/ResponsiveTopologyTestDriver.java
@@ -138,7 +138,7 @@ public class ResponsiveTopologyTestDriver extends TopologyTestDriver {
     final Properties props = baseProps(userProps);
 
     final SessionClients sessionClients = new SessionClients(
-        Optional.empty(), Optional.of(client), client.mockAdmin()
+        Optional.empty(), Optional.of(client), false, client.mockAdmin()
     );
     final var restoreListener = mockRestoreListener(props);
     sessionClients.initialize(restoreListener.metrics(), restoreListener);


### PR DESCRIPTION
Adds an in-memory responsive store type that stores all data in memory. It never stores an offset, so on a restore the entire store is restored from offset 0. This is meant to be used for test environments where we dont want to run a remote store.