### PR TITLE
change mongo scans to filter client-side

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraClient.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraClient.java
@@ -36,6 +36,7 @@ import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.function.BooleanSupplier;
+import org.apache.kafka.common.utils.Bytes;
 
 /**
  * {@code CassandraClient} wraps a {@link CqlSession} with utility methods
@@ -49,10 +50,10 @@ public class CassandraClient {
   private final CqlSession session;
 
   private final ResponsiveConfig config;
-  private final TableCache<RemoteKVTable<BoundStatement>> kvFactory;
-  private final TableCache<RemoteKVTable<BoundStatement>> factFactory;
+  private final TableCache<Bytes, Integer, RemoteKVTable<BoundStatement>> kvFactory;
+  private final TableCache<Bytes, Integer, RemoteKVTable<BoundStatement>> factFactory;
   private final WindowedTableCache<RemoteWindowedTable<BoundStatement>> windowedFactory;
-  private final TableCache<CassandraFactTable> globalFactory;
+  private final TableCache<Bytes, Integer, CassandraFactTable> globalFactory;
 
   /**
    * @param session the Cassandra session, expected to be initialized
@@ -178,15 +179,15 @@ public class CassandraClient {
     session.close();
   }
 
-  public TableCache<CassandraFactTable> globalFactory() {
+  public TableCache<Bytes, Integer, CassandraFactTable> globalFactory() {
     return globalFactory;
   }
 
-  public TableCache<RemoteKVTable<BoundStatement>> kvFactory() {
+  public TableCache<Bytes, Integer, RemoteKVTable<BoundStatement>> kvFactory() {
     return kvFactory;
   }
 
-  public TableCache<RemoteKVTable<BoundStatement>> factFactory() {
+  public TableCache<Bytes, Integer, RemoteKVTable<BoundStatement>> factFactory() {
     return factFactory;
   }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraFactFlushManager.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraFactFlushManager.java
@@ -34,13 +34,14 @@ public class CassandraFactFlushManager extends KVFlushManager {
   public CassandraFactFlushManager(
       final CassandraFactTable table,
       final CassandraClient client,
-      final int kafkaPartition
+      final int kafkaPartition,
+      final TablePartitioner<Bytes, Integer> partitioner
   ) {
     this.table = table;
     this.client = client;
     this.kafkaPartition = kafkaPartition;
+    this.partitioner = partitioner;
 
-    partitioner = TablePartitioner.defaultPartitioner();
     logPrefix = String.format("%s[%d] fact-store", table.name(), kafkaPartition);
   }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraKeyValueTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraKeyValueTable.java
@@ -77,7 +77,7 @@ public class CassandraKeyValueTable implements RemoteKVTable<BoundStatement> {
   private final PreparedStatement ensureEpoch;
 
   public static CassandraKeyValueTable create(
-      final RemoteTableSpec spec,
+      final RemoteTableSpec<Bytes, Integer> spec,
       final CassandraClient client
   ) throws InterruptedException, TimeoutException {
     final String name = spec.tableName();

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraWindowedTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraWindowedTable.java
@@ -97,7 +97,7 @@ public class CassandraWindowedTable implements RemoteWindowedTable<BoundStatemen
   private final PreparedStatement ensureEpoch;
 
   public static CassandraWindowedTable create(
-      final RemoteTableSpec spec,
+      final RemoteTableSpec<WindowedKey, Segmenter.SegmentPartition> spec,
       final CassandraClient client,
       final WindowSegmentPartitioner partitioner
   ) throws InterruptedException, TimeoutException {

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/MongoKVFlushManager.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/MongoKVFlushManager.java
@@ -44,13 +44,14 @@ public class MongoKVFlushManager extends KVFlushManager {
   public MongoKVFlushManager(
       final MongoKVTable table,
       final MongoCollection<KVDoc> kvDocs,
-      final int kafkaPartition
+      final int kafkaPartition,
+      final TablePartitioner<Bytes, Integer> partitioner
   ) {
     this.table = table;
     this.kvDocs = kvDocs;
     this.kafkaPartition = kafkaPartition;
+    this.partitioner = partitioner;
 
-    partitioner = TablePartitioner.defaultPartitioner();
     logPrefix = String.format("%s[%d] kv-store {epoch=%d} ",
                               table.name(), kafkaPartition, table.localEpoch(kafkaPartition));
     log = new LogContext(logPrefix).logger(MongoKVFlushManager.class);

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/RemoteTableSpecFactory.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/RemoteTableSpecFactory.java
@@ -40,35 +40,36 @@ import org.apache.kafka.common.utils.Bytes;
  */
 public class RemoteTableSpecFactory {
 
-  public static RemoteTableSpec globalSpec(
+  public static RemoteTableSpec<Bytes, Integer> globalSpec(
       final ResponsiveKeyValueParams params,
       final TablePartitioner<Bytes, Integer> partitioner
   ) {
-    return new GlobalTableSpec(new BaseTableSpec(params.name().tableName(), partitioner));
+    return new GlobalTableSpec<>(new BaseTableSpec<>(params.name().tableName(), partitioner));
   }
 
-  public static RemoteTableSpec fromKVParams(
+  public static RemoteTableSpec<Bytes, Integer> fromKVParams(
       final ResponsiveKeyValueParams params,
       final TablePartitioner<Bytes, Integer> partitioner
   ) {
-    RemoteTableSpec spec = new BaseTableSpec(params.name().tableName(), partitioner);
+    RemoteTableSpec<Bytes, Integer> spec =
+        new BaseTableSpec<>(params.name().tableName(), partitioner);
 
     if (params.timeToLive().isPresent()) {
-      spec = new TtlTableSpec(spec, params.timeToLive().get());
+      spec = new TtlTableSpec<>(spec, params.timeToLive().get());
     }
 
     if (params.schemaType() == SchemaTypes.KVSchema.FACT) {
-      spec = new TimeWindowedCompactionTableSpec(spec);
+      spec = new TimeWindowedCompactionTableSpec<>(spec);
     }
 
     return spec;
   }
 
-  public static RemoteTableSpec fromWindowParams(
+  public static RemoteTableSpec<WindowedKey, SegmentPartition> fromWindowParams(
       final ResponsiveWindowParams params,
       final TablePartitioner<WindowedKey, SegmentPartition> partitioner
   ) {
-    return new BaseTableSpec(params.name().tableName(), partitioner);
+    return new BaseTableSpec<>(params.name().tableName(), partitioner);
   }
 
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/SessionTableCache.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/SessionTableCache.java
@@ -16,8 +16,10 @@
 
 package dev.responsive.kafka.internal.db;
 
+import dev.responsive.kafka.internal.db.partitioning.Segmenter;
 import dev.responsive.kafka.internal.db.partitioning.SessionSegmentPartitioner;
 import dev.responsive.kafka.internal.db.spec.RemoteTableSpec;
+import dev.responsive.kafka.internal.utils.SessionKey;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
@@ -28,8 +30,10 @@ public class SessionTableCache<T extends RemoteTable<?, ?>> {
 
   @FunctionalInterface
   public interface Factory<T> {
-    T create(final RemoteTableSpec spec, SessionSegmentPartitioner partitioner)
-        throws InterruptedException, TimeoutException;
+    T create(
+        final RemoteTableSpec<SessionKey, Segmenter.SegmentPartition> spec,
+        SessionSegmentPartitioner partitioner
+    ) throws InterruptedException, TimeoutException;
   }
 
   private final Map<String, T> tables = new HashMap<>();
@@ -43,7 +47,10 @@ public class SessionTableCache<T extends RemoteTable<?, ?>> {
    * Creates a table with the supplied {@code tableName} with the
    * desired schema.
    */
-  public synchronized T create(RemoteTableSpec spec, SessionSegmentPartitioner partitioner)
+  public synchronized T create(
+      RemoteTableSpec<SessionKey, Segmenter.SegmentPartition> spec,
+      SessionSegmentPartitioner partitioner
+  )
       throws InterruptedException, TimeoutException {
     final T existing = tables.get(spec.tableName());
     if (existing != null) {

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/TableCache.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/TableCache.java
@@ -28,18 +28,18 @@ import javax.annotation.concurrent.ThreadSafe;
  * table are only prepared once during the lifetime of the application.
  */
 @ThreadSafe
-public class TableCache<T extends RemoteTable<?, ?>> {
+public class TableCache<K, V, T extends RemoteTable<?, ?>> {
 
   @FunctionalInterface
-  public interface Factory<T> {
-    T create(final RemoteTableSpec spec)
+  public interface Factory<K, V, T> {
+    T create(final RemoteTableSpec<K, V> spec)
         throws InterruptedException, TimeoutException;
   }
 
   private final Map<String, T> tables = new HashMap<>();
-  private final Factory<T> factory;
+  private final Factory<K, V, T> factory;
 
-  public TableCache(final Factory<T> factory) {
+  public TableCache(final Factory<K, V, T> factory) {
     this.factory = factory;
   }
 
@@ -47,7 +47,7 @@ public class TableCache<T extends RemoteTable<?, ?>> {
    * Creates a table with the supplied {@code tableName} with the
    * desired schema.
    */
-  public synchronized T create(RemoteTableSpec spec)
+  public synchronized T create(RemoteTableSpec<K, V> spec)
       throws InterruptedException, TimeoutException {
     final T existing = tables.get(spec.tableName());
     if (existing != null) {

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/WindowedTableCache.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/WindowedTableCache.java
@@ -16,8 +16,10 @@
 
 package dev.responsive.kafka.internal.db;
 
+import dev.responsive.kafka.internal.db.partitioning.Segmenter;
 import dev.responsive.kafka.internal.db.partitioning.WindowSegmentPartitioner;
 import dev.responsive.kafka.internal.db.spec.RemoteTableSpec;
+import dev.responsive.kafka.internal.utils.WindowedKey;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
@@ -28,7 +30,10 @@ public class WindowedTableCache<T extends RemoteTable<?, ?>> {
 
   @FunctionalInterface
   public interface Factory<T> {
-    T create(final RemoteTableSpec spec, WindowSegmentPartitioner partitioner)
+    T create(
+        final RemoteTableSpec<WindowedKey, Segmenter.SegmentPartition> spec,
+        WindowSegmentPartitioner partitioner
+    )
         throws InterruptedException, TimeoutException;
   }
 
@@ -43,7 +48,10 @@ public class WindowedTableCache<T extends RemoteTable<?, ?>> {
    * Creates a table with the supplied {@code tableName} with the
    * desired schema.
    */
-  public synchronized T create(RemoteTableSpec spec, WindowSegmentPartitioner partitioner)
+  public synchronized T create(
+      RemoteTableSpec<WindowedKey, Segmenter.SegmentPartition> spec,
+      WindowSegmentPartitioner partitioner
+  )
       throws InterruptedException, TimeoutException {
     final T existing = tables.get(spec.tableName());
     if (existing != null) {

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/inmemory/InMemoryKVTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/inmemory/InMemoryKVTable.java
@@ -142,6 +142,11 @@ public class InMemoryKVTable implements RemoteKVTable<Object> {
         public Integer metadataTablePartition(int kafkaPartition) {
           return kafkaPartition;
         }
+
+        @Override
+        public boolean belongs(final Bytes key, final int kafkaPartition) {
+          return kafkaPartition == InMemoryKVTable.this.kafkaPartition;
+        }
       };
     }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/KVDoc.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/KVDoc.java
@@ -29,7 +29,6 @@ public class KVDoc {
   public static final String VALUE = "value";
   public static final String EPOCH = "epoch";
   public static final String TIMESTAMP = "ts";
-  public static final String KAFKA_PARTITION = "partition";
   public static final String TOMBSTONE_TS = "tombstoneTs";
 
   // We use a string key for ID because mongo range scans don't work as expected for binary
@@ -39,7 +38,6 @@ public class KVDoc {
   byte[] value;
   long epoch;
   long timestamp;
-  int kafkaPartition;
   Date tombstoneTs;
 
   public KVDoc() {
@@ -50,14 +48,12 @@ public class KVDoc {
       @BsonProperty(ID) String id,
       @BsonProperty(VALUE) byte[] value,
       @BsonProperty(EPOCH) long epoch,
-      @BsonProperty(TIMESTAMP) long timestamp,
-      @BsonProperty(KAFKA_PARTITION) int kafkaPartition
+      @BsonProperty(TIMESTAMP) long timestamp
   ) {
     this.id = id;
     this.value = value;
     this.epoch = epoch;
     this.timestamp = timestamp;
-    this.kafkaPartition = kafkaPartition;
   }
 
   public String getKey() {
@@ -92,14 +88,6 @@ public class KVDoc {
     return timestamp;
   }
 
-  public int getKafkaPartition() {
-    return kafkaPartition;
-  }
-
-  public void setKafkaPartition(final int kafkaPartition) {
-    this.kafkaPartition = kafkaPartition;
-  }
-
   public Date getTombstoneTs() {
     return tombstoneTs;
   }
@@ -120,14 +108,12 @@ public class KVDoc {
     return epoch == kvDoc.epoch
         && Objects.equals(id, kvDoc.id)
         && Arrays.equals(value, kvDoc.value)
-        && Objects.equals(timestamp, kvDoc.timestamp)
-        && Objects.equals(kafkaPartition, kvDoc.kafkaPartition)
         && Objects.equals(tombstoneTs, kvDoc.tombstoneTs);
   }
 
   @Override
   public int hashCode() {
-    int result = Objects.hash(id, epoch, tombstoneTs, timestamp, kafkaPartition);
+    int result = Objects.hash(id, epoch, tombstoneTs);
     result = 31 * result + Arrays.hashCode(value);
     return result;
   }
@@ -139,8 +125,6 @@ public class KVDoc {
         + ", value=" + Arrays.toString(value)
         + ", epoch=" + epoch
         + ", tombstoneTs=" + tombstoneTs
-        + ", timestamp=" + timestamp
-        + ", kafkaPartition=" + kafkaPartition
         + '}';
   }
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/ResponsiveMongoClient.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/ResponsiveMongoClient.java
@@ -30,10 +30,11 @@ import dev.responsive.kafka.internal.db.partitioning.WindowSegmentPartitioner;
 import dev.responsive.kafka.internal.db.spec.BaseTableSpec;
 import dev.responsive.kafka.internal.db.spec.TtlTableSpec;
 import java.util.concurrent.TimeoutException;
+import org.apache.kafka.common.utils.Bytes;
 
 public class ResponsiveMongoClient {
 
-  private final TableCache<MongoKVTable> kvTableCache;
+  private final TableCache<Bytes, Integer, MongoKVTable> kvTableCache;
   private final WindowedTableCache<MongoWindowedTable> windowTableCache;
   private final SessionTableCache<MongoSessionTable> sessionTableCache;
   private final MongoClient client;
@@ -49,7 +50,8 @@ public class ResponsiveMongoClient {
             client,
             spec.tableName(),
             collectionCreationOptions,
-            spec instanceof TtlTableSpec ? ((TtlTableSpec) spec).ttl() : null
+            spec instanceof TtlTableSpec ? ((TtlTableSpec) spec).ttl() : null,
+            spec.partitioner()
         ));
     windowTableCache = new WindowedTableCache<>(
         (spec, partitioner) -> new MongoWindowedTable(
@@ -70,23 +72,26 @@ public class ResponsiveMongoClient {
     );
   }
 
-  public RemoteKVTable<WriteModel<KVDoc>> kvTable(final String name)
+  public RemoteKVTable<WriteModel<KVDoc>> kvTable(
+      final String name,
+      final TablePartitioner<Bytes, Integer> partitioner
+  )
       throws InterruptedException, TimeoutException {
-    return kvTableCache.create(new BaseTableSpec(name, TablePartitioner.defaultPartitioner()));
+    return kvTableCache.create(new BaseTableSpec<>(name, partitioner));
   }
 
   public RemoteWindowedTable<WriteModel<WindowDoc>> windowedTable(
       final String name,
       final WindowSegmentPartitioner partitioner
   ) throws InterruptedException, TimeoutException {
-    return windowTableCache.create(new BaseTableSpec(name, partitioner), partitioner);
+    return windowTableCache.create(new BaseTableSpec<>(name, partitioner), partitioner);
   }
 
   public RemoteSessionTable<WriteModel<SessionDoc>> sessionTable(
       final String name,
       final SessionSegmentPartitioner partitioner
   ) throws InterruptedException, TimeoutException {
-    return sessionTableCache.create(new BaseTableSpec(name, partitioner), partitioner);
+    return sessionTableCache.create(new BaseTableSpec<>(name, partitioner), partitioner);
   }
 
   public void close() {

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/partitioning/DefaultPartitioner.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/partitioning/DefaultPartitioner.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.kafka.internal.db.partitioning;
+
+import org.apache.kafka.clients.producer.internals.BuiltInPartitioner;
+import org.apache.kafka.common.utils.Bytes;
+
+/**
+ * A default, no-op partitioner that is one-to-one with the Kafka partition
+ * and has only a single dimension to the partitioning key
+ *
+ * @param <K> the record key type
+ */
+public class DefaultPartitioner<K> implements TablePartitioner<K, Integer> {
+
+  private final int numPartitions;
+
+  public DefaultPartitioner(final int numPartitions) {
+    this.numPartitions = numPartitions;
+  }
+
+  @Override
+  public Integer tablePartition(final int kafkaPartition, final K key) {
+    return kafkaPartition;
+  }
+
+  @Override
+  public Integer metadataTablePartition(final int kafkaPartition) {
+    return kafkaPartition;
+  }
+
+  @Override
+  public boolean belongs(final Bytes key, final int kafkaPartition) {
+    return BuiltInPartitioner.partitionForKey(key.get(), numPartitions) == kafkaPartition;
+  }
+
+}

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/partitioning/GlobalPartitioner.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/partitioning/GlobalPartitioner.java
@@ -14,21 +14,23 @@
  * limitations under the License.
  */
 
-package dev.responsive.kafka.internal.db.spec;
+package dev.responsive.kafka.internal.db.partitioning;
 
-import com.datastax.oss.driver.api.querybuilder.SchemaBuilder;
-import com.datastax.oss.driver.api.querybuilder.schema.CreateTableWithOptions;
+import org.apache.kafka.common.utils.Bytes;
 
-public class GlobalTableSpec<K, V> extends DelegatingTableSpec<K, V> {
+/**
+ * Partitioner that is used only for global tables
+ */
+public class GlobalPartitioner<K> extends DefaultPartitioner<K> {
 
-  public GlobalTableSpec(final RemoteTableSpec<K, V> delegate) {
-    super(delegate);
+  public GlobalPartitioner() {
+    super(0);
   }
 
   @Override
-  public CreateTableWithOptions applyOptions(final CreateTableWithOptions base) {
-    return delegate()
-        .applyOptions(base)
-        .withCompaction(SchemaBuilder.leveledCompactionStrategy());
+  public boolean belongs(final Bytes key, final int kafkaPartition) {
+    // never filter out anything with global tables
+    return true;
   }
+
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/partitioning/SessionSegmentPartitioner.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/partitioning/SessionSegmentPartitioner.java
@@ -17,6 +17,7 @@
 package dev.responsive.kafka.internal.db.partitioning;
 
 import dev.responsive.kafka.internal.utils.SessionKey;
+import org.apache.kafka.common.utils.Bytes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,6 +47,15 @@ public class SessionSegmentPartitioner implements
   @Override
   public Segmenter.SegmentPartition metadataTablePartition(final int kafkaPartition) {
     return new Segmenter.SegmentPartition(kafkaPartition, METADATA_SEGMENT_ID);
+  }
+
+  @Override
+  public boolean belongs(final Bytes key, final int kafkaPartition) {
+    throw new UnsupportedOperationException(
+        "SessionSegmentPartitioner relies on specific mapping of kafka partition to key. This "
+            + "method should not be called as the assumption is that only keys "
+            + "stored for the given partition will be returned. If this exception "
+            + "is seen in production please file a ticket with the Responsive team.");
   }
 
   public Segmenter segmenter() {

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/partitioning/SubPartitioner.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/partitioning/SubPartitioner.java
@@ -105,6 +105,15 @@ public class SubPartitioner implements TablePartitioner<Bytes, Integer> {
     return first(kafkaPartition);
   }
 
+  @Override
+  public boolean belongs(final Bytes key, final int kafkaPartition) {
+    throw new UnsupportedOperationException(
+        "SubPartitioner relies on specific mapping of kafka partition to key. This "
+            + "method should not be called as the assumption is that only keys "
+            + "stored for the given partition will be returned. If this exception "
+            + "is seen in production please file a ticket with the Responsive team.");
+  }
+
   /**
    * @param kafkaPartition the original kafka partition
    *

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/partitioning/TablePartitioner.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/partitioning/TablePartitioner.java
@@ -16,6 +16,8 @@
 
 package dev.responsive.kafka.internal.db.partitioning;
 
+import org.apache.kafka.common.utils.Bytes;
+
 public interface TablePartitioner<K, P> {
 
   /**
@@ -31,27 +33,15 @@ public interface TablePartitioner<K, P> {
    */
   P metadataTablePartition(final int kafkaPartition);
 
-  static <K> TablePartitioner<K, Integer> defaultPartitioner() {
-    return new DefaultPartitioner<>();
-  }
-
   /**
-   * A default, no-op partitioner that is one-to-one with the Kafka partition
-   * and has only a single dimension to the partitioning key
-   *
-   * @param <K> the record key type
+   * @param key             the data key
+   * @param kafkaPartition  the partition in kafka
+   * @return whether {@code key} belongs in {@code kafkaPartition}
    */
-  class DefaultPartitioner<K> implements TablePartitioner<K, Integer> {
+  boolean belongs(final Bytes key, final int kafkaPartition);
 
-    @Override
-    public Integer tablePartition(final int kafkaPartition, final K key) {
-      return kafkaPartition;
-    }
-
-    @Override
-    public Integer metadataTablePartition(final int kafkaPartition) {
-      return kafkaPartition;
-    }
-
+  static <K> TablePartitioner<K, Integer> defaultPartitioner(final int numPartitions) {
+    return new DefaultPartitioner<>(numPartitions);
   }
+
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/partitioning/WindowSegmentPartitioner.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/partitioning/WindowSegmentPartitioner.java
@@ -17,6 +17,7 @@
 package dev.responsive.kafka.internal.db.partitioning;
 
 import dev.responsive.kafka.internal.utils.WindowedKey;
+import org.apache.kafka.common.utils.Bytes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,6 +53,15 @@ public class WindowSegmentPartitioner implements
   @Override
   public Segmenter.SegmentPartition metadataTablePartition(final int kafkaPartition) {
     return new Segmenter.SegmentPartition(kafkaPartition, METADATA_SEGMENT_ID);
+  }
+
+  @Override
+  public boolean belongs(final Bytes key, final int kafkaPartition) {
+    throw new UnsupportedOperationException(
+        "WindowSegmentPartitioner relies on specific mapping of kafka partition to key. This "
+            + "method should not be called as the assumption is that only keys "
+            + "stored for the given partition will be returned. If this exception "
+            + "is seen in production please file a ticket with the Responsive team.");
   }
 
   public Segmenter segmenter() {

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/spec/BaseTableSpec.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/spec/BaseTableSpec.java
@@ -21,12 +21,12 @@ import dev.responsive.kafka.internal.db.TableOperations;
 import dev.responsive.kafka.internal.db.partitioning.TablePartitioner;
 import java.util.EnumSet;
 
-public class BaseTableSpec implements RemoteTableSpec {
+public class BaseTableSpec<K, V> implements RemoteTableSpec<K, V> {
 
   private final String name;
-  final TablePartitioner<?, ?> partitioner;
+  final TablePartitioner<K, V> partitioner;
 
-  public BaseTableSpec(final String name, final TablePartitioner<?, ?> partitioner) {
+  public BaseTableSpec(final String name, final TablePartitioner<K, V> partitioner) {
     this.name = name;
     this.partitioner = partitioner;
   }
@@ -37,7 +37,7 @@ public class BaseTableSpec implements RemoteTableSpec {
   }
 
   @Override
-  public TablePartitioner<?, ?> partitioner() {
+  public TablePartitioner<K, V> partitioner() {
     return partitioner;
   }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/spec/DelegatingTableSpec.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/spec/DelegatingTableSpec.java
@@ -21,11 +21,11 @@ import dev.responsive.kafka.internal.db.TableOperations;
 import dev.responsive.kafka.internal.db.partitioning.TablePartitioner;
 import java.util.EnumSet;
 
-public abstract class DelegatingTableSpec implements RemoteTableSpec {
+public abstract class DelegatingTableSpec<K, V> implements RemoteTableSpec<K, V> {
 
-  private final RemoteTableSpec delegate;
+  private final RemoteTableSpec<K, V> delegate;
 
-  protected DelegatingTableSpec(final RemoteTableSpec delegate) {
+  protected DelegatingTableSpec(final RemoteTableSpec<K, V> delegate) {
     this.delegate = delegate;
   }
 
@@ -35,7 +35,7 @@ public abstract class DelegatingTableSpec implements RemoteTableSpec {
   }
 
   @Override
-  public TablePartitioner<?, ?> partitioner() {
+  public TablePartitioner<K, V> partitioner() {
     return delegate.partitioner();
   }
 
@@ -49,7 +49,7 @@ public abstract class DelegatingTableSpec implements RemoteTableSpec {
     return delegate.applyOptions(base);
   }
 
-  public RemoteTableSpec delegate() {
+  public RemoteTableSpec<K, V> delegate() {
     return delegate;
   }
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/spec/RemoteTableSpec.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/spec/RemoteTableSpec.java
@@ -26,11 +26,11 @@ import java.util.EnumSet;
  * Defines the table specifications for a {@link RemoteTable} that are
  * independent of the schema of the table.
  */
-public interface RemoteTableSpec {
+public interface RemoteTableSpec<K, V> {
 
   String tableName();
 
-  TablePartitioner<?, ?> partitioner();
+  TablePartitioner<K, V> partitioner();
 
   /**
    * @return the set of operations that are not supported by this table

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/spec/TimeWindowedCompactionTableSpec.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/spec/TimeWindowedCompactionTableSpec.java
@@ -24,9 +24,9 @@ import java.time.Duration;
 import java.util.EnumSet;
 import java.util.concurrent.TimeUnit;
 
-public class TimeWindowedCompactionTableSpec extends DelegatingTableSpec {
+public class TimeWindowedCompactionTableSpec<K, V> extends DelegatingTableSpec<K, V> {
 
-  public TimeWindowedCompactionTableSpec(final RemoteTableSpec delegate) {
+  public TimeWindowedCompactionTableSpec(final RemoteTableSpec<K, V> delegate) {
     super(delegate);
   }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/spec/TtlTableSpec.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/spec/TtlTableSpec.java
@@ -19,11 +19,11 @@ package dev.responsive.kafka.internal.db.spec;
 import com.datastax.oss.driver.api.querybuilder.schema.CreateTableWithOptions;
 import java.time.Duration;
 
-public class TtlTableSpec extends DelegatingTableSpec {
+public class TtlTableSpec<K, V> extends DelegatingTableSpec<K, V> {
 
   private final Duration ttl;
 
-  public TtlTableSpec(final RemoteTableSpec delegate, final Duration ttl) {
+  public TtlTableSpec(final RemoteTableSpec<K, V> delegate, final Duration ttl) {
     super(delegate);
     this.ttl = ttl;
   }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/GlobalOperations.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/GlobalOperations.java
@@ -17,12 +17,12 @@
 package dev.responsive.kafka.internal.stores;
 
 import static dev.responsive.kafka.internal.config.InternalSessionConfigs.loadSessionClients;
-import static dev.responsive.kafka.internal.db.partitioning.TablePartitioner.defaultPartitioner;
 
 import dev.responsive.kafka.api.stores.ResponsiveKeyValueParams;
 import dev.responsive.kafka.internal.db.CassandraClient;
 import dev.responsive.kafka.internal.db.CassandraFactTable;
 import dev.responsive.kafka.internal.db.RemoteTableSpecFactory;
+import dev.responsive.kafka.internal.db.partitioning.GlobalPartitioner;
 import dev.responsive.kafka.internal.metrics.ResponsiveRestoreListener;
 import dev.responsive.kafka.internal.utils.SessionClients;
 import java.util.Collection;
@@ -59,7 +59,7 @@ public class GlobalOperations implements KeyValueOperations {
 
     final SessionClients sessionClients = loadSessionClients(appConfigs);
     final var client = sessionClients.cassandraClient();
-    final var spec = RemoteTableSpecFactory.globalSpec(params, defaultPartitioner());
+    final var spec = RemoteTableSpecFactory.globalSpec(params, new GlobalPartitioner<>());
 
     final var table = client.globalFactory().create(spec);
     table.init(IGNORED_PARTITION);

--- a/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveKeyValueStoreRestoreIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveKeyValueStoreRestoreIntegrationTest.java
@@ -375,11 +375,14 @@ public class ResponsiveKeyValueStoreRestoreIntegrationTest {
               changelog.topic()
           );
           table = cassandraClient.kvFactory()
-              .create(new BaseTableSpec(aggName(), partitioner));
+              .create(new BaseTableSpec<>(aggName(), partitioner));
           break;
         case FACT:
           table = cassandraClient.factFactory()
-              .create(new BaseTableSpec(aggName(), TablePartitioner.defaultPartitioner()));
+              .create(new BaseTableSpec<>(
+                  aggName(),
+                  TablePartitioner.defaultPartitioner(NUM_PARTITIONS)
+              ));
           break;
         default:
           throw new IllegalArgumentException("Unexpected type " + type);
@@ -396,7 +399,8 @@ public class ResponsiveKeyValueStoreRestoreIntegrationTest {
       table = new MongoKVTable(
           mongoClient,
           aggName(),
-          CollectionCreationOptions.fromConfig(config)
+          CollectionCreationOptions.fromConfig(config),
+          TablePartitioner.defaultPartitioner(NUM_PARTITIONS)
       );
       table.init(0);
     } else {

--- a/kafka-client/src/test/java/dev/responsive/kafka/integration/TablePartitionerIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/integration/TablePartitionerIntegrationTest.java
@@ -182,7 +182,7 @@ public class TablePartitionerIntegrationTest {
           storeName + "-changelog"
       );
       final CassandraKeyValueTable table = CassandraKeyValueTable.create(
-          new BaseTableSpec(cassandraName, partitioner), client);
+          new BaseTableSpec<>(cassandraName, partitioner), client);
 
       assertThat(client.numPartitions(cassandraName), is(OptionalInt.of(32)));
       assertThat(client.count(cassandraName, 0), is(2L));
@@ -230,9 +230,11 @@ public class TablePartitionerIntegrationTest {
           properties
       );
       final String cassandraName = new TableName(storeName).tableName();
-      final var partitioner = TablePartitioner.defaultPartitioner();
       final CassandraFactTable table = CassandraFactTable.create(
-          new BaseTableSpec(cassandraName, partitioner), client);
+          new BaseTableSpec<>(
+              cassandraName,
+              TablePartitioner.defaultPartitioner(NUM_PARTITIONS_INPUT)
+          ), client);
 
       final var offset0 = table.fetchOffset(0);
       final var offset1 = table.fetchOffset(1);
@@ -311,7 +313,7 @@ public class TablePartitionerIntegrationTest {
           storeName + "-changelog"
       );
       final CassandraKeyValueTable table = CassandraKeyValueTable.create(
-          new BaseTableSpec(cassandraName, partitioner), client);
+          new BaseTableSpec<>(cassandraName, partitioner), client);
 
       assertThat(client.numPartitions(cassandraName), is(OptionalInt.of(32)));
       assertThat(client.count(cassandraName, 0), is(2L));

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/CassandraFactTableIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/CassandraFactTableIntegrationTest.java
@@ -73,7 +73,7 @@ class CassandraFactTableIntegrationTest {
     final String tableName = params.name().tableName();
     final CassandraFactTable schema = (CassandraFactTable) client
         .factFactory()
-        .create(RemoteTableSpecFactory.fromKVParams(params, defaultPartitioner()));
+        .create(RemoteTableSpecFactory.fromKVParams(params, defaultPartitioner(1)));
 
     // When:
     final var token = schema.init(1);
@@ -105,7 +105,7 @@ class CassandraFactTableIntegrationTest {
 
     // When:
     client.factFactory()
-        .create(RemoteTableSpecFactory.fromKVParams(params, defaultPartitioner()));
+        .create(RemoteTableSpecFactory.fromKVParams(params, defaultPartitioner(1)));
 
     // Then:
     final var table = session.getMetadata()
@@ -132,7 +132,7 @@ class CassandraFactTableIntegrationTest {
 
     // When:
     client.factFactory()
-        .create(RemoteTableSpecFactory.fromKVParams(params, defaultPartitioner()));
+        .create(RemoteTableSpecFactory.fromKVParams(params, defaultPartitioner(1)));
 
     // Then:
     final var table = session.getMetadata()
@@ -151,7 +151,7 @@ class CassandraFactTableIntegrationTest {
     params = ResponsiveKeyValueParams.fact(storeName);
     final RemoteKVTable<BoundStatement> table = client
         .factFactory()
-        .create(RemoteTableSpecFactory.fromKVParams(params, defaultPartitioner()));
+        .create(RemoteTableSpecFactory.fromKVParams(params, defaultPartitioner(1)));
 
     table.init(1);
 
@@ -177,7 +177,7 @@ class CassandraFactTableIntegrationTest {
 
     final RemoteKVTable<BoundStatement> table = client
         .factFactory()
-        .create(RemoteTableSpecFactory.fromKVParams(params, defaultPartitioner()));
+        .create(RemoteTableSpecFactory.fromKVParams(params, defaultPartitioner(1)));
 
     table.init(1);
 

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/CassandraKVTableIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/CassandraKVTableIntegrationTest.java
@@ -82,7 +82,7 @@ public class CassandraKVTableIntegrationTest {
         name + "-changelog"
     );
     table = CassandraKeyValueTable.create(
-        new BaseTableSpec(name, partitioner), client);
+        new BaseTableSpec<>(name, partitioner), client);
   }
 
   @Test

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/CommitBufferTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/CommitBufferTest.java
@@ -186,7 +186,7 @@ public class CommitBufferTest {
 
     sessionClients.initialize(responsiveMetrics, null);
     table = (CassandraKeyValueTable) client.kvFactory().create(
-        new BaseTableSpec(name, partitioner));
+        new BaseTableSpec<>(name, partitioner));
     changelog = new TopicPartition(name + "-changelog", KAFKA_PARTITION);
 
     when(admin.deleteRecords(Mockito.any())).thenReturn(new DeleteRecordsResult(Map.of(

--- a/kafka-client/src/test/java/dev/responsive/kafka/testutils/MultiStateStoreContext.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/testutils/MultiStateStoreContext.java
@@ -106,6 +106,7 @@ public class MultiStateStoreContext implements InvocationHandler, StateRestoreCa
 
   @Override
   public void restore(final byte[] bytes, final byte[] bytes1) {
+    // TODO: this fails restoration for RecordBatchingStateRestoreCallback (used in RocksDB)
     this.restoreCallbacks.forEach(callback -> callback.restore(bytes, bytes1));
   }
 

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/internal/clients/TTDCassandraClient.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/internal/clients/TTDCassandraClient.java
@@ -37,6 +37,7 @@ import dev.responsive.kafka.internal.utils.RemoteMonitor;
 import java.time.Duration;
 import java.util.OptionalInt;
 import java.util.concurrent.CompletionStage;
+import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.Time;
 
 public class TTDCassandraClient extends CassandraClient {
@@ -44,7 +45,7 @@ public class TTDCassandraClient extends CassandraClient {
   private final ResponsiveStoreRegistry storeRegistry = new ResponsiveStoreRegistry();
   private final TTDMockAdmin admin;
 
-  private final TableCache<RemoteKVTable<BoundStatement>> kvFactory;
+  private final TableCache<Bytes, Integer, RemoteKVTable<BoundStatement>> kvFactory;
   private final WindowedTableCache<RemoteWindowedTable<BoundStatement>> windowedFactory;
 
   public TTDCassandraClient(final TTDMockAdmin admin, final Time time) {
@@ -120,12 +121,12 @@ public class TTDCassandraClient extends CassandraClient {
   }
 
   @Override
-  public TableCache<RemoteKVTable<BoundStatement>> kvFactory() {
+  public TableCache<Bytes, Integer, RemoteKVTable<BoundStatement>> kvFactory() {
     return kvFactory;
   }
 
   @Override
-  public TableCache<RemoteKVTable<BoundStatement>> factFactory() {
+  public TableCache<Bytes, Integer, RemoteKVTable<BoundStatement>> factFactory() {
     return kvFactory;
   }
 

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/internal/db/TTDWindowedTable.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/internal/db/TTDWindowedTable.java
@@ -18,6 +18,7 @@ package dev.responsive.kafka.internal.db;
 
 import com.datastax.oss.driver.api.core.cql.BoundStatement;
 import dev.responsive.kafka.internal.clients.TTDCassandraClient;
+import dev.responsive.kafka.internal.db.partitioning.Segmenter;
 import dev.responsive.kafka.internal.db.partitioning.Segmenter.SegmentPartition;
 import dev.responsive.kafka.internal.db.partitioning.TablePartitioner;
 import dev.responsive.kafka.internal.db.partitioning.WindowSegmentPartitioner;
@@ -36,7 +37,7 @@ public class TTDWindowedTable extends TTDTable<WindowedKey>
   private final WindowSegmentPartitioner partitioner;
 
   public static TTDWindowedTable create(
-      final RemoteTableSpec spec,
+      final RemoteTableSpec<WindowedKey, Segmenter.SegmentPartition> spec,
       final CassandraClient client,
       final WindowSegmentPartitioner partitioner
   ) {
@@ -44,7 +45,7 @@ public class TTDWindowedTable extends TTDTable<WindowedKey>
   }
 
   public TTDWindowedTable(
-      final RemoteTableSpec spec,
+      final RemoteTableSpec<WindowedKey, Segmenter.SegmentPartition> spec,
       final TTDCassandraClient client,
       WindowSegmentPartitioner partitioner
   ) {


### PR DESCRIPTION
Turns out this was a bit more of a refactoring nightmare than I wanted it to be! Strategy was to pass in alongside the `TablePartitioner` a method that allows us to determine whether or not a key belongs to a Kafka partition. We can consider refactoring that to return a specific partition instead of whether or not a key "belongs" in a given one, but this makes it simpler to bypass the method in cases where it doesn't need to be implemented.

90% of this PR is just adding generics all over the place to somewhere that were necessary to get the `TablePartitioner` piped into the tables instead of being created in the flush manager