### PR TITLE
Remove state store requirement for async processing

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveKafkaStreams.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveKafkaStreams.java
@@ -451,8 +451,8 @@ public class ResponsiveKafkaStreams extends KafkaStreams {
         );
         delegateKafkaClientSupplier = new AsyncStreamsKafkaClientSupplier(
                 innerClientSupplier,
-                asyncRegistry,
-                streamsConfig);
+                asyncRegistry
+        );
         this.asyncThreadPoolRegistry = Optional.of(asyncRegistry);
       } else {
         delegateKafkaClientSupplier = innerClientSupplier;

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/async/AsyncFixedKeyProcessorSupplier.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/async/AsyncFixedKeyProcessorSupplier.java
@@ -63,13 +63,6 @@ public class AsyncFixedKeyProcessorSupplier<KIn, VIn, VOut>
       final FixedKeyProcessorSupplier<KIn, VIn, VOut> userProcessorSupplier,
       final Set<StoreBuilder<?>> userStoreBuilders
   ) {
-    if (userStoreBuilders == null || userStoreBuilders.isEmpty()) {
-      throw new UnsupportedOperationException(
-          "Async processing currently requires at least one state store be "
-              + "connected to the async processor, and that stores be connected "
-              + "by implementing the #stores method in your processor supplier");
-    }
-
     this.userProcessorSupplier = userProcessorSupplier;
     this.asyncStoreBuilders = initializeAsyncBuilders(userStoreBuilders);
   }

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/AsyncProcessor.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/AsyncProcessor.java
@@ -46,7 +46,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.utils.LogContext;
-import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.StreamsException;
 import org.apache.kafka.streams.errors.TaskMigratedException;
 import org.apache.kafka.streams.processor.Cancellable;

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/AsyncProcessor.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/AsyncProcessor.java
@@ -750,9 +750,9 @@ public class AsyncProcessor<KIn, VIn, KOut, VOut>
           String.join(",", connectedStores.keySet()),
           String.join(", ", accessedStores.keySet()));
       throw new IllegalStateException(
-          "Names of actual stores initialized by this processor does not "
-              + "match the connected store names that were provided "
-              + "to the AsyncProcessorSupplier");
+          "Processor initialized some stores that were not connected via the ProcessorSupplier, "
+              + "please connect stores for async processors by implementing the "
+              + "ProcessorSupplier#storesNames method");
     }
   }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/AsyncProcessor.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/AsyncProcessor.java
@@ -98,8 +98,9 @@ public class AsyncProcessor<KIn, VIn, KOut, VOut>
   private String streamThreadName;
   private String asyncProcessorName;
   private TaskId taskId;
+  private AsyncProcessorId asyncId;
 
-  private AsyncThreadPool threadPool;
+  private AsyncThreadPoolRegistration asyncThreadPoolRegistration;
   private SchedulingQueue<KIn> schedulingQueue;
   private FinalizingQueue finalizingQueue;
 
@@ -189,6 +190,7 @@ public class AsyncProcessor<KIn, VIn, KOut, VOut>
     this.streamThreadName = Thread.currentThread().getName();
     this.taskId = internalContext.taskId();
     this.asyncProcessorName = internalContext.currentNode().name();
+    this.asyncId = AsyncProcessorId.of(asyncProcessorName, taskId.partition());
 
     this.logPrefix = String.format(
         "stream-thread [%s] %s[%d] ",
@@ -221,8 +223,9 @@ public class AsyncProcessor<KIn, VIn, KOut, VOut>
     final long punctuationInterval = configs.getLong(ASYNC_FLUSH_INTERVAL_MS_CONFIG);
     final int maxEventsPerKey = configs.getInt(ASYNC_MAX_EVENTS_QUEUED_PER_KEY_CONFIG);
 
-    this.threadPool = getAsyncThreadPool(taskContext, streamThreadName);
-    this.threadPool.maybeInitThreadPoolMetrics();
+    this.asyncThreadPoolRegistration = getAsyncThreadPool(taskContext, streamThreadName);
+    asyncThreadPoolRegistration.registerAsyncProcessor(asyncId, this::flushPendingEventsForCommit);
+    asyncThreadPoolRegistration.threadPool().maybeInitThreadPoolMetrics();
 
     this.schedulingQueue = new MeteredSchedulingQueue<>(
         metricsRecorder,
@@ -252,7 +255,7 @@ public class AsyncProcessor<KIn, VIn, KOut, VOut>
         streamThreadName,
         taskId.partition(),
         connectedStoreBuilders.values(),
-        this::flushAndAwaitPendingEvents
+        this::flushPendingEventsForCommit
     );
   }
 
@@ -268,7 +271,7 @@ public class AsyncProcessor<KIn, VIn, KOut, VOut>
       log.error("the scheduling queue for {} was expected to be empty", taskId);
       throw new IllegalStateException("scheduling queue expected to be empty");
     }
-    if (!threadPool.isEmpty(asyncProcessorName, taskId.partition())) {
+    if (!asyncThreadPoolRegistration.threadPool().isEmpty(asyncProcessorName, taskId.partition())) {
       log.error("the thread pool for {} was expected to be empty", taskId);
       throw new IllegalStateException("thread pool expected to be empty");
     }
@@ -367,7 +370,7 @@ public class AsyncProcessor<KIn, VIn, KOut, VOut>
     metricsRecorder.close();
 
     punctuator.cancel();
-    threadPool.removeProcessor(asyncProcessorName, taskId.partition());
+    asyncThreadPoolRegistration.unregisterAsyncProcessor(asyncId);
 
     if (userProcessor != null) {
       userProcessor.close();
@@ -390,9 +393,10 @@ public class AsyncProcessor<KIn, VIn, KOut, VOut>
   /**
    * Block on all pending records to be scheduled, executed, and fully complete processing through
    * the topology, as well as all state store operations to be applied. Called at the beginning of
-   * each commit, similar to #flushCache
+   * each commit to make sure we've finished up any records we're committing offsets for
+   * TODO: add a timeout in case we get stuck somewhere
    */
-  public void flushAndAwaitPendingEvents() {
+  public void flushPendingEventsForCommit() {
     if (fatalException != null) {
       // if there was a fatal exception, just throw right away so that we exit right
       // away and minimize the risk of causing further problems. Additionally, processing for
@@ -445,9 +449,8 @@ public class AsyncProcessor<KIn, VIn, KOut, VOut>
    * tied to events that belong to this specific AsyncProcessor or task.
    */
   private void checkFatalExceptionsFromAsyncThreadPool() {
-    final Optional<Throwable> fatal = threadPool.checkUncaughtExceptions(
-        asyncProcessorName, taskId.partition()
-    );
+    final Optional<Throwable> fatal = asyncThreadPoolRegistration.threadPool()
+        .checkUncaughtExceptions(asyncProcessorName, taskId.partition());
     
     if (fatal.isPresent()) {
       log.error("Detected uncaught fatal exception from the async thread pool", fatal.get());
@@ -594,7 +597,7 @@ public class AsyncProcessor<KIn, VIn, KOut, VOut>
     }
     final int numScheduled = eventsToSchedule.size();
     if (numScheduled > 0) {
-      threadPool.scheduleForProcessing(
+      asyncThreadPoolRegistration.threadPool().scheduleForProcessing(
           asyncProcessorName,
           taskId,
           eventsToSchedule,
@@ -754,14 +757,12 @@ public class AsyncProcessor<KIn, VIn, KOut, VOut>
     }
   }
 
-  private static AsyncThreadPool getAsyncThreadPool(
+  private static AsyncThreadPoolRegistration getAsyncThreadPool(
       final ProcessingContext context,
       final String streamThreadName
   ) {
     try {
-      final AsyncThreadPoolRegistry registry = loadAsyncThreadPoolRegistry(
-          context.appConfigsWithPrefix(StreamsConfig.MAIN_CONSUMER_PREFIX)
-      );
+      final AsyncThreadPoolRegistry registry = loadAsyncThreadPoolRegistry(context.appConfigs());
       return registry.asyncThreadPoolForStreamThread(streamThreadName);
     } catch (final Exception e) {
       throw new ConfigException(

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/AsyncProcessor.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/AsyncProcessor.java
@@ -223,7 +223,7 @@ public class AsyncProcessor<KIn, VIn, KOut, VOut>
     final int maxEventsPerKey = configs.getInt(ASYNC_MAX_EVENTS_QUEUED_PER_KEY_CONFIG);
 
     this.asyncThreadPoolRegistration = getAsyncThreadPool(taskContext, streamThreadName);
-    asyncThreadPoolRegistration.registerAsyncProcessor(asyncId, this::flushPendingEventsForCommit);
+    asyncThreadPoolRegistration.registerAsyncProcessor(taskId, this::flushPendingEventsForCommit);
     asyncThreadPoolRegistration.threadPool().maybeInitThreadPoolMetrics();
 
     this.schedulingQueue = new MeteredSchedulingQueue<>(

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/AsyncProcessorId.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/AsyncProcessorId.java
@@ -16,10 +16,12 @@
 
 package dev.responsive.kafka.api.async.internals;
 
+import java.util.Comparator;
+
 /**
  * Simple container class for info that uniquely identifies a {@link AsyncProcessor} instance
  */
-public class AsyncProcessorId {
+public class AsyncProcessorId implements Comparable<AsyncProcessorId> {
 
   public final String processorName;
   public final int partition;
@@ -60,5 +62,11 @@ public class AsyncProcessorId {
   @Override
   public String toString() {
     return "AsyncProcessorId<" + processorName + "_" + partition + '>';
+  }
+
+  @Override
+  public int compareTo(final AsyncProcessorId o) {
+    final int comparingName = this.processorName.compareTo(o.processorName);
+    return comparingName != 0 ? comparingName : this.partition - o.partition;
   }
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/AsyncProcessorId.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/AsyncProcessorId.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2024 Responsive Computing, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package dev.responsive.kafka.api.async.internals;
+
+/**
+ * Simple container class for info that uniquely identifies a {@link AsyncProcessor} instance
+ */
+public class AsyncProcessorId {
+
+  public final String processorName;
+  public final int partition;
+
+  public static AsyncProcessorId of(final String processorName, final int partition) {
+    return new AsyncProcessorId(processorName, partition);
+  }
+
+  private AsyncProcessorId(final String processorName, final int partition) {
+    this.processorName = processorName;
+    this.partition = partition;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final AsyncProcessorId that = (AsyncProcessorId) o;
+
+    if (partition != that.partition) {
+      return false;
+    }
+    return processorName.equals(that.processorName);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = processorName.hashCode();
+    result = 31 * result + partition;
+    return result;
+  }
+
+  @Override
+  public String toString() {
+    return "AsyncProcessorId<" + processorName + "_" + partition + '>';
+  }
+}

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/AsyncProcessorId.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/AsyncProcessorId.java
@@ -16,8 +16,6 @@
 
 package dev.responsive.kafka.api.async.internals;
 
-import java.util.Comparator;
-
 /**
  * Simple container class for info that uniquely identifies a {@link AsyncProcessor} instance
  */

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/AsyncThreadPoolRegistration.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/AsyncThreadPoolRegistration.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2024 Responsive Computing, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package dev.responsive.kafka.api.async.internals;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class AsyncThreadPoolRegistration {
+
+  private final AsyncThreadPool threadPool;
+
+  private final Map<AsyncProcessorId, Runnable> asyncProcessorsToFlush = new HashMap<>();
+
+  public AsyncThreadPoolRegistration(
+      final AsyncThreadPool threadPool
+  ) {
+    this.threadPool = threadPool;
+  }
+
+  public AsyncThreadPool threadPool() {
+    return threadPool;
+  }
+
+  public void registerAsyncProcessor(final AsyncProcessorId id, final Runnable flushProcessor) {
+    asyncProcessorsToFlush.put(id, flushProcessor);
+  }
+
+  public void unregisterAsyncProcessor(final AsyncProcessorId id) {
+    asyncProcessorsToFlush.remove(id);
+    threadPool.removeProcessor(id);
+  }
+
+  public void flush() {
+    // TODO: this is non-ideal for stateless apps since we're flush each processor instance
+    //  sequentially and might end up waiting for async results from one processor while there
+    //  are others ready and waiting on other processors/partitions.
+    //  We should loop over all processors and only wait/block when we really have nothing to do
+    //  (doesn't matter for stateful apps since this method is a no-op due to flushing
+    //  everything during #flushCache which comes earlier in the commit process)
+    asyncProcessorsToFlush.values().forEach(Runnable::run);
+  }
+
+  public void close() {
+    threadPool.shutdown();
+  }
+}

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/AsyncThreadPoolRegistry.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/AsyncThreadPoolRegistry.java
@@ -96,18 +96,18 @@ public class AsyncThreadPoolRegistry {
   }
 
   private void shutdownAsyncThreadPool(final String streamThreadName, final boolean fromStart) {
-    final AsyncThreadPoolRegistration threadPool = streamThreadToAsyncPool.remove(streamThreadName);
+    final AsyncThreadPoolRegistration registration = streamThreadToAsyncPool.remove(streamThreadName);
 
     // It's possible the consumer was closed twice for some reason, in which case
     // we have already unregistered and begun shutdown for this pool
-    if (threadPool != null) {
+    if (registration != null) {
       if (fromStart) {
         LOG.warn(
             "Shutting down old orphaned async thread pool for StreamThread {}",
             streamThreadName
         );
       }
-      threadPool.close();
+      registration.close();
     }
   }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/AsyncThreadPoolRegistry.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/AsyncThreadPoolRegistry.java
@@ -43,7 +43,7 @@ public class AsyncThreadPoolRegistry {
   private final int asyncThreadPoolSize;
   private final int maxQueuedEvents;
   private final ResponsiveMetrics responsiveMetrics;
-  private final Map<String, AsyncThreadPool> streamThreadToAsyncPool;
+  private final Map<String, AsyncThreadPoolRegistration> streamThreadToAsyncPool;
 
   public AsyncThreadPoolRegistry(
       final int numStreamThreads,
@@ -60,7 +60,7 @@ public class AsyncThreadPoolRegistry {
   /**
    * Registers and starts up a new AsyncThreadPool for the given StreamThread
    */
-  public void startNewAsyncThreadPool(final String streamThreadName) {
+  public AsyncThreadPoolRegistration startNewAsyncThreadPool(final String streamThreadName) {
     shutdownAsyncThreadPool(streamThreadName, true);
     final AsyncThreadPool newThreadPool = new AsyncThreadPool(
         streamThreadName,
@@ -68,10 +68,17 @@ public class AsyncThreadPoolRegistry {
         maxQueuedEvents,
         responsiveMetrics
     );
-    streamThreadToAsyncPool.put(streamThreadName, newThreadPool);
+
+    final var asyncThreadPoolRegistration = new AsyncThreadPoolRegistration(newThreadPool);
+    streamThreadToAsyncPool.put(
+        streamThreadName,
+        asyncThreadPoolRegistration
+    );
+
+    return asyncThreadPoolRegistration;
   }
 
-  public AsyncThreadPool asyncThreadPoolForStreamThread(
+  public AsyncThreadPoolRegistration asyncThreadPoolForStreamThread(
       final String streamThreadName
   ) {
     return streamThreadToAsyncPool.get(streamThreadName);
@@ -89,7 +96,7 @@ public class AsyncThreadPoolRegistry {
   }
 
   private void shutdownAsyncThreadPool(final String streamThreadName, final boolean fromStart) {
-    final AsyncThreadPool threadPool = streamThreadToAsyncPool.remove(streamThreadName);
+    final AsyncThreadPoolRegistration threadPool = streamThreadToAsyncPool.remove(streamThreadName);
 
     // It's possible the consumer was closed twice for some reason, in which case
     // we have already unregistered and begun shutdown for this pool
@@ -100,7 +107,7 @@ public class AsyncThreadPoolRegistry {
             streamThreadName
         );
       }
-      threadPool.shutdown();
+      threadPool.close();
     }
   }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/AsyncThreadPoolRegistry.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/AsyncThreadPoolRegistry.java
@@ -96,7 +96,8 @@ public class AsyncThreadPoolRegistry {
   }
 
   private void shutdownAsyncThreadPool(final String streamThreadName, final boolean fromStart) {
-    final AsyncThreadPoolRegistration registration = streamThreadToAsyncPool.remove(streamThreadName);
+    final AsyncThreadPoolRegistration registration =
+        streamThreadToAsyncPool.remove(streamThreadName);
 
     // It's possible the consumer was closed twice for some reason, in which case
     // we have already unregistered and begun shutdown for this pool

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/AsyncUtils.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/AsyncUtils.java
@@ -21,6 +21,7 @@ import static dev.responsive.kafka.api.async.internals.AsyncThreadPool.ASYNC_THR
 import dev.responsive.kafka.api.async.internals.stores.AbstractAsyncStoreBuilder;
 import dev.responsive.kafka.internal.stores.ResponsiveStoreBuilder;
 import dev.responsive.kafka.internal.stores.ResponsiveStoreBuilder.StoreType;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
@@ -66,6 +67,10 @@ public class AsyncUtils {
   public static Map<String, AbstractAsyncStoreBuilder<?, ?, ?>> initializeAsyncBuilders(
       final Set<StoreBuilder<?>> userConnectedStores
   ) {
+    if (userConnectedStores == null || userConnectedStores.isEmpty()) {
+      return Collections.emptyMap();
+    }
+
     final Map<String, AbstractAsyncStoreBuilder<?, ?, ?>> asyncStoreBuilders = new HashMap<>();
     for (final StoreBuilder<?> builder : userConnectedStores) {
       final String storeName = builder.name();

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/AsyncStreamsConsumer.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/AsyncStreamsConsumer.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2024 Responsive Computing, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package dev.responsive.kafka.internal.clients;
+
+import dev.responsive.kafka.api.async.internals.AsyncThreadPoolRegistry;
+import java.time.Duration;
+import java.util.Map;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+
+/**
+ * Simple wrapper around the underlying ResponsiveConsumer that handles async stuff under ALOS.
+ * <p>
+ * The async consumer has two jobs: first, it registers and manages the lifecycle of the
+ * async thread pool associated with this StreamThread. Second, it's used to make sure any
+ * pending async records get flushed through the topology before committing offsets for
+ * those records.
+ * <p>
+ * If EOS is enabled, the async consumer will not be used at all and the above responsibilities
+ * fall instead to the {@link AsyncStreamsProducer}
+ */
+public class AsyncStreamsConsumer<K, V> extends DelegatingConsumer<K, V> {
+
+  private final String streamThreadName;
+  private final AsyncThreadPoolRegistry asyncThreadPoolRegistry;
+  private final Runnable flushAsyncProcessors;
+
+  public AsyncStreamsConsumer(
+      final Consumer<K, V> delegate,
+      final AsyncThreadPoolRegistry asyncThreadPoolRegistry
+  ) {
+    super(delegate);
+    this.streamThreadName = Thread.currentThread().getName();
+    this.asyncThreadPoolRegistry = asyncThreadPoolRegistry;
+    final var asyncThreadPoolRegistration = asyncThreadPoolRegistry
+        .startNewAsyncThreadPool(streamThreadName);
+    this.flushAsyncProcessors = asyncThreadPoolRegistration::flush;
+
+  }
+
+  @Override
+  public void commitSync(final Map<TopicPartition, OffsetAndMetadata> offsets) {
+    flushAsyncProcessors.run();
+    super.commitSync(offsets);
+  }
+
+  @Override
+  public void commitSync(final Map<TopicPartition, OffsetAndMetadata> offsets,
+                         final Duration timeout) {
+    flushAsyncProcessors.run();
+    super.commitSync(offsets, timeout);
+  }
+
+
+  @Override
+  public void close() {
+    shutdownAsyncThreadPool();
+    super.close();
+  }
+
+  @Override
+  public void close(final Duration timeout) {
+    shutdownAsyncThreadPool();
+    super.close(timeout);
+  }
+
+  private void shutdownAsyncThreadPool() {
+    if (!streamThreadName.equals(Thread.currentThread().getName())) {
+      throw new IllegalStateException(String.format(
+          "Attempted to close consumer for StreamThread %s from thread %s",
+          streamThreadName, Thread.currentThread().getName())
+      );
+    }
+    asyncThreadPoolRegistry.shutdownAsyncThreadPool(streamThreadName);
+  }
+}

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/AsyncStreamsConsumer.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/AsyncStreamsConsumer.java
@@ -16,6 +16,8 @@
 
 package dev.responsive.kafka.internal.clients;
 
+import static dev.responsive.kafka.internal.utils.Utils.extractThreadNameFromConsumerClientId;
+
 import dev.responsive.kafka.api.async.internals.AsyncThreadPoolRegistry;
 import java.time.Duration;
 import java.util.Map;
@@ -42,10 +44,12 @@ public class AsyncStreamsConsumer<K, V> extends DelegatingConsumer<K, V> {
 
   public AsyncStreamsConsumer(
       final Consumer<K, V> delegate,
+      final String clientId,
       final AsyncThreadPoolRegistry asyncThreadPoolRegistry
   ) {
     super(delegate);
-    this.streamThreadName = Thread.currentThread().getName();
+    this.streamThreadName = extractThreadNameFromConsumerClientId(clientId);
+
     this.asyncThreadPoolRegistry = asyncThreadPoolRegistry;
     final var asyncThreadPoolRegistration = asyncThreadPoolRegistry
         .startNewAsyncThreadPool(streamThreadName);

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/AsyncStreamsKafkaClientSupplier.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/AsyncStreamsKafkaClientSupplier.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2024 Responsive Computing, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package dev.responsive.kafka.internal.clients;
+
+import static dev.responsive.kafka.internal.config.ConfigUtils.eosEnabled;
+import static dev.responsive.kafka.internal.config.InternalSessionConfigs.loadAsyncThreadPoolRegistry;
+
+import dev.responsive.kafka.api.async.internals.AsyncThreadPoolRegistry;
+import dev.responsive.kafka.api.config.ResponsiveConfig;
+import java.util.Map;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.streams.KafkaClientSupplier;
+import org.apache.kafka.streams.StreamsConfig;
+
+public class AsyncStreamsKafkaClientSupplier implements KafkaClientSupplier {
+
+  private final KafkaClientSupplier delegateKafkaClientSupplier;
+  private final boolean eosEnabled;
+  private final AsyncThreadPoolRegistry asyncThreadPoolRegistry;
+
+  public AsyncStreamsKafkaClientSupplier(
+      final KafkaClientSupplier delegateKafkaClientSupplier,
+      final ResponsiveConfig responsiveConfig,
+      final StreamsConfig streamsConfig
+  ) {
+    this.delegateKafkaClientSupplier = delegateKafkaClientSupplier;
+    this.asyncThreadPoolRegistry = loadAsyncThreadPoolRegistry(responsiveConfig.originals());
+    this.eosEnabled = eosEnabled(streamsConfig);
+  }
+
+  @Override
+  public Admin getAdmin(final Map<String, Object> config) {
+    return delegateKafkaClientSupplier.getAdmin(config);
+  }
+
+  @Override
+  public Producer<byte[], byte[]> getProducer(final Map<String, Object> config) {
+    final var innerProducer = delegateKafkaClientSupplier.getProducer(config);
+
+    if (eosEnabled) {
+      return new AsyncStreamsProducer<>(innerProducer, asyncThreadPoolRegistry);
+    } else {
+      return innerProducer;
+    }
+  }
+
+  @Override
+  public Consumer<byte[], byte[]> getConsumer(final Map<String, Object> config) {
+    final var innerConsumer = delegateKafkaClientSupplier.getConsumer(config);
+
+    if (!eosEnabled) {
+      return new AsyncStreamsConsumer<>(innerConsumer, asyncThreadPoolRegistry);
+    } else {
+      return innerConsumer;
+    }
+  }
+
+  @Override
+  public Consumer<byte[], byte[]> getRestoreConsumer(final Map<String, Object> config) {
+    return delegateKafkaClientSupplier.getRestoreConsumer(config);
+  }
+
+  @Override
+  public Consumer<byte[], byte[]> getGlobalConsumer(final Map<String, Object> config) {
+    return delegateKafkaClientSupplier.getGlobalConsumer(config);
+  }
+
+}

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/AsyncStreamsKafkaClientSupplier.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/AsyncStreamsKafkaClientSupplier.java
@@ -16,8 +16,6 @@
 
 package dev.responsive.kafka.internal.clients;
 
-import static dev.responsive.kafka.internal.config.ConfigUtils.eosEnabled;
-
 import dev.responsive.kafka.api.async.internals.AsyncThreadPoolRegistry;
 import java.util.Map;
 import org.apache.kafka.clients.admin.Admin;
@@ -26,7 +24,6 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.streams.KafkaClientSupplier;
-import org.apache.kafka.streams.StreamsConfig;
 
 public class AsyncStreamsKafkaClientSupplier implements KafkaClientSupplier {
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/AsyncStreamsProducer.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/AsyncStreamsProducer.java
@@ -36,7 +36,6 @@ import org.apache.kafka.common.errors.ProducerFencedException;
 public class AsyncStreamsProducer<K, V> extends DelegatingProducer<K, V> {
 
   private final String streamThreadName;
-  private final AsyncThreadPoolRegistry asyncThreadPoolRegistry;
   private final Runnable flushAsyncProcessors;
 
   public AsyncStreamsProducer(
@@ -47,7 +46,6 @@ public class AsyncStreamsProducer<K, V> extends DelegatingProducer<K, V> {
     super(delegate);
     this.streamThreadName = extractThreadNameFromProducerClientId(clientId);
 
-    this.asyncThreadPoolRegistry = asyncThreadPoolRegistry;
     final var asyncThreadPoolRegistration = asyncThreadPoolRegistry
         .startNewAsyncThreadPool(streamThreadName);
     this.flushAsyncProcessors = asyncThreadPoolRegistration::flush;
@@ -60,8 +58,7 @@ public class AsyncStreamsProducer<K, V> extends DelegatingProducer<K, V> {
     //  tasks are not part of this commit and in theory could still be processing
     super.commitTransaction();
   }
-
-
+  
   @Override
   public void flush() {
     flushAsyncProcessors.run();

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/AsyncStreamsProducer.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/AsyncStreamsProducer.java
@@ -16,6 +16,8 @@
 
 package dev.responsive.kafka.internal.clients;
 
+import static dev.responsive.kafka.internal.utils.Utils.extractThreadNameFromProducerClientId;
+
 import dev.responsive.kafka.api.async.internals.AsyncThreadPoolRegistry;
 import java.time.Duration;
 import org.apache.kafka.clients.producer.Producer;
@@ -40,10 +42,12 @@ public class AsyncStreamsProducer<K, V> extends DelegatingProducer<K, V> {
 
   public AsyncStreamsProducer(
       final Producer<K, V> delegate,
+      final String clientId,
       final AsyncThreadPoolRegistry asyncThreadPoolRegistry
   ) {
     super(delegate);
-    this.streamThreadName = Thread.currentThread().getName();
+    this.streamThreadName = extractThreadNameFromProducerClientId(clientId);
+
     this.asyncThreadPoolRegistry = asyncThreadPoolRegistry;
     final var asyncThreadPoolRegistration = asyncThreadPoolRegistry
         .startNewAsyncThreadPool(streamThreadName);
@@ -58,14 +62,12 @@ public class AsyncStreamsProducer<K, V> extends DelegatingProducer<K, V> {
 
   @Override
   public void close() {
-    // TODO: Producer is closed on reset under EOSv2 :/
     shutdownAsyncThreadPool();
     super.close();
   }
 
   @Override
   public void close(final Duration timeout) {
-    // TODO: Producer is closed on reset under EOSv2 :/
     shutdownAsyncThreadPool();
     super.close();
   }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/AsyncStreamsProducer.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/AsyncStreamsProducer.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2024 Responsive Computing, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package dev.responsive.kafka.internal.clients;
+
+import dev.responsive.kafka.api.async.internals.AsyncThreadPoolRegistry;
+import java.time.Duration;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.common.errors.ProducerFencedException;
+
+/**
+ * Simple wrapper around the underlying ResponsiveProducer that handles async stuff under EOS.
+ * <p>
+ * The async producer has two jobs: first, it registers and manages the lifecycle of the
+ * async thread pool associated with this StreamThread. Second, it's used to make sure any
+ * pending async records get flushed through the topology before committing a transaction with
+ * those records.
+ * <p>
+ * If ALOS is used, the async producer will not be used at all and the above responsibilities
+ * fall instead to the {@link AsyncStreamsConsumer}
+ */
+public class AsyncStreamsProducer<K, V> extends DelegatingProducer<K, V> {
+
+  private final String streamThreadName;
+  private final AsyncThreadPoolRegistry asyncThreadPoolRegistry;
+  private final Runnable flushAsyncProcessors;
+
+  public AsyncStreamsProducer(
+      final Producer<K, V> delegate,
+      final AsyncThreadPoolRegistry asyncThreadPoolRegistry
+  ) {
+    super(delegate);
+    this.streamThreadName = Thread.currentThread().getName();
+    this.asyncThreadPoolRegistry = asyncThreadPoolRegistry;
+    final var asyncThreadPoolRegistration = asyncThreadPoolRegistry
+        .startNewAsyncThreadPool(streamThreadName);
+    this.flushAsyncProcessors = asyncThreadPoolRegistration::flush;
+  }
+
+  @Override
+  public void commitTransaction() throws ProducerFencedException {
+    flushAsyncProcessors.run();
+    super.commitTransaction();
+  }
+
+  @Override
+  public void close() {
+    // TODO: Producer is closed on reset under EOSv2 :/
+    shutdownAsyncThreadPool();
+    super.close();
+  }
+
+  @Override
+  public void close(final Duration timeout) {
+    // TODO: Producer is closed on reset under EOSv2 :/
+    shutdownAsyncThreadPool();
+    super.close();
+  }
+
+  private void shutdownAsyncThreadPool() {
+    if (!streamThreadName.equals(Thread.currentThread().getName())) {
+      throw new IllegalStateException(String.format(
+          "Attempted to close producer for StreamThread %s from thread %s",
+          streamThreadName, Thread.currentThread().getName())
+      );
+    }
+    asyncThreadPoolRegistry.shutdownAsyncThreadPool(streamThreadName);
+  }
+}

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/DelegatingProducer.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/DelegatingProducer.java
@@ -1,0 +1,121 @@
+/*
+ * Copyright 2024 Responsive Computing, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package dev.responsive.kafka.internal.clients;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Future;
+import org.apache.kafka.clients.consumer.ConsumerGroupMetadata;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.producer.Callback;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.errors.ProducerFencedException;
+
+public abstract class DelegatingProducer<K, V> implements Producer<K, V> {
+
+  private final Producer<K, V> delegate;
+
+  public DelegatingProducer(final Producer<K, V> delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public void initTransactions() {
+    delegate.initTransactions();
+  }
+
+  @Override
+  public void beginTransaction() throws ProducerFencedException {
+    delegate.beginTransaction();
+  }
+
+  @Override
+  @SuppressWarnings("deprecation")
+  public void sendOffsetsToTransaction(
+      final Map<TopicPartition, OffsetAndMetadata> offsets,
+      final String consumerGroupId
+  ) throws ProducerFencedException {
+    delegate.sendOffsetsToTransaction(offsets, consumerGroupId);
+  }
+
+  @Override
+  public void sendOffsetsToTransaction(
+      final Map<TopicPartition, OffsetAndMetadata> offsets,
+      final ConsumerGroupMetadata groupMetadata
+  ) throws ProducerFencedException {
+    delegate.sendOffsetsToTransaction(offsets, groupMetadata);
+  }
+
+  @Override
+  public void commitTransaction() throws ProducerFencedException {
+    delegate.commitTransaction();
+  }
+
+  @Override
+  public void abortTransaction() throws ProducerFencedException {
+    delegate.abortTransaction();
+  }
+
+  @Override
+  public Future<RecordMetadata> send(final ProducerRecord<K, V> record) {
+    return delegate.send(record);
+  }
+
+  @Override
+  public Future<RecordMetadata> send(final ProducerRecord<K, V> record, final Callback callback) {
+    return delegate.send(record, callback);
+  }
+
+  @Override
+  public void flush() {
+    delegate.flush();
+  }
+
+  @Override
+  public List<PartitionInfo> partitionsFor(final String topic) {
+    return delegate.partitionsFor(topic);
+  }
+
+  @Override
+  public Map<MetricName, ? extends Metric> metrics() {
+    return delegate.metrics();
+  }
+
+  @Override
+  public Uuid clientInstanceId(final Duration duration) {
+    return delegate.clientInstanceId(duration);
+  }
+
+  @Override
+  public void close() {
+    delegate.close();
+  }
+
+  @Override
+  public void close(final Duration timeout) {
+    delegate.close();
+  }
+
+}

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/ResponsiveConsumer.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/ResponsiveConsumer.java
@@ -35,7 +35,6 @@ public class ResponsiveConsumer<K, V> extends DelegatingConsumer<K, V> {
   private final Logger log;
 
   private final List<Listener> listeners;
-  private final Runnable shutdownAsyncThreadPool;
 
   private static class RebalanceListener implements ConsumerRebalanceListener {
     private final ConsumerRebalanceListener wrappedRebalanceListener;
@@ -80,15 +79,13 @@ public class ResponsiveConsumer<K, V> extends DelegatingConsumer<K, V> {
   public ResponsiveConsumer(
       final String clientId,
       final Consumer<K, V> delegate,
-      final List<Listener> listeners,
-      final Runnable shutdownAsyncThreadPool
+      final List<Listener> listeners
   ) {
     super(delegate);
     this.log = new LogContext(
         String.format("responsive-consumer [%s]", Objects.requireNonNull(clientId))
     ).logger(ResponsiveConsumer.class);
     this.listeners = Objects.requireNonNull(listeners);
-    this.shutdownAsyncThreadPool = shutdownAsyncThreadPool;
   }
 
   @Override
@@ -121,14 +118,12 @@ public class ResponsiveConsumer<K, V> extends DelegatingConsumer<K, V> {
 
   @Override
   public void close() {
-    shutdownAsyncThreadPool.run();
     super.close();
     listeners.forEach(l -> ignoreException(l::onClose));
   }
 
   @Override
   public void close(final Duration timeout) {
-    shutdownAsyncThreadPool.run();
     super.close(timeout);
     listeners.forEach(l -> ignoreException(l::onClose));
   }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/ResponsiveKafkaClientSupplier.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/ResponsiveKafkaClientSupplier.java
@@ -19,7 +19,6 @@ package dev.responsive.kafka.internal.clients;
 import static dev.responsive.kafka.internal.config.ConfigUtils.eosEnabled;
 import static dev.responsive.kafka.internal.utils.Utils.extractThreadId;
 import static dev.responsive.kafka.internal.utils.Utils.extractThreadNameFromConsumerClientId;
-import static org.apache.kafka.streams.StreamsConfig.AT_LEAST_ONCE;
 
 import dev.responsive.kafka.api.config.CompatibilityMode;
 import dev.responsive.kafka.api.config.ResponsiveConfig;

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/config/ConfigUtils.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/config/ConfigUtils.java
@@ -19,6 +19,7 @@ package dev.responsive.kafka.internal.config;
 import static dev.responsive.kafka.api.config.ResponsiveConfig.RESPONSIVE_APPLICATION_ID_CONFIG;
 import static dev.responsive.kafka.api.config.ResponsiveConfig.RESPONSIVE_ENV_CONFIG;
 import static dev.responsive.kafka.api.config.ResponsiveConfig.RESPONSIVE_ORG_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.AT_LEAST_ONCE;
 
 import dev.responsive.kafka.api.config.CompatibilityMode;
 import dev.responsive.kafka.api.config.ResponsiveConfig;
@@ -76,6 +77,10 @@ public class ConfigUtils {
     }
 
     return streamsConfig.getString(StreamsConfig.APPLICATION_ID_CONFIG);
+  }
+
+  public static boolean eosEnabled(final StreamsConfig configs) {
+    return !AT_LEAST_ONCE.equals(configs.getString(StreamsConfig.PROCESSING_GUARANTEE_CONFIG));
   }
 
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/config/InternalSessionConfigs.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/config/InternalSessionConfigs.java
@@ -1,7 +1,5 @@
 package dev.responsive.kafka.internal.config;
 
-import static org.apache.kafka.streams.StreamsConfig.mainConsumerPrefix;
-
 import dev.responsive.kafka.api.async.internals.AsyncThreadPoolRegistry;
 import dev.responsive.kafka.internal.metrics.ResponsiveMetrics;
 import dev.responsive.kafka.internal.stores.ResponsiveStoreRegistry;
@@ -9,7 +7,6 @@ import dev.responsive.kafka.internal.utils.SessionClients;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.kafka.streams.TopologyDescription;
-import org.apache.kafka.streams.processor.api.ProcessorContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/config/InternalSessionConfigs.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/config/InternalSessionConfigs.java
@@ -61,14 +61,6 @@ public final class InternalSessionConfigs {
     );
   }
 
-  public static boolean isAsyncThreadPoolRegistryEnabled(final Map<String, Object> configs) {
-    return configs.containsKey(INTERNAL_ASYNC_THREAD_POOL_REGISTRY_CONFIG);
-  }
-
-  // CAUTION: this method assumes the provided config map has stripped away the
-  // main.consumer prefix that was added to this config in the original Streams
-  // properties. See the javadocs below for the Builder#withAsyncThreadPoolRegistry
-  // method for more details on when it is safe to use this
   public static AsyncThreadPoolRegistry loadAsyncThreadPoolRegistry(final Map<String, Object> configs) {
     return loadFromConfig(
         configs,
@@ -108,23 +100,8 @@ public final class InternalSessionConfigs {
   public static class Builder {
     private final Map<String, Object> configs = new HashMap<>();
 
-    /**
-     * Note: we must add the main consumer prefix when first building the config
-     * map with this registry, as it is needed in the #getMainConsumer method of the
-     * KafkaClientSupplier, and only main-consumer configs are included in the copy
-     * of the config map it receives.
-     * Importantly, we should NOT include this prefix when attempting to retrieve this
-     * registry on the other end, unless you are extracting it from the original, app-wide
-     * config map. This prefix will be stripped away when the config is copied into a
-     * prefix-based submap, such as the one passed in to the KafkaClientSupplier for
-     * the main consumer or the one returned from the
-     * {@link ProcessorContext#appConfigsWithPrefix(String)} API.
-     * The {@link #loadAsyncThreadPoolRegistry(Map)} method assumes the prefix has been
-     * stripped and therefore only works on filtered submaps like in the two
-     * examples above
-     */
     public Builder withAsyncThreadPoolRegistry(final AsyncThreadPoolRegistry registry) {
-      configs.put(mainConsumerPrefix(INTERNAL_ASYNC_THREAD_POOL_REGISTRY_CONFIG), registry);
+      configs.put(INTERNAL_ASYNC_THREAD_POOL_REGISTRY_CONFIG, registry);
       return this;
     }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/metrics/ResponsiveRestoreListener.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/metrics/ResponsiveRestoreListener.java
@@ -24,7 +24,7 @@ import static dev.responsive.kafka.internal.metrics.ApplicationMetrics.NUM_RESTO
 import static dev.responsive.kafka.internal.metrics.ApplicationMetrics.NUM_RESTORING_CHANGELOGS_DESCRIPTION;
 import static dev.responsive.kafka.internal.metrics.StoreMetrics.TIME_RESTORING;
 import static dev.responsive.kafka.internal.metrics.StoreMetrics.TIME_RESTORING_DESCRIPTION;
-import static dev.responsive.kafka.internal.utils.Utils.extractThreadId;
+import static dev.responsive.kafka.internal.utils.Utils.extractThreadIdFromThreadName;
 
 import java.io.Closeable;
 import java.util.concurrent.ConcurrentHashMap;
@@ -62,7 +62,7 @@ public class ResponsiveRestoreListener implements StateRestoreListener, Closeabl
         TIME_RESTORING_DESCRIPTION,
         metrics.storeLevelMetric(
             StoreMetrics.STORE_METRIC_GROUP,
-            extractThreadId(Thread.currentThread().getName()),
+            extractThreadIdFromThreadName(Thread.currentThread().getName()),
             topicPartition,
             storeName
         )

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/CommitBuffer.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/CommitBuffer.java
@@ -34,7 +34,7 @@ import static dev.responsive.kafka.internal.metrics.StoreMetrics.FLUSH_TOTAL_DES
 import static dev.responsive.kafka.internal.metrics.StoreMetrics.STORE_METRIC_GROUP;
 import static dev.responsive.kafka.internal.metrics.StoreMetrics.TIME_SINCE_LAST_FLUSH;
 import static dev.responsive.kafka.internal.metrics.StoreMetrics.TIME_SINCE_LAST_FLUSH_DESCRIPTION;
-import static dev.responsive.kafka.internal.utils.Utils.extractThreadId;
+import static dev.responsive.kafka.internal.utils.Utils.extractThreadIdFromThreadName;
 
 import dev.responsive.kafka.api.config.ResponsiveConfig;
 import dev.responsive.kafka.internal.db.BatchFlusher;
@@ -182,7 +182,7 @@ public class CommitBuffer<K extends Comparable<K>, P>
 
     final String storeName = tableName.kafkaName();
 
-    final String streamThreadId = extractThreadId(Thread.currentThread().getName());
+    final String streamThreadId = extractThreadIdFromThreadName(Thread.currentThread().getName());
 
     flushSensorName = getSensorName(FLUSH, streamThreadId, changelog);
     flushLatencySensorName = getSensorName(FLUSH_LATENCY, streamThreadId, changelog);

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/utils/Utils.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/utils/Utils.java
@@ -20,14 +20,73 @@ import java.util.regex.Pattern;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+@SuppressWarnings("checkstyle:linelength")
 public final class Utils {
 
   private static final Logger LOG = LoggerFactory.getLogger(Utils.class);
 
-  private static final Pattern THREAD_NAME_CONSUMER_REGEX = Pattern.compile("(.*)-consumer$");
+  private static final Pattern STREAM_THREAD_ID_PRODUCER_REGEX = Pattern.compile(".*-(StreamThread-\\d+)-producer");
+  private static final Pattern STREAM_THREAD_ID_CONSUMER_REGEX = Pattern.compile(".*-(StreamThread-\\d+)-consumer");
+  private static final Pattern STREAM_THREAD_ID_RESTORE_CONSUMER_REGEX = Pattern.compile(".*-(StreamThread-\\d+)-restore-consumer");
 
-  private static final Pattern STREAM_THREAD_REGEX = Pattern.compile(".*-(StreamThread-\\d+)");
-  private static final Pattern GLOBAL_THREAD_REGEX = Pattern.compile(".*-(GlobalStreamThread+)");
+  private static final Pattern STREAM_THREAD_NAME_PRODUCER_REGEX = Pattern.compile("(.*)-producer$");
+  private static final Pattern STREAM_THREAD_NAME_CONSUMER_REGEX = Pattern.compile("(.*)-consumer$");
+
+  private static final Pattern STREAM_THREAD_ID_REGEX = Pattern.compile(".*-(StreamThread-\\d+)");
+  private static final Pattern GLOBAL_THREAD_ID_REGEX = Pattern.compile(".*-(GlobalStreamThread+)");
+
+  /**
+   * @param clientId the producer client id
+   * @return the extracted StreamThread id, of the form "StreamThread-n"
+   */
+  public static String extractThreadIdFromProducerClientId(final String clientId) {
+    final var match = STREAM_THREAD_ID_PRODUCER_REGEX.matcher(clientId);
+    if (!match.find()) {
+      LOG.error("Unable to parse thread id from producer client id = {}", clientId);
+      throw new RuntimeException("unexpected client id " + clientId);
+    }
+    return match.group(1);
+  }
+
+  /**
+   * @param clientId the consumer client id
+   * @return the extracted StreamThread id, of the form "StreamThread-n"
+   */
+  public static String extractThreadIdFromConsumerClientId(final String clientId) {
+    final var match = STREAM_THREAD_ID_CONSUMER_REGEX.matcher(clientId);
+    if (!match.find()) {
+      LOG.error("Unable to parse thread id from consumer client id = {}", clientId);
+      throw new RuntimeException("unexpected client id " + clientId);
+    }
+    return match.group(1);
+  }
+
+  /**
+   * @param clientId the restore consumer client id
+   * @return the extracted StreamThread id, of the form "StreamThread-n"
+   */
+  public static String extractThreadIdFromRestoreConsumerClientId(final String clientId) {
+    final var match = STREAM_THREAD_ID_RESTORE_CONSUMER_REGEX.matcher(clientId);
+    if (!match.find()) {
+      LOG.error("Unable to parse thread id from restore consumer client id = {}", clientId);
+      throw new RuntimeException("unexpected client id " + clientId);
+    }
+    return match.group(1);
+  }
+
+  /**
+   * @param clientId the producer client id
+   * @return the full thread name of the StreamThread that owns this producer,
+   *         of the form [processId]-StreamThread-n
+   */
+  public static String extractThreadNameFromProducerClientId(final String clientId) {
+    final var threadNameMatcher = STREAM_THREAD_NAME_PRODUCER_REGEX.matcher(clientId);
+    if (!threadNameMatcher.find()) {
+      throw new IllegalArgumentException("Attempted to extract threadName from producer clientId "
+                                             + "but no matches were found in " + clientId);
+    }
+    return threadNameMatcher.group(1);
+  }
 
   /**
    * @param clientId the consumer client id
@@ -35,13 +94,12 @@ public final class Utils {
    *         of the form [processId]-StreamThread-n
    */
   public static String extractThreadNameFromConsumerClientId(final String clientId) {
-    final var threadNameMatcher = THREAD_NAME_CONSUMER_REGEX.matcher(clientId);
+    final var threadNameMatcher = STREAM_THREAD_NAME_CONSUMER_REGEX.matcher(clientId);
     if (!threadNameMatcher.find()) {
       throw new IllegalArgumentException("Attempted to extract threadName from consumer clientId "
                                              + "but no matches were found in " + clientId);
     }
     return threadNameMatcher.group(1);
-
   }
 
   /**
@@ -49,13 +107,13 @@ public final class Utils {
    *
    * @return the entire thread suffix, eg "StreamThread-1" or "GlobalStreamThread"
    */
-  public static String extractThreadId(final String threadName) {
-    final var streamThreadMatcher = STREAM_THREAD_REGEX.matcher(threadName);
+  public static String extractThreadIdFromThreadName(final String threadName) {
+    final var streamThreadMatcher = STREAM_THREAD_ID_REGEX.matcher(threadName);
     if (streamThreadMatcher.find()) {
       return streamThreadMatcher.group(1);
     }
 
-    final var globalThreadMatcher = GLOBAL_THREAD_REGEX.matcher(threadName);
+    final var globalThreadMatcher = GLOBAL_THREAD_ID_REGEX.matcher(threadName);
     if (globalThreadMatcher.find()) {
       return globalThreadMatcher.group(1);
     }

--- a/kafka-client/src/test/java/dev/responsive/kafka/api/async/internals/AsyncThreadPoolTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/api/async/internals/AsyncThreadPoolTest.java
@@ -136,7 +136,7 @@ class AsyncThreadPoolTest {
     final var other0InFlight = Map.copyOf(pool.getInFlight("other", 0));
 
     // when:
-    pool.removeProcessor("processor", 0);
+    pool.removeProcessor(AsyncProcessorId.of("processor", 0));
 
     // then:
     for (final var t : List.of(task1, task2, task3, taskOtherPartition, taskOtherProcessor)) {
@@ -155,7 +155,7 @@ class AsyncThreadPoolTest {
     schedule("processor", 0, finalizingQueue0, event1);
 
     // when:
-    pool.removeProcessor("processor", 0);
+    pool.removeProcessor(AsyncProcessorId.of("processor", 0));
 
     // then:
     for (final var t : List.of(task1)) {

--- a/kafka-client/src/test/java/dev/responsive/kafka/async/AsyncProcessorIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/async/AsyncProcessorIntegrationTest.java
@@ -70,7 +70,10 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -475,7 +478,9 @@ public class AsyncProcessorIntegrationTest {
         asyncKVStore
     );
 
-    final List<Throwable> expectedExceptions = new LinkedList<>();
+    // needs to be concurrent since slow StreamThreads can hit the exception handler
+    // and add new elements to this while we're iterating through it during the assertions
+    final Set<Throwable> expectedExceptions = new ConcurrentSkipListSet<>();
     final List<Throwable> unexpectedExceptions = new LinkedList<>();
 
     try (final var streams = new ResponsiveKafkaStreams(builder.build(), properties)) {

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/clients/ResponsiveConsumerTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/clients/ResponsiveConsumerTest.java
@@ -57,7 +57,7 @@ class ResponsiveConsumerTest {
   @BeforeEach
   public void setup() {
     consumer = new ResponsiveConsumer<>(
-        "clientid", wrapped, List.of(listener1, listener2), () -> {});
+        "clientid", wrapped, List.of(listener1, listener2));
   }
 
   @Test

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/clients/ResponsiveKafkaClientSupplierTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/clients/ResponsiveKafkaClientSupplierTest.java
@@ -126,7 +126,7 @@ class ResponsiveKafkaClientSupplierTest {
         factories.createResponsiveProducer(any(), (ResponsiveProducer<byte[], byte[]>) any(), any())
     ).thenReturn(responsiveProducer);
     lenient().when(factories.createResponsiveConsumer(
-        any(), (ResponsiveConsumer<byte[], byte[]>) any(), any(), any())
+        any(), (ResponsiveConsumer<byte[], byte[]>) any(), any())
     ).thenReturn(responsiveConsumer);
     lenient().when(factories.createMetricsPublishingCommitListener(any(), any(), any()))
         .thenReturn(commitMetricListener);
@@ -196,7 +196,7 @@ class ResponsiveKafkaClientSupplierTest {
 
     // then:
     verify(factories).createResponsiveConsumer(
-        any(), any(), consumerListenerCaptor.capture(), any());
+        any(), any(), consumerListenerCaptor.capture());
     assertThat(consumerListenerCaptor.getValue(), Matchers.hasItem(commitMetricListener));
     verify(factories).createMetricsPublishingCommitListener(
         metrics, "StreamThread-0", offsetRecorder);
@@ -229,7 +229,7 @@ class ResponsiveKafkaClientSupplierTest {
 
     // then:
     verify(factories).createResponsiveConsumer(
-        any(), any(), consumerListenerCaptor.capture(), any());
+        any(), any(), consumerListenerCaptor.capture());
     assertThat(consumerListenerCaptor.getValue(), Matchers.hasItem(consumerEndOffsetsPollListener));
   }
 
@@ -241,7 +241,7 @@ class ResponsiveKafkaClientSupplierTest {
 
     // then:
     verify(factories).createResponsiveConsumer(
-        any(), any(), consumerListenerCaptor.capture(), any());
+        any(), any(), consumerListenerCaptor.capture());
     consumerListenerCaptor.getValue().forEach(ResponsiveConsumer.Listener::onClose);
     verify(commitMetricListener, times(0)).close();
     verify(factories).createResponsiveProducer(any(), any(), producerListenerCaptor.capture());


### PR DESCRIPTION
The general approach approach here is fairly straightforward: when there are no state stores we can use to hook into the `#flushCache` call before a commit, we simply hook into the actual clients' commit methods and flush the processors before proceeding with the commit. For ALOS apps, we flush via the consumer's `#commitSync` while with EOS we flush via the producer's `#commitTransaction`

To make this work cleanly, I extracted the async thread pool management from the ResponsiveKafkaClientSupplier/ResponsiveConsumer and put it into a new layer for all the async logic which only gets created when async processing is enabled. Similarly, we only create the async version of the relevant client and have it handle the async thread pool lifecycle -- in others, for EOS apps everything happens in the AsyncStreamsProducer and there is no AsyncStreamsConsumer, and vice versa for ALOS apps.