### PR TITLE
Allow configuration of generic Mongo params via connection string

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveKafkaStreams.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveKafkaStreams.java
@@ -19,6 +19,7 @@ package dev.responsive.kafka.api;
 import static dev.responsive.kafka.api.config.ResponsiveConfig.ASYNC_MAX_EVENTS_QUEUED_PER_ASYNC_THREAD_CONFIG;
 import static dev.responsive.kafka.api.config.ResponsiveConfig.ASYNC_THREAD_POOL_SIZE_CONFIG;
 import static dev.responsive.kafka.api.config.ResponsiveConfig.METRICS_ENABLED_CONFIG;
+import static dev.responsive.kafka.api.config.ResponsiveConfig.MONGO_ADDITIONAL_CONNECTION_STRING_PARAMS_CONFIG;
 import static dev.responsive.kafka.api.config.ResponsiveConfig.MONGO_ENDPOINT_CONFIG;
 import static dev.responsive.kafka.api.config.ResponsiveConfig.MONGO_PASSWORD_CONFIG;
 import static dev.responsive.kafka.api.config.ResponsiveConfig.MONGO_USERNAME_CONFIG;
@@ -493,7 +494,8 @@ public class ResponsiveKafkaStreams extends KafkaStreams {
           final var mongoClient = SessionUtil.connect(
               hostname,
               clientId,
-              clientSecret == null ? null : clientSecret.value()
+              clientSecret == null ? null : clientSecret.value(),
+              responsiveConfig.getString(MONGO_ADDITIONAL_CONNECTION_STRING_PARAMS_CONFIG)
           );
           final boolean timestampFirstOrder =
               responsiveConfig.getBoolean(MONGO_WINDOWED_KEY_TIMESTAMP_FIRST_CONFIG);

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
@@ -85,6 +85,10 @@ public class ResponsiveConfig extends AbstractConfig {
   public static final String MONGO_ENDPOINT_CONFIG = "responsive.mongo.endpoint";
   private static final String MONGO_ENDPOINT_DOC = "The MongoDB endpoint to connect to.";
 
+  public static final String MONGO_ADDITIONAL_CONNECTION_STRING_PARAMS_CONFIG = "responsive.mongo.additional.connection.string.params";
+  private static final String MONGO_ADDITIONAL_CONNECTION_STRING_PARAMS_DOC = "Additional MongoDB config options to be appended to the "
+      + "connection string. ";
+
   public static final String MONGO_COLLECTION_SHARDING_ENABLED_CONFIG = "responsive.mongo.collection.sharding.enabled";
   private static final boolean MONGO_COLLECTION_SHARDING_ENABLED_DEFAULT = false;
   private static final String MONGO_COLLECTION_SHARDING_ENABLED_DOC = "Toggles use of sharded collections. Set "
@@ -503,6 +507,12 @@ public class ResponsiveConfig extends AbstractConfig {
           MONGO_WINDOWED_KEY_TIMESTAMP_FIRST_DEFAULT,
           Importance.LOW,
           MONGO_WINDOWED_KEY_TIMESTAMP_FIRST_DOC
+      ).define(
+          MONGO_ADDITIONAL_CONNECTION_STRING_PARAMS_CONFIG,
+          Type.STRING,
+          "",
+          Importance.LOW,
+          MONGO_ADDITIONAL_CONNECTION_STRING_PARAMS_DOC
       ).define(
           WINDOW_BLOOM_FILTER_COUNT_CONFIG,
           Type.INT,

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/utils/SessionUtil.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/utils/SessionUtil.java
@@ -42,6 +42,7 @@ import dev.responsive.kafka.internal.db.ResponsiveRetryPolicy;
 import java.net.InetSocketAddress;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import org.bson.Document;
 
@@ -121,6 +122,7 @@ public final class SessionUtil {
 
     MongoClientSettings settings = MongoClientSettings.builder()
         .applyConnectionString(new ConnectionString(connectionString))
+        .applyToConnectionPoolSettings(b -> b.maxConnectionIdleTime(60000, TimeUnit.MILLISECONDS))
         .readConcern(ReadConcern.MAJORITY)
         .writeConcern(WriteConcern.MAJORITY)
         .serverApi(serverApi)

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/utils/SessionUtil.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/utils/SessionUtil.java
@@ -42,7 +42,6 @@ import dev.responsive.kafka.internal.db.ResponsiveRetryPolicy;
 import java.net.InetSocketAddress;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import org.bson.Document;
 
@@ -94,7 +93,8 @@ public final class SessionUtil {
   public static MongoClient connect(
       final String hostname,
       @Nullable final String clientId,
-      @Nullable final String clientSecret
+      @Nullable final String clientSecret,
+      final String additionalParams
   ) {
     final String connectionString;
     if (clientId != null && clientSecret != null) {
@@ -116,13 +116,16 @@ public final class SessionUtil {
       connectionString = hostname;
     }
 
+    final String connectionStringWithParams = additionalParams.equals("")
+        ? connectionString
+        : connectionString + "/?" + additionalParams;
+
     ServerApi serverApi = ServerApi.builder()
         .version(ServerApiVersion.V1)
         .build();
 
     MongoClientSettings settings = MongoClientSettings.builder()
-        .applyConnectionString(new ConnectionString(connectionString))
-        .applyToConnectionPoolSettings(b -> b.maxConnectionIdleTime(60000, TimeUnit.MILLISECONDS))
+        .applyConnectionString(new ConnectionString(connectionStringWithParams))
         .readConcern(ReadConcern.MAJORITY)
         .writeConcern(WriteConcern.MAJORITY)
         .serverApi(serverApi)

--- a/kafka-client/src/test/java/dev/responsive/kafka/integration/MinimalIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/integration/MinimalIntegrationTest.java
@@ -36,6 +36,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
 
 import dev.responsive.kafka.api.ResponsiveKafkaStreams;
+import dev.responsive.kafka.api.config.ResponsiveConfig;
 import dev.responsive.kafka.api.config.StorageBackend;
 import dev.responsive.kafka.testutils.ResponsiveConfigParam;
 import dev.responsive.kafka.testutils.ResponsiveExtension;
@@ -72,7 +73,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 public class MinimalIntegrationTest {
 
   @RegisterExtension
-  static ResponsiveExtension EXTENSION = new ResponsiveExtension(StorageBackend.CASSANDRA);
+  static ResponsiveExtension EXTENSION = new ResponsiveExtension(StorageBackend.MONGO_DB);
 
   private static final String INPUT_TOPIC = "input";
   private static final String OUTPUT_TOPIC = "output";
@@ -159,6 +160,10 @@ public class MinimalIntegrationTest {
     properties.put(STATESTORE_CACHE_MAX_BYTES_CONFIG, 0);
     properties.put(STORE_FLUSH_RECORDS_TRIGGER_CONFIG, 1);
     properties.put(COMMIT_INTERVAL_MS_CONFIG, 1);
+
+    properties.put(
+        ResponsiveConfig.MONGO_ADDITIONAL_CONNECTION_STRING_PARAMS_CONFIG, "maxIdleTimeMs=60000"
+    );
 
     properties.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 1);
     properties.put(consumerPrefix(ConsumerConfig.METADATA_MAX_AGE_CONFIG), "1000");

--- a/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveKafkaStreamsIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveKafkaStreamsIntegrationTest.java
@@ -147,7 +147,7 @@ public class ResponsiveKafkaStreamsIntegrationTest {
 
     // Then:
     try (
-        final var mongoClient = SessionUtil.connect(mongo.getConnectionString(), null, null);
+        final var mongoClient = SessionUtil.connect(mongo.getConnectionString(), null, null, "");
         final var deserializer = new StringDeserializer();
     ) {
       final List<String> dbs = new ArrayList<>();

--- a/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveKeyValueStoreRestoreIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveKeyValueStoreRestoreIntegrationTest.java
@@ -391,7 +391,8 @@ public class ResponsiveKeyValueStoreRestoreIntegrationTest {
       final var mongoClient = SessionUtil.connect(
           hostname,
           user,
-          pass == null ? null : pass.value()
+          pass == null ? null : pass.value(),
+          ""
       );
       table = new MongoKVTable(
           mongoClient,

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/mongo/MongoKVTableTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/mongo/MongoKVTableTest.java
@@ -61,7 +61,7 @@ class MongoKVTableTest {
     name = info.getDisplayName().replace("()", "");
 
     final String mongoConnection = (String) props.get(MONGO_ENDPOINT_CONFIG);
-    client = SessionUtil.connect(mongoConnection, null, null);
+    client = SessionUtil.connect(mongoConnection, null, null, "");
   }
 
   @Test

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/mongo/MongoSessionTableTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/mongo/MongoSessionTableTest.java
@@ -61,7 +61,7 @@ class MongoSessionTableTest {
     name = info.getDisplayName().replace("()", "");
 
     final String mongoConnection = (String) props.get(MONGO_ENDPOINT_CONFIG);
-    client = SessionUtil.connect(mongoConnection, null, null);
+    client = SessionUtil.connect(mongoConnection, null, null, "");
   }
 
   /*

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/mongo/MongoWindowTableTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/mongo/MongoWindowTableTest.java
@@ -57,7 +57,7 @@ class MongoWindowTableTest {
     name = info.getDisplayName().replace("()", "");
 
     final String mongoConnection = (String) props.get(MONGO_ENDPOINT_CONFIG);
-    client = SessionUtil.connect(mongoConnection, null, null);
+    client = SessionUtil.connect(mongoConnection, null, null, "");
   }
 
   @Test

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/mongo/MongoWindowedTableTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/mongo/MongoWindowedTableTest.java
@@ -52,7 +52,7 @@ class MongoWindowedTableTest {
     name = info.getDisplayName().replace("()", "");
 
     final String mongoConnection = (String) props.get(MONGO_ENDPOINT_CONFIG);
-    client = SessionUtil.connect(mongoConnection, null, null);
+    client = SessionUtil.connect(mongoConnection, null, null, "");
 
     partitioner = new WindowSegmentPartitioner(10_000L, 1_000L, false);
     segment = partitioner.segmenter().activeSegments(0, 100).get(0);


### PR DESCRIPTION
Wanted to be able to set a higher connection idle timeout. Might as well take the opportunity to allow configuration of all the Mongo params via the connection string, rather than adding them one by one.

Context: saw this in an Antithesis run of the regression test:

```
org.apache.kafka.streams.errors.StreamsException: com.mongodb.MongoSocketReadException: Prematurely reached end of stream
```

According to some brief googling, this suggests the Mongo connection closed due to being idle. I'm guessing this is an effect of the chaos testing

