### PR TITLE
Use SDK for Antithesis tests

### DIFF
--- a/kafka-client-examples/e2e-test/build.gradle.kts
+++ b/kafka-client-examples/e2e-test/build.gradle.kts
@@ -10,16 +10,17 @@ application {
 dependencies {
     // todo: how to set the version here?
     implementation(project(":kafka-client"))
-    implementation("com.google.guava:guava:32.1.1-jre")
-    implementation("org.apache.kafka:kafka-clients:3.7.0")
-    implementation("org.apache.kafka:kafka-streams:3.7.0")
-    implementation("org.apache.logging.log4j:log4j-slf4j-impl:2.20.0")
+    implementation(libs.kafka.clients)
+    implementation(libs.kafka.streams)
+
+    implementation("com.antithesis:sdk:1.3.1")
     implementation("org.apache.commons:commons-text:1.10.0")
-    implementation("com.scylladb:java-driver-core:4.15.0.0")
-    implementation("com.scylladb:java-driver-query-builder:4.15.0.0")
-    implementation("com.scylladb:java-driver-mapper-runtime:4.15.0.0")
-    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.15.2")
-    implementation("org.mongodb:mongodb-driver-core:4.10.2")
+
+    implementation(libs.guava)
+    implementation(libs.slf4j.log4j2)
+    implementation(libs.bundles.scylla)
+    implementation(libs.jackson)
+    implementation(libs.mongodb.driver.core)
 
     testImplementation(testlibs.bundles.base)
     testImplementation(testlibs.bundles.testcontainers)

--- a/kafka-client-examples/e2e-test/src/main/java/dev/responsive/examples/common/UncaughtStreamsAntithesisHandler.java
+++ b/kafka-client-examples/e2e-test/src/main/java/dev/responsive/examples/common/UncaughtStreamsAntithesisHandler.java
@@ -27,6 +27,7 @@ import com.datastax.oss.driver.api.core.servererrors.WriteFailureException;
 import com.datastax.oss.driver.api.core.servererrors.WriteTimeoutException;
 import com.mongodb.MongoNotPrimaryException;
 import com.mongodb.MongoQueryException;
+import com.mongodb.MongoSocketReadException;
 import com.mongodb.MongoTimeoutException;
 import java.net.ConnectException;
 import java.util.LinkedList;
@@ -77,6 +78,7 @@ public class UncaughtStreamsAntithesisHandler implements StreamsUncaughtExceptio
         InjectedE2ETestException.class,
         InvalidProducerEpochException.class,
         MongoNotPrimaryException.class,
+        MongoSocketReadException.class,
         MongoTimeoutException.class,
         ProducerFencedException.class,
         ReadFailureException.class,

--- a/kafka-client-examples/e2e-test/src/main/java/dev/responsive/examples/regression/ResultsComparatorService.java
+++ b/kafka-client-examples/e2e-test/src/main/java/dev/responsive/examples/regression/ResultsComparatorService.java
@@ -97,9 +97,11 @@ public class ResultsComparatorService<T extends Comparable<T>>
       // from the Responsive app and are ready to start injecting failures
       if (!setupCompleteSignalFired
           && records.records(resultsTopic(true)).iterator().hasNext()) {
+        LOG.info("Received at least one output record, setup is complete");
         Lifecycle.setupComplete(null);
-        EventSignals.logNumConsumedOutputRecords(records.count());
         setupCompleteSignalFired = true;
+
+        EventSignals.logNumConsumedOutputRecords(records.count());
       }
 
       records.records(resultsTopic(true)).forEach(r -> {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -46,7 +46,7 @@ dependencyResolutionManagement {
 
     versionCatalogs {
         create("libs") {
-            version("jackson", "2.14.2")
+            version("jackson", "2.15.2")
             version("kafka", "3.7.0")
             version("scylla", "4.15.0.0")
             version("javaoperatorsdk", "4.3.0")
@@ -67,6 +67,7 @@ dependencyResolutionManagement {
             library("scylla-mapper-runtime", "com.scylladb", "java-driver-mapper-runtime").versionRef("scylla")
             bundle("scylla", listOf("scylla-driver-core", "scylla-query-builder", "scylla-mapper-runtime"))
 
+            library("mongodb-driver-core", "org.mongodb", "mongodb-driver-core").versionRef("mongoDB")
             library("mongodb-driver-sync", "org.mongodb", "mongodb-driver-sync").versionRef("mongoDB")
 
             library("javaoperatorsdk", "io.javaoperatorsdk", "operator-framework").versionRef("javaoperatorsdk")


### PR DESCRIPTION
Beginning the migration to the new SDK for Antithesis. Mostly focusing on the new regression test in this PR and the `"ANTITHESIS NEVER"` string literals, will complete the migration in a followup PR to catch any remaining assertions from the async test
