### PR TITLE
couple releases of kafka-client and responsive-spring

### DIFF
--- a/.github/actions/for-module-in-group/action.yaml
+++ b/.github/actions/for-module-in-group/action.yaml
@@ -70,3 +70,14 @@ runs:
         OSSRH_PASSWORD: ${{ inputs.OSSRH_PASSWORD }}
         SIGNING_KEY: ${{ inputs.SIGNING_KEY }}
         SIGNING_PASSWORD: ${{ inputs.SIGNING_PASSWORD }}
+
+    - name: "Gradle Build & Publish | kafka-client: responsive-spring"
+      if: ${{ (inputs.module == 'kafka-client') && (inputs.action == 'gradle-build-and-publish') }}
+      uses: ./.github/actions/gradle-build-and-publish
+      with:
+        module: "responsive-spring"
+        force_version: ${{ steps.gradle-build-and-publish-root-module.outputs.release_version }}
+        OSSRH_USER: ${{ inputs.OSSRH_USER }}
+        OSSRH_PASSWORD: ${{ inputs.OSSRH_PASSWORD }}
+        SIGNING_KEY: ${{ inputs.SIGNING_KEY }}
+        SIGNING_PASSWORD: ${{ inputs.SIGNING_PASSWORD }}

--- a/responsive-spring/build.gradle.kts
+++ b/responsive-spring/build.gradle.kts
@@ -27,49 +27,10 @@ java {
     }
 }
 
-/*********** Generated Resources ***********/
-
-val gitCommitId: String by lazy {
-    val stdout = ByteArrayOutputStream()
-    //rootProject.exec {
-    exec {
-        commandLine("git", "rev-parse", "--verify", "--short", "HEAD")
-        standardOutput = stdout
-    }
-    stdout.toString().trim()
-}
-
-val writeVersionPropertiesFile = "writeVersionPropertiesFile"
-val gitVersion = version
-
-val resourcesDir = "$buildDir/resources/main"
-val versionFilePath = "$resourcesDir/version.properties"
-
-tasks.register(writeVersionPropertiesFile) {
-    val versionFile = file(versionFilePath)
-    outputs.file(versionFile)
-    doFirst {
-        file(versionFilePath).writeText(
-                "git.build.version=" + gitVersion + "\n" +
-                        "git.commit.id=" + gitCommitId + "\n"
-        )
-    }
-}
-
-tasks.compileJava {
-    dependsOn(tasks[writeVersionPropertiesFile])
-}
-
-tasks.publishToMavenLocal {
-    dependsOn(tasks[writeVersionPropertiesFile])
-}
-
-tasks.publish {
-    dependsOn(tasks[writeVersionPropertiesFile])
-}
+version = project(":kafka-client").version
 
 dependencies {
-    api(project(":kafka-client"))
+    implementation(project(":kafka-client"))
     implementation("com.google.code.findbugs:jsr305:3.0.2")
     implementation("org.springframework.kafka:spring-kafka:3.2.4")
     implementation("org.springframework.boot:spring-boot-starter:3.3.2")


### PR DESCRIPTION
This uses the same mechanism we use to release the responsive-test-utils, which depends on a release of kafka-client, to ensure that `responsive-spring` artifacts are released in tandem with `kafka-client`