### PR TITLE
Collect MongoDB command execution metrics

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveKafkaStreams.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveKafkaStreams.java
@@ -493,7 +493,8 @@ public class ResponsiveKafkaStreams extends KafkaStreams {
           final var mongoClient = SessionUtil.connect(
               hostname,
               clientId,
-              clientSecret == null ? null : clientSecret.value()
+              clientSecret == null ? null : clientSecret.value(),
+              metrics
           );
           final boolean timestampFirstOrder =
               responsiveConfig.getBoolean(MONGO_WINDOWED_KEY_TIMESTAMP_FIRST_CONFIG);

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoTelemetryListener.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoTelemetryListener.java
@@ -1,0 +1,138 @@
+/*
+ * Copyright 2024 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.responsive.kafka.internal.db.mongo;
+
+import com.mongodb.event.CommandFailedEvent;
+import com.mongodb.event.CommandListener;
+import com.mongodb.event.CommandSucceededEvent;
+import dev.responsive.kafka.internal.metrics.ResponsiveMetrics;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.stats.CumulativeCount;
+import org.apache.kafka.common.metrics.stats.CumulativeSum;
+
+/**
+ * Listener which reports MongoDB command failures and successes. For each result,
+ * we record a total count representing the number of commands executed which had that
+ * result (success or failure), and a cumulative latency. Reported metrics are tagged by
+ * the MongoDB command name.
+ */
+public class MongoTelemetryListener implements CommandListener {
+  private static final String MONGODB_METRICS_GROUP = "responsive-mongodb";
+
+  static final MetricName COMMANDS_SUCCEEDED_LATENCY = new MetricName(
+      "commands-succeeded-cumulative-latency",
+      MONGODB_METRICS_GROUP,
+      "cumulative commands succeeded latency",
+      Collections.emptyMap()
+  );
+  private static final MetricName COMMANDS_SUCCEEDED_COUNT = new MetricName(
+      "commands-succeeded-count",
+      MONGODB_METRICS_GROUP,
+      "total commands succeeded",
+      Collections.emptyMap()
+  );
+
+  static final MetricName COMMANDS_FAILED_COUNT = new MetricName(
+        "commands-failed-count",
+        MONGODB_METRICS_GROUP,
+        "total commands failed",
+        Collections.emptyMap()
+    );
+  static final MetricName COMMANDS_FAILED_LATENCY = new MetricName(
+      "commands-failed-cumulative-latency",
+      MONGODB_METRICS_GROUP,
+      "cumulative commands failed latency",
+      Collections.emptyMap()
+  );
+
+  private final ResponsiveMetrics metrics;
+
+  public MongoTelemetryListener(ResponsiveMetrics metrics) {
+    this.metrics = metrics;
+  }
+
+  @Override
+  public void commandSucceeded(final CommandSucceededEvent event) {
+    getOrCreateSensor(event.getCommandName(), true)
+        .record(event.getElapsedTime(TimeUnit.MILLISECONDS));
+  }
+
+  @Override
+  public void commandFailed(final CommandFailedEvent event) {
+    getOrCreateSensor(event.getCommandName(), false)
+        .record(event.getElapsedTime(TimeUnit.MILLISECONDS));
+  }
+
+  private Sensor getOrCreateSensor(
+      String command,
+      boolean isSuccess
+  ) {
+    String sensorName = "mongodb-commands" + "-" + command +
+        (isSuccess? "-succeeded" : "-failed");
+
+    Sensor sensor = metrics.getSensor(sensorName);
+    if (sensor == null) {
+      sensor = metrics.addSensor(sensorName);
+
+      if (isSuccess) {
+        sensor.add(commandsSucceededCount(command), new CumulativeCount());
+        sensor.add(commandsSucceededLatency(command), new CumulativeSum());
+      } else {
+        sensor.add(commandsFailedCount(command), new CumulativeCount());
+        sensor.add(commandsFailedLatency(command), new CumulativeSum());
+      }
+    }
+
+    return sensor;
+  }
+
+  static MetricName commandsSucceededCount(String command) {
+    return metricName(COMMANDS_SUCCEEDED_COUNT, buildTags(command));
+  }
+
+  static MetricName commandsSucceededLatency(String command) {
+    return metricName(COMMANDS_SUCCEEDED_LATENCY, buildTags(command));
+  }
+
+  static MetricName commandsFailedCount(String command) {
+    return metricName(COMMANDS_FAILED_COUNT, buildTags(command));
+  }
+
+  static MetricName commandsFailedLatency(String command) {
+    return metricName(COMMANDS_FAILED_LATENCY, buildTags(command));
+  }
+
+  private static Map<String, String> buildTags(String command) {
+    return Collections.singletonMap("command", command);
+  }
+
+  private static MetricName metricName(
+      MetricName template,
+      Map<String, String> tags
+  ) {
+    return new MetricName(
+        template.name(),
+        template.group(),
+        template.description(),
+        tags
+    );
+  }
+
+}

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoTelemetryListener.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoTelemetryListener.java
@@ -35,7 +35,7 @@ import org.apache.kafka.common.metrics.stats.CumulativeSum;
  * the MongoDB command name.
  */
 public class MongoTelemetryListener implements CommandListener {
-  private static final String MONGODB_METRICS_GROUP = "responsive-mongodb";
+  private static final String MONGODB_METRICS_GROUP = "mongodb";
 
   static final MetricName COMMANDS_SUCCEEDED_LATENCY = new MetricName(
       "commands-succeeded-cumulative-latency",

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoTelemetryListener.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoTelemetryListener.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package dev.responsive.kafka.internal.db.mongo;
 
 import com.mongodb.event.CommandFailedEvent;
@@ -84,8 +85,8 @@ public class MongoTelemetryListener implements CommandListener {
       String command,
       boolean isSuccess
   ) {
-    String sensorName = "mongodb-commands" + "-" + command +
-        (isSuccess? "-succeeded" : "-failed");
+    String sensorName = "mongodb-commands" + "-" + command
+        + (isSuccess ? "-succeeded" : "-failed");
 
     Sensor sensor = metrics.getSensor(sensorName);
     if (sensor == null) {

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/ResponsiveMongoClient.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/ResponsiveMongoClient.java
@@ -29,7 +29,6 @@ import dev.responsive.kafka.internal.db.partitioning.TablePartitioner;
 import dev.responsive.kafka.internal.db.partitioning.WindowSegmentPartitioner;
 import dev.responsive.kafka.internal.db.spec.BaseTableSpec;
 import dev.responsive.kafka.internal.db.spec.TtlTableSpec;
-
 import java.util.concurrent.TimeoutException;
 
 public class ResponsiveMongoClient {

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/ResponsiveMongoClient.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/ResponsiveMongoClient.java
@@ -29,6 +29,7 @@ import dev.responsive.kafka.internal.db.partitioning.TablePartitioner;
 import dev.responsive.kafka.internal.db.partitioning.WindowSegmentPartitioner;
 import dev.responsive.kafka.internal.db.spec.BaseTableSpec;
 import dev.responsive.kafka.internal.db.spec.TtlTableSpec;
+
 import java.util.concurrent.TimeoutException;
 
 public class ResponsiveMongoClient {

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/metrics/ResponsiveMetrics.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/metrics/ResponsiveMetrics.java
@@ -223,6 +223,10 @@ public class ResponsiveMetrics implements Closeable {
     return metrics.sensor(sensorName);
   }
 
+  public Sensor getSensor(final String sensorName) {
+    return metrics.getSensor(sensorName);
+  }
+
   public void removeSensor(final String sensorName) {
     metrics.removeSensor(sensorName);
   }

--- a/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveKafkaStreamsIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveKafkaStreamsIntegrationTest.java
@@ -147,7 +147,13 @@ public class ResponsiveKafkaStreamsIntegrationTest {
 
     // Then:
     try (
-        final var mongoClient = SessionUtil.connect(mongo.getConnectionString(), null, null, "", null);
+        final var mongoClient = SessionUtil.connect(
+            mongo.getConnectionString(),
+            null,
+            null,
+            "",
+            null
+        );
         final var deserializer = new StringDeserializer();
     ) {
       final List<String> dbs = new ArrayList<>();

--- a/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveKafkaStreamsIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveKafkaStreamsIntegrationTest.java
@@ -147,7 +147,7 @@ public class ResponsiveKafkaStreamsIntegrationTest {
 
     // Then:
     try (
-        final var mongoClient = SessionUtil.connect(mongo.getConnectionString(), null, null);
+        final var mongoClient = SessionUtil.connect(mongo.getConnectionString(), null, null, null);
         final var deserializer = new StringDeserializer();
     ) {
       final List<String> dbs = new ArrayList<>();

--- a/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveKeyValueStoreRestoreIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveKeyValueStoreRestoreIntegrationTest.java
@@ -391,7 +391,8 @@ public class ResponsiveKeyValueStoreRestoreIntegrationTest {
       final var mongoClient = SessionUtil.connect(
           hostname,
           user,
-          pass == null ? null : pass.value()
+          pass == null ? null : pass.value(),
+          null
       );
       table = new MongoKVTable(
           mongoClient,

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/mongo/MongoKVTableTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/mongo/MongoKVTableTest.java
@@ -61,7 +61,7 @@ class MongoKVTableTest {
     name = info.getDisplayName().replace("()", "");
 
     final String mongoConnection = (String) props.get(MONGO_ENDPOINT_CONFIG);
-    client = SessionUtil.connect(mongoConnection, null, null);
+    client = SessionUtil.connect(mongoConnection, null, null, null);
   }
 
   @Test

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/mongo/MongoSessionTableTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/mongo/MongoSessionTableTest.java
@@ -61,7 +61,7 @@ class MongoSessionTableTest {
     name = info.getDisplayName().replace("()", "");
 
     final String mongoConnection = (String) props.get(MONGO_ENDPOINT_CONFIG);
-    client = SessionUtil.connect(mongoConnection, null, null);
+    client = SessionUtil.connect(mongoConnection, null, null, null);
   }
 
   /*

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/mongo/MongoTelemetryListenerTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/mongo/MongoTelemetryListenerTest.java
@@ -13,6 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package dev.responsive.kafka.internal.db.mongo;
 
 import static dev.responsive.kafka.internal.db.mongo.MongoTelemetryListener.commandsFailedCount;

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/mongo/MongoTelemetryListenerTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/mongo/MongoTelemetryListenerTest.java
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2024 Responsive Computing, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package dev.responsive.kafka.internal.db.mongo;
+
+import static dev.responsive.kafka.internal.db.mongo.MongoTelemetryListener.commandsFailedCount;
+import static dev.responsive.kafka.internal.db.mongo.MongoTelemetryListener.commandsFailedLatency;
+import static dev.responsive.kafka.internal.db.mongo.MongoTelemetryListener.commandsSucceededCount;
+import static dev.responsive.kafka.internal.db.mongo.MongoTelemetryListener.commandsSucceededLatency;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.mongodb.event.CommandFailedEvent;
+import com.mongodb.event.CommandSucceededEvent;
+import dev.responsive.kafka.internal.metrics.ResponsiveMetrics;
+import dev.responsive.kafka.internal.metrics.exporter.MetricsExportService;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.metrics.Metrics;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+public class MongoTelemetryListenerTest {
+
+  @Test
+  public void testSuccessMetricNames() {
+    final MetricName findSuccessCountName = commandsSucceededCount("find");
+    assertEquals("responsive-mongodb", findSuccessCountName.group());
+    assertEquals("commands-succeeded-count", findSuccessCountName.name());
+    assertEquals(Collections.singletonMap("command", "find"), findSuccessCountName.tags());
+
+    final MetricName findSuccessLatencyName = commandsSucceededLatency("find");
+    assertEquals("responsive-mongodb", findSuccessLatencyName.group());
+    assertEquals("commands-succeeded-cumulative-latency", findSuccessLatencyName.name());
+    assertEquals(Collections.singletonMap("command", "find"), findSuccessLatencyName.tags());
+  }
+
+  @Test
+  public void testFailureMetricNames() {
+    final MetricName findFailureCountName = commandsFailedCount("find");
+    assertEquals("responsive-mongodb", findFailureCountName.group());
+    assertEquals("commands-failed-count", findFailureCountName.name());
+    assertEquals(Collections.singletonMap("command", "find"), findFailureCountName.tags());
+
+    final MetricName findFailureLatencyName = commandsFailedLatency("find");
+    assertEquals("responsive-mongodb", findFailureLatencyName.group());
+    assertEquals("commands-failed-cumulative-latency", findFailureLatencyName.name());
+    assertEquals(Collections.singletonMap("command", "find"), findFailureLatencyName.tags());
+  }
+
+  @Test
+  public void testSuccessfulCommand() {
+    final ResponsiveMetrics metrics = new ResponsiveMetrics(
+        new Metrics(),
+        Mockito.mock(MetricsExportService.class)
+    );
+
+    final MongoTelemetryListener listener = new MongoTelemetryListener(metrics);
+    final CommandSucceededEvent successEvent = Mockito.mock(CommandSucceededEvent.class);
+
+    Mockito.when(successEvent.getCommandName()).thenReturn("count");
+    int initialMetricsCount = metrics.metrics().size();
+    Mockito.when(successEvent.getElapsedTime(TimeUnit.MILLISECONDS)).thenReturn(200L);
+    listener.commandSucceeded(successEvent);
+
+    assertEquals(initialMetricsCount + 2, metrics.metrics().size());
+    assertEquals(1L, metricValue(metrics, commandsSucceededCount("count")));
+    assertEquals(200L, metricValue(metrics, commandsSucceededLatency("count")));
+
+    Mockito.when(successEvent.getElapsedTime(TimeUnit.MILLISECONDS)).thenReturn(300L);
+    listener.commandSucceeded(successEvent);
+    assertEquals(2L, metricValue(metrics, commandsSucceededCount("count")));
+    assertEquals(500L, metricValue(metrics, commandsSucceededLatency("count")));
+
+    Mockito.when(successEvent.getCommandName()).thenReturn("find");
+    listener.commandSucceeded(successEvent);
+    assertEquals(initialMetricsCount + 4, metrics.metrics().size());
+    assertEquals(1L, metricValue(metrics, commandsSucceededCount("find")));
+    assertEquals(300L, metricValue(metrics, commandsSucceededLatency("find")));
+    assertEquals(2L, metricValue(metrics, commandsSucceededCount("count")));
+    assertEquals(500L, metricValue(metrics, commandsSucceededLatency("count")));
+
+    final CommandFailedEvent failedEvent = Mockito.mock(CommandFailedEvent.class);
+    Mockito.when(failedEvent.getElapsedTime(TimeUnit.MILLISECONDS)).thenReturn(50L);
+    Mockito.when(failedEvent.getCommandName()).thenReturn("find");
+    listener.commandFailed(failedEvent);
+    assertEquals(initialMetricsCount + 6, metrics.metrics().size());
+    assertEquals(1L, metricValue(metrics, commandsFailedCount("find")));
+    assertEquals(50L, metricValue(metrics, commandsFailedLatency("find")));
+    assertEquals(1L, metricValue(metrics, commandsSucceededCount("find")));
+    assertEquals(300L, metricValue(metrics, commandsSucceededLatency("find")));
+    assertEquals(2L, metricValue(metrics, commandsSucceededCount("count")));
+    assertEquals(500L, metricValue(metrics, commandsSucceededLatency("count")));
+  }
+
+  @Test
+  public void testFailedCommand() {
+    final ResponsiveMetrics metrics = new ResponsiveMetrics(
+        new Metrics(),
+        Mockito.mock(MetricsExportService.class)
+    );
+
+    final MongoTelemetryListener listener = new MongoTelemetryListener(metrics);
+    final CommandFailedEvent failedEvent = Mockito.mock(CommandFailedEvent.class);
+
+    Mockito.when(failedEvent.getCommandName()).thenReturn("count");
+    int initialMetricsCount = metrics.metrics().size();
+    Mockito.when(failedEvent.getElapsedTime(TimeUnit.MILLISECONDS)).thenReturn(200L);
+    listener.commandFailed(failedEvent);
+
+    assertEquals(initialMetricsCount + 2, metrics.metrics().size());
+    assertEquals(1L, metricValue(metrics, commandsFailedCount("count")));
+    assertEquals(200L, metricValue(metrics, commandsFailedLatency("count")));
+
+    Mockito.when(failedEvent.getElapsedTime(TimeUnit.MILLISECONDS)).thenReturn(300L);
+    listener.commandFailed(failedEvent);
+    assertEquals(2L, metricValue(metrics, commandsFailedCount("count")));
+    assertEquals(500L, metricValue(metrics, commandsFailedLatency("count")));
+
+    Mockito.when(failedEvent.getCommandName()).thenReturn("find");
+    listener.commandFailed(failedEvent);
+    assertEquals(initialMetricsCount + 4, metrics.metrics().size());
+    assertEquals(1L, metricValue(metrics, commandsFailedCount("find")));
+    assertEquals(300L, metricValue(metrics, commandsFailedLatency("find")));
+    assertEquals(2L, metricValue(metrics, commandsFailedCount("count")));
+    assertEquals(500L, metricValue(metrics, commandsFailedLatency("count")));
+
+    final CommandSucceededEvent successEvent = Mockito.mock(CommandSucceededEvent.class);
+    Mockito.when(successEvent.getCommandName()).thenReturn("count");
+    Mockito.when(successEvent.getElapsedTime(TimeUnit.MILLISECONDS)).thenReturn(50L);
+    listener.commandSucceeded(successEvent);
+    assertEquals(initialMetricsCount + 6, metrics.metrics().size());
+    assertEquals(1L, metricValue(metrics, commandsSucceededCount("count")));
+    assertEquals(50L, metricValue(metrics, commandsSucceededLatency("count")));
+    assertEquals(1L, metricValue(metrics, commandsFailedCount("find")));
+    assertEquals(300L, metricValue(metrics, commandsFailedLatency("find")));
+    assertEquals(2L, metricValue(metrics, commandsFailedCount("count")));
+    assertEquals(500L, metricValue(metrics, commandsFailedLatency("count")));
+  }
+
+  private long metricValue(
+      ResponsiveMetrics metrics,
+      MetricName name
+  ) {
+    Double value = (Double) metrics.metrics()
+        .get(name)
+        .metricValue();
+    return value.longValue();
+  }
+
+}

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/mongo/MongoTelemetryListenerTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/mongo/MongoTelemetryListenerTest.java
@@ -38,12 +38,12 @@ public class MongoTelemetryListenerTest {
   @Test
   public void shouldHaveCorrectNamesForSuccessMetrics() {
     final MetricName findSuccessCountName = commandsSucceededCount("find");
-    assertEquals("responsive-mongodb", findSuccessCountName.group());
+    assertEquals("mongodb", findSuccessCountName.group());
     assertEquals("commands-succeeded-count", findSuccessCountName.name());
     assertEquals(Collections.singletonMap("command", "find"), findSuccessCountName.tags());
 
     final MetricName findSuccessLatencyName = commandsSucceededLatency("find");
-    assertEquals("responsive-mongodb", findSuccessLatencyName.group());
+    assertEquals("mongodb", findSuccessLatencyName.group());
     assertEquals("commands-succeeded-cumulative-latency", findSuccessLatencyName.name());
     assertEquals(Collections.singletonMap("command", "find"), findSuccessLatencyName.tags());
   }
@@ -51,12 +51,12 @@ public class MongoTelemetryListenerTest {
   @Test
   public void shouldHaveCorrectNamesForFailureMetrics() {
     final MetricName findFailureCountName = commandsFailedCount("find");
-    assertEquals("responsive-mongodb", findFailureCountName.group());
+    assertEquals("mongodb", findFailureCountName.group());
     assertEquals("commands-failed-count", findFailureCountName.name());
     assertEquals(Collections.singletonMap("command", "find"), findFailureCountName.tags());
 
     final MetricName findFailureLatencyName = commandsFailedLatency("find");
-    assertEquals("responsive-mongodb", findFailureLatencyName.group());
+    assertEquals("mongodb", findFailureLatencyName.group());
     assertEquals("commands-failed-cumulative-latency", findFailureLatencyName.name());
     assertEquals(Collections.singletonMap("command", "find"), findFailureLatencyName.tags());
   }

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/mongo/MongoTelemetryListenerTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/mongo/MongoTelemetryListenerTest.java
@@ -36,7 +36,7 @@ import org.mockito.Mockito;
 public class MongoTelemetryListenerTest {
 
   @Test
-  public void testSuccessMetricNames() {
+  public void shouldHaveCorrectNamesForSuccessMetrics() {
     final MetricName findSuccessCountName = commandsSucceededCount("find");
     assertEquals("responsive-mongodb", findSuccessCountName.group());
     assertEquals("commands-succeeded-count", findSuccessCountName.name());
@@ -49,7 +49,7 @@ public class MongoTelemetryListenerTest {
   }
 
   @Test
-  public void testFailureMetricNames() {
+  public void shouldHaveCorrectNamesForFailureMetrics() {
     final MetricName findFailureCountName = commandsFailedCount("find");
     assertEquals("responsive-mongodb", findFailureCountName.group());
     assertEquals("commands-failed-count", findFailureCountName.name());
@@ -62,7 +62,7 @@ public class MongoTelemetryListenerTest {
   }
 
   @Test
-  public void testSuccessfulCommand() {
+  public void shouldRecordSuccessfulCommandExecution() {
     final ResponsiveMetrics metrics = new ResponsiveMetrics(
         new Metrics(),
         Mockito.mock(MetricsExportService.class)
@@ -107,7 +107,7 @@ public class MongoTelemetryListenerTest {
   }
 
   @Test
-  public void testFailedCommand() {
+  public void shouldRecordFailedCommandExecution() {
     final ResponsiveMetrics metrics = new ResponsiveMetrics(
         new Metrics(),
         Mockito.mock(MetricsExportService.class)

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/mongo/MongoWindowTableTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/mongo/MongoWindowTableTest.java
@@ -57,7 +57,7 @@ class MongoWindowTableTest {
     name = info.getDisplayName().replace("()", "");
 
     final String mongoConnection = (String) props.get(MONGO_ENDPOINT_CONFIG);
-    client = SessionUtil.connect(mongoConnection, null, null);
+    client = SessionUtil.connect(mongoConnection, null, null, null);
   }
 
   @Test

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/mongo/MongoWindowedTableTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/mongo/MongoWindowedTableTest.java
@@ -52,7 +52,7 @@ class MongoWindowedTableTest {
     name = info.getDisplayName().replace("()", "");
 
     final String mongoConnection = (String) props.get(MONGO_ENDPOINT_CONFIG);
-    client = SessionUtil.connect(mongoConnection, null, null);
+    client = SessionUtil.connect(mongoConnection, null, null, null);
 
     partitioner = new WindowSegmentPartitioner(10_000L, 1_000L, false);
     segment = partitioner.segmenter().activeSegments(0, 100).get(0);


### PR DESCRIPTION
This patch adds collection of MongoDB command metrics. We implement a `CommandListener` as documented [here](https://www.mongodb.com/docs/drivers/java/sync/v4.6/fundamentals/monitoring/) which records counts and cumulative latencies for command successes and failures.