### PR TITLE
change the way e2e test checks for stalls

### DIFF
--- a/kafka-client-examples/e2e-test/src/main/java/dev/responsive/examples/e2etest/Params.java
+++ b/kafka-client-examples/e2e-test/src/main/java/dev/responsive/examples/e2etest/Params.java
@@ -9,12 +9,12 @@ public class Params {
   public static final int EXCEPTION_INJECT_THRESHOLD
       = Integer.parseInt(System.getenv().getOrDefault("EXCEPTION_INJECT_THRESHOLD", "1"));
   public static final int NUM_KEYS
-      = Integer.parseInt(System.getenv().getOrDefault("NUM_KEYS", "16"));
+      = Integer.parseInt(System.getenv().getOrDefault("NUM_KEYS", "32"));
   public static final int MAX_OUTSTANDING
       = Integer.parseInt(System.getenv().getOrDefault("MAX_OUTSTANDING", "500"));
   public static final int RECEIVE_THRESHOLD
-      = Integer.parseInt(System.getenv().getOrDefault("RECEIVE_THRESHOLD", "360"));
+      = Integer.parseInt(System.getenv().getOrDefault("RECEIVE_THRESHOLD", "480"));
   public static final int FAULT_STOP_THRESHOLD
-      = Integer.parseInt(System.getenv().getOrDefault("FAULT_STOP_THRESHOLD", "300"));
+      = Integer.parseInt(System.getenv().getOrDefault("FAULT_STOP_THRESHOLD", "480"));
   public static final String MODE = System.getenv().getOrDefault("E2E_APP_MODE", "APPLICATION");
 }


### PR DESCRIPTION
change the way the e2e test checks for stalls:
1. first it looks at the commit and end offsets of the sink, and looks for any keys that have been missed when the committed offset moves past the earliest unreceived input for that key
2. second, it looks for partitions that haven't made progress in a while