### PR TITLE
Add new custom Antithesis params and run mongo regression test in nightlies

### DIFF
--- a/.github/workflows/github-e2e-manual.yaml
+++ b/.github/workflows/github-e2e-manual.yaml
@@ -6,7 +6,7 @@ on:
         description: 'The backend storage type to use'
         type: choice
         required: true
-        default: 'scylla'
+        default: 'mongo'
         options:
           - scylla
           - mongo

--- a/.github/workflows/github-e2e-nightly.yaml
+++ b/.github/workflows/github-e2e-nightly.yaml
@@ -3,7 +3,7 @@ on:
   schedule:
     - cron: '30 4 * * *'
 jobs:
-  build:
+  async-scylla:
     permissions:
       id-token: write # This is required for requesting the JWT
       contents: write # This is required for actions/checkout (read) and publishing tags (write)
@@ -12,4 +12,14 @@ jobs:
       test-duration: "6.0"
       backend: "scylla"
       test-type: "async"
+    secrets: inherit
+  regression-mongo:
+    permissions:
+      id-token: write # This is required for requesting the JWT
+      contents: write # This is required for actions/checkout (read) and publishing tags (write)
+    uses: responsivedev/responsive-pub/.github/workflows/github-e2e.yaml@main
+    with:
+      test-duration: "6.0"
+      backend: "mongo"
+      test-type: "regression"
     secrets: inherit

--- a/.github/workflows/github-e2e.yaml
+++ b/.github/workflows/github-e2e.yaml
@@ -6,7 +6,7 @@ on:
         description: 'The backend storage type to use'
         type: string
         required: true
-        default: 'scylla'
+        default: 'mongo'
       test-type:
         description: 'Which test variant to run'
         type: string
@@ -106,6 +106,8 @@ jobs:
           email_recipients: "antithesis-responsive-aaaamurlsqy6e3hxnx6ksnec5y@antithesisgroup.slack.com"
           additional_parameters: |-
             custom.duration=${{ inputs.test-duration }}
+            custom.database_type=${{ inputs.backend }}
+            custom.test_type=${{ inputs.test-type }}
 
       #  env:
       #    KAFKA_CLIENT_VERSION: ${{ steps.kafka_client_version.outputs.KAFKA_CLIENT_VERSION }}


### PR DESCRIPTION
Two new Antithesis custom params:
-database_type just determines which nodes get fault injection (mongo vs scylla)
-test_type is just used to gate test-specific assertions until we can migrate fully to the Java SDK