### PR TITLE
initial commit for spring boot compatbility (JDK 17)

### DIFF
--- a/responsive-spring/build.gradle.kts
+++ b/responsive-spring/build.gradle.kts
@@ -1,0 +1,76 @@
+import java.io.ByteArrayOutputStream
+
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+plugins {
+    id("responsive.java-library-conventions")
+    id("java")
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(17))
+    }
+}
+
+/*********** Generated Resources ***********/
+
+val gitCommitId: String by lazy {
+    val stdout = ByteArrayOutputStream()
+    //rootProject.exec {
+    exec {
+        commandLine("git", "rev-parse", "--verify", "--short", "HEAD")
+        standardOutput = stdout
+    }
+    stdout.toString().trim()
+}
+
+val writeVersionPropertiesFile = "writeVersionPropertiesFile"
+val gitVersion = version
+
+val resourcesDir = "$buildDir/resources/main"
+val versionFilePath = "$resourcesDir/version.properties"
+
+tasks.register(writeVersionPropertiesFile) {
+    val versionFile = file(versionFilePath)
+    outputs.file(versionFile)
+    doFirst {
+        file(versionFilePath).writeText(
+                "git.build.version=" + gitVersion + "\n" +
+                        "git.commit.id=" + gitCommitId + "\n"
+        )
+    }
+}
+
+tasks.compileJava {
+    dependsOn(tasks[writeVersionPropertiesFile])
+}
+
+tasks.publishToMavenLocal {
+    dependsOn(tasks[writeVersionPropertiesFile])
+}
+
+tasks.publish {
+    dependsOn(tasks[writeVersionPropertiesFile])
+}
+
+dependencies {
+    api(project(":kafka-client"))
+    implementation("com.google.code.findbugs:jsr305:3.0.2")
+    implementation("org.springframework.kafka:spring-kafka:3.2.4")
+    implementation("org.springframework.boot:spring-boot-starter:3.3.2")
+}

--- a/responsive-spring/build.gradle.kts
+++ b/responsive-spring/build.gradle.kts
@@ -73,4 +73,6 @@ dependencies {
     implementation("com.google.code.findbugs:jsr305:3.0.2")
     implementation("org.springframework.kafka:spring-kafka:3.2.4")
     implementation("org.springframework.boot:spring-boot-starter:3.3.2")
+
+    testImplementation(testlibs.bundles.base)
 }

--- a/responsive-spring/src/main/java/dev/responsive/spring/annotations/EnableResponsive.java
+++ b/responsive-spring/src/main/java/dev/responsive/spring/annotations/EnableResponsive.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.spring.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.context.annotation.Import;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Import(ResponsiveDefaultConfiguration.class)
+public @interface EnableResponsive {
+}

--- a/responsive-spring/src/main/java/dev/responsive/spring/annotations/ResponsiveDefaultConfiguration.java
+++ b/responsive-spring/src/main/java/dev/responsive/spring/annotations/ResponsiveDefaultConfiguration.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.spring.annotations;
+
+import dev.responsive.spring.config.ResponsiveFactoryBean;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.UnsatisfiedDependencyException;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.KafkaStreamsDefaultConfiguration;
+import org.springframework.kafka.config.KafkaStreamsConfiguration;
+import org.springframework.kafka.config.StreamsBuilderFactoryBean;
+import org.springframework.kafka.config.StreamsBuilderFactoryBeanConfigurer;
+
+@Configuration(proxyBeanMethods = false)
+public class ResponsiveDefaultConfiguration extends KafkaStreamsDefaultConfiguration {
+
+  @Bean(name = DEFAULT_STREAMS_BUILDER_BEAN_NAME)
+  @Override
+  public StreamsBuilderFactoryBean defaultKafkaStreamsBuilder(
+      @Qualifier(DEFAULT_STREAMS_CONFIG_BEAN_NAME)
+      final ObjectProvider<KafkaStreamsConfiguration> streamsConfigProvider,
+      final ObjectProvider<StreamsBuilderFactoryBeanConfigurer> configurerProvider
+  ) {
+    KafkaStreamsConfiguration streamsConfig = streamsConfigProvider.getIfAvailable();
+    if (streamsConfig != null) {
+      StreamsBuilderFactoryBean fb = new ResponsiveFactoryBean(streamsConfig);
+      configurerProvider.orderedStream().forEach(configurer -> configurer.configure(fb));
+      return fb;
+    } else {
+      throw new UnsatisfiedDependencyException(KafkaStreamsDefaultConfiguration.class.getName(),
+          DEFAULT_STREAMS_BUILDER_BEAN_NAME, "streamsConfig", "There is no '"
+          + DEFAULT_STREAMS_CONFIG_BEAN_NAME + "' " + KafkaStreamsConfiguration.class.getName()
+          + " bean in the application context.\n"
+          + "Consider declaring one or don't use @EnableKafkaStreams."
+      );
+    }
+  }
+}

--- a/responsive-spring/src/main/java/dev/responsive/spring/config/ResponsiveFactoryBean.java
+++ b/responsive-spring/src/main/java/dev/responsive/spring/config/ResponsiveFactoryBean.java
@@ -1,0 +1,353 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.spring.config;
+
+import dev.responsive.kafka.api.ResponsiveKafkaStreams;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.locks.ReentrantLock;
+import org.apache.commons.logging.LogFactory;
+import org.apache.kafka.streams.KafkaClientSupplier;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.TopologyConfig;
+import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
+import org.apache.kafka.streams.processor.StateRestoreListener;
+import org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier;
+import org.springframework.core.log.LogAccessor;
+import org.springframework.kafka.KafkaException;
+import org.springframework.kafka.config.KafkaStreamsConfiguration;
+import org.springframework.kafka.config.KafkaStreamsCustomizer;
+import org.springframework.kafka.config.KafkaStreamsInfrastructureCustomizer;
+import org.springframework.kafka.config.StreamsBuilderFactoryBean;
+import org.springframework.kafka.core.CleanupConfig;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+
+public class ResponsiveFactoryBean extends StreamsBuilderFactoryBean {
+
+  public static final Duration DEFAULT_CLOSE_TIMEOUT = Duration.ofSeconds(10);
+
+  private static final LogAccessor LOGGER =
+      new LogAccessor(LogFactory.getLog(StreamsBuilderFactoryBean.class));
+
+  private final ReentrantLock lifecycleLock = new ReentrantLock();
+  private final List<StreamsBuilderFactoryBean.Listener> listeners = new ArrayList<>();
+
+  private KafkaClientSupplier clientSupplier = new DefaultKafkaClientSupplier();
+  private Properties properties;
+  private CleanupConfig cleanupConfig;
+  private KafkaStreamsInfrastructureCustomizer infrastructureCustomizer = new InfraCustomizer();
+
+  private KafkaStreamsCustomizer kafkaStreamsCustomizer;
+  private KafkaStreams.StateListener stateListener;
+  private StateRestoreListener stateRestoreListener;
+  private StreamsUncaughtExceptionHandler streamsUncaughtExceptionHandler;
+  private boolean autoStartup = true;
+  private int phase = Integer.MAX_VALUE - 1000; // NOSONAR magic #
+  private Duration closeTimeout = DEFAULT_CLOSE_TIMEOUT;
+  private boolean leaveGroupOnClose = false;
+  private KafkaStreams kafkaStreams;
+  private volatile boolean running;
+  private Topology topology;
+  private String beanName;
+
+  public ResponsiveFactoryBean() {
+    this.cleanupConfig = new CleanupConfig();
+  }
+
+  public ResponsiveFactoryBean(KafkaStreamsConfiguration streamsConfiguration) {
+    this(streamsConfiguration, new CleanupConfig());
+  }
+
+  public ResponsiveFactoryBean(
+      KafkaStreamsConfiguration streamsConfig,
+      CleanupConfig cleanupConfig
+  ) {
+    super(streamsConfig, cleanupConfig);
+    Assert.notNull(streamsConfig, "'streamsConfig' must not be null");
+    Assert.notNull(cleanupConfig, "'cleanupConfig' must not be null");
+    this.properties = streamsConfig.asProperties();
+    this.cleanupConfig = cleanupConfig;
+  }
+
+  @Override
+  public synchronized void setBeanName(final String name) {
+    this.beanName = name;
+  }
+
+  @Override
+  public void setStreamsConfiguration(Properties streamsConfig) {
+    Assert.notNull(streamsConfig, "'streamsConfig' must not be null");
+    this.properties = streamsConfig;
+  }
+
+  @Override
+  @Nullable
+  public Properties getStreamsConfiguration() {
+    return properties;
+  }
+
+  @Override
+  public void setClientSupplier(final KafkaClientSupplier clientSupplier) {
+    Assert.notNull(clientSupplier, "'clientSupplier' must not be null");
+    this.clientSupplier = clientSupplier;
+  }
+
+  @Override
+  public void setInfrastructureCustomizer(
+      final KafkaStreamsInfrastructureCustomizer infrastructureCustomizer
+  ) {
+    Assert.notNull(infrastructureCustomizer, "'infrastructureCustomizer' must not be null");
+    this.infrastructureCustomizer = infrastructureCustomizer;
+  }
+
+  @Override
+  public void setKafkaStreamsCustomizer(final KafkaStreamsCustomizer kafkaStreamsCustomizer) {
+    Assert.notNull(kafkaStreamsCustomizer, "'kafkaStreamsCustomizer' must not be null");
+    this.kafkaStreamsCustomizer = kafkaStreamsCustomizer;
+  }
+
+  @Override
+  public void setStateListener(final KafkaStreams.StateListener stateListener) {
+    this.stateListener = stateListener;
+  }
+
+  @Override
+  public void setStreamsUncaughtExceptionHandler(
+      final StreamsUncaughtExceptionHandler streamsUncaughtExceptionHandler
+  ) {
+    this.streamsUncaughtExceptionHandler = streamsUncaughtExceptionHandler;
+  }
+
+  @Override
+  public StreamsUncaughtExceptionHandler getStreamsUncaughtExceptionHandler() {
+    return streamsUncaughtExceptionHandler;
+  }
+
+  @Override
+  public void setStateRestoreListener(final StateRestoreListener stateRestoreListener) {
+    this.stateRestoreListener = stateRestoreListener;
+  }
+
+  @Override
+  public void setCloseTimeout(final int closeTimeout) {
+    this.closeTimeout = Duration.ofSeconds(closeTimeout);
+  }
+
+  @Override
+  public void setLeaveGroupOnClose(final boolean leaveGroupOnClose) {
+    this.leaveGroupOnClose = leaveGroupOnClose;
+  }
+
+  @Override
+  public Topology getTopology() {
+    return topology;
+  }
+
+  @Override
+  public Class<?> getObjectType() {
+    return super.getObjectType();
+  }
+
+  @Override
+  public void setAutoStartup(final boolean autoStartup) {
+    this.autoStartup = autoStartup;
+  }
+
+  @Override
+  public void setPhase(final int phase) {
+    this.phase = phase;
+  }
+
+  @Override
+  public int getPhase() {
+    return this.phase;
+  }
+
+  @Override
+  public void setCleanupConfig(final CleanupConfig cleanupConfig) {
+    this.cleanupConfig = cleanupConfig;
+  }
+
+  @Override
+  @Nullable
+  public synchronized KafkaStreams getKafkaStreams() {
+    this.lifecycleLock.lock();
+    try {
+      return this.kafkaStreams;
+    } finally {
+      this.lifecycleLock.unlock();
+    }
+  }
+
+  @Override
+  public List<Listener> getListeners() {
+    return Collections.unmodifiableList(this.listeners);
+  }
+
+  @Override
+  public void addListener(Listener listener) {
+    Assert.notNull(listener, "'listener' cannot be null");
+    this.listeners.add(listener);
+  }
+
+  @Override
+  public boolean removeListener(Listener listener) {
+    return this.listeners.remove(listener);
+  }
+
+  @Override
+  protected StreamsBuilder createInstance() {
+    this.lifecycleLock.lock();
+    try {
+      if (this.autoStartup) {
+        Assert.state(
+            this.properties != null,
+            "streams configuration properties must not be null"
+        );
+      }
+      StreamsBuilder builder = createStreamBuilder();
+      this.infrastructureCustomizer.configureBuilder(builder);
+      return builder;
+    } finally {
+      this.lifecycleLock.unlock();
+    }
+  }
+
+  @Override
+  public boolean isAutoStartup() {
+    return this.autoStartup;
+  }
+
+  @Override
+  public void start() {
+    this.lifecycleLock.lock();
+    try {
+      if (!this.running) {
+        try {
+          Assert.state(
+              this.properties != null,
+              "streams configuration properties must not be null"
+          );
+          this.kafkaStreams = new ResponsiveKafkaStreams(
+              this.topology,
+              this.properties,
+              this.clientSupplier
+          );
+          this.kafkaStreams.setStateListener(this.stateListener);
+          this.kafkaStreams.setGlobalStateRestoreListener(this.stateRestoreListener);
+          if (this.streamsUncaughtExceptionHandler != null) {
+            this.kafkaStreams.setUncaughtExceptionHandler(this.streamsUncaughtExceptionHandler);
+          }
+          if (this.kafkaStreamsCustomizer != null) {
+            this.kafkaStreamsCustomizer.customize(this.kafkaStreams);
+          }
+          if (this.cleanupConfig.cleanupOnStart()) {
+            this.kafkaStreams.cleanUp();
+          }
+          this.kafkaStreams.start();
+          for (Listener listener : this.listeners) {
+            listener.streamsAdded(this.beanName, this.kafkaStreams);
+          }
+          this.running = true;
+        } catch (Exception e) {
+          throw new KafkaException("Could not start stream: ", e);
+        }
+      }
+    } finally {
+      this.lifecycleLock.unlock();
+    }
+  }
+
+  @Override
+  public void stop(Runnable callback) {
+    stop();
+    if (callback != null) {
+      callback.run();
+    }
+  }
+
+  @Override
+  public void stop() {
+    this.lifecycleLock.lock();
+    try {
+      if (this.running) {
+        try {
+          if (this.kafkaStreams != null) {
+            this.kafkaStreams.close(new KafkaStreams.CloseOptions()
+                .timeout(this.closeTimeout)
+                .leaveGroup(this.leaveGroupOnClose)
+            );
+            if (this.cleanupConfig.cleanupOnStop()) {
+              this.kafkaStreams.cleanUp();
+            }
+            for (Listener listener : this.listeners) {
+              listener.streamsRemoved(this.beanName, this.kafkaStreams);
+            }
+            this.kafkaStreams = null;
+          }
+        } catch (Exception e) {
+          LOGGER.error(e, "Failed to stop streams");
+        } finally {
+          this.running = false;
+        }
+      }
+    } finally {
+      this.lifecycleLock.unlock();
+    }
+  }
+
+  @Override
+  public void afterSingletonsInstantiated() {
+    try {
+      this.topology = getObject().build(this.properties);
+      this.infrastructureCustomizer.configureTopology(this.topology);
+      LOGGER.debug(() -> this.topology.describe().toString());
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public boolean isRunning() {
+    this.lifecycleLock.lock();
+    try {
+      return this.running;
+    } finally {
+      this.lifecycleLock.unlock();
+    }
+  }
+
+  private StreamsBuilder createStreamBuilder() {
+    if (this.properties == null) {
+      return new StreamsBuilder();
+    } else {
+      StreamsConfig streamsConfig = new StreamsConfig(this.properties);
+      TopologyConfig topologyConfig = new TopologyConfig(streamsConfig);
+      return new StreamsBuilder(topologyConfig);
+    }
+  }
+
+  private static class InfraCustomizer implements KafkaStreamsInfrastructureCustomizer {
+  }
+}

--- a/responsive-spring/src/test/java/dev/responsive/spring/KafkaStreamsApp.java
+++ b/responsive-spring/src/test/java/dev/responsive/spring/KafkaStreamsApp.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2023 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dev.responsive.spring;
+
+import dev.responsive.kafka.api.config.ResponsiveConfig;
+import dev.responsive.kafka.api.config.StorageBackend;
+import dev.responsive.spring.annotations.EnableResponsive;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.admin.TopicDescription;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.streams.KeyValue;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.Named;
+import org.apache.kafka.streams.kstream.Printed;
+import org.apache.kafka.streams.kstream.TimeWindows;
+import org.apache.kafka.streams.kstream.ValueMapper;
+import org.springframework.boot.SpringApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.annotation.KafkaStreamsDefaultConfiguration;
+import org.springframework.kafka.config.KafkaStreamsConfiguration;
+import org.springframework.kafka.config.StreamsBuilderFactoryBeanConfigurer;
+import org.springframework.kafka.config.TopicBuilder;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaAdmin;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
+import org.springframework.kafka.streams.RecoveringDeserializationExceptionHandler;
+
+@Configuration
+@EnableKafka
+@EnableResponsive
+public class KafkaStreamsApp {
+
+  public static void main(String[] args) throws NoSuchMethodException {
+    SpringApplication.run(KafkaStreamsApp.class, args);
+  }
+
+  @Bean(name = KafkaStreamsDefaultConfiguration.DEFAULT_STREAMS_CONFIG_BEAN_NAME)
+  public KafkaStreamsConfiguration streamsConfigs() {
+    Map<String, Object> props = new HashMap<>();
+    props.put(StreamsConfig.APPLICATION_ID_CONFIG, "testStreams");
+    props.put(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+    props.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
+    props.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.String().getClass().getName());
+    props.put(ResponsiveConfig.STORAGE_BACKEND_TYPE_CONFIG, StorageBackend.MONGO_DB.name());
+    props.put(ResponsiveConfig.MONGO_ENDPOINT_CONFIG, "mongodb://localhost:27017");
+    props.put(StreamsConfig.DEFAULT_DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG,
+        RecoveringDeserializationExceptionHandler.class);
+    props.put(
+        RecoveringDeserializationExceptionHandler.KSTREAM_DESERIALIZATION_RECOVERER,
+        recoverer()
+    );
+    return new KafkaStreamsConfiguration(props);
+  }
+
+  @Bean
+  public StreamsBuilderFactoryBeanConfigurer moreMagic() {
+    return fb -> fb.setStateListener((newState, oldState) -> {
+      System.out.println("State transition from " + oldState + " to " + newState);
+    });
+  }
+
+  @Bean
+  public KafkaAdmin admin() {
+    Map<String, Object> configs = new HashMap<>();
+    configs.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+    return new KafkaAdmin(configs);
+  }
+
+  @Bean
+  public NewTopic topic1() {
+    return TopicBuilder.name("streamingTopic1")
+        .build();
+  }
+
+  @Bean
+  public KStream<String, String> magic(StreamsBuilder streamBuilder, KafkaAdmin admin) {
+    final Map<String, TopicDescription> streamingTopic1 = admin.describeTopics("streamingTopic1");
+    System.out.println(streamingTopic1);
+
+    KStream<String, String> stream = streamBuilder.stream("streamingTopic1");
+    stream
+        .mapValues((ValueMapper<String, String>) String::toUpperCase)
+        .groupByKey()
+        .windowedBy(TimeWindows.ofSizeWithNoGrace(Duration.ofMillis(1_000)))
+        .reduce((String value1, String value2) -> value1 + value2,
+            Named.as("windowStore"))
+        .toStream()
+        .map((windowedId, value) -> new KeyValue<>(windowedId.key(), value))
+        .filter((i, s) -> s.length() > 40)
+        .to("streamingTopic2");
+
+    stream.print(Printed.toSysOut());
+    return stream;
+  }
+
+  @Bean
+  public DeadLetterPublishingRecoverer recoverer() {
+    return new DeadLetterPublishingRecoverer(kafkaTemplate(),
+        (record, ex) -> new TopicPartition("recovererDLQ", -1));
+  }
+
+  @Bean
+  public ProducerFactory<String, String> producerFactory() {
+    Map<String, Object> configProps = new HashMap<>();
+    configProps.put(
+        ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
+        "localhost:9092");
+    configProps.put(
+        ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+        ByteArraySerializer.class);
+    configProps.put(
+        ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+        ByteArraySerializer.class);
+    return new DefaultKafkaProducerFactory<>(configProps);
+  }
+
+  @Bean
+  public KafkaTemplate<String, String> kafkaTemplate() {
+    return new KafkaTemplate<>(producerFactory());
+  }
+
+}

--- a/responsive-spring/src/test/java/dev/responsive/spring/KafkaStreamsApp.java
+++ b/responsive-spring/src/test/java/dev/responsive/spring/KafkaStreamsApp.java
@@ -37,6 +37,7 @@ import org.apache.kafka.streams.kstream.Named;
 import org.apache.kafka.streams.kstream.Printed;
 import org.apache.kafka.streams.kstream.TimeWindows;
 import org.apache.kafka.streams.kstream.ValueMapper;
+import org.junit.jupiter.api.Disabled;
 import org.springframework.boot.SpringApplication;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -55,6 +56,7 @@ import org.springframework.kafka.streams.RecoveringDeserializationExceptionHandl
 @Configuration
 @EnableKafka
 @EnableResponsive
+@Disabled // ignore from tests
 public class KafkaStreamsApp {
 
   public static void main(String[] args) throws NoSuchMethodException {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -26,6 +26,7 @@ include("kafka-client-examples:simple-example")
 include("kafka-client-examples:e2e-test")
 include("kafka-client-bootstrap")
 include("responsive-test-utils")
+include("responsive-spring")
 
 include("controller-api")
 include("operator")


### PR DESCRIPTION
See `KafkaStreamsApp` for how it's used. I tried many approaches to avoid copying a bunch of code over from the `spring-kafka` package and this was the best I could come up with.

I tried using bytecode manipulation, but turns out it's really difficult to replace a constructor call in Java -- so if I was going to override the entire `start` method in the bean I may as well just do what I did here so we have full control over it going forward.

I tested the basic functionality as well as the integration with other beans (like the DLQ bean) and it seems to work... difficult to tell what will break and what won't though!