### PR TITLE
Add Mongo/Cassandra metrics to otel config

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoTelemetryListener.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoTelemetryListener.java
@@ -35,7 +35,7 @@ import org.apache.kafka.common.metrics.stats.CumulativeSum;
  * the MongoDB command name.
  */
 public class MongoTelemetryListener implements CommandListener {
-  private static final String MONGODB_METRICS_GROUP = "mongodb";
+  private static final String MONGODB_METRICS_GROUP = "mongodb-client";
 
   static final MetricName COMMANDS_SUCCEEDED_LATENCY = new MetricName(
       "commands-succeeded-cumulative-latency",

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/metrics/CassandraMetricsFactory.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/metrics/CassandraMetricsFactory.java
@@ -52,7 +52,7 @@ import org.apache.kafka.common.metrics.stats.CumulativeSum;
  * </p>
  */
 public class CassandraMetricsFactory implements MetricsFactory {
-  static final String CASSANDRA_METRICS_GROUP = "cassandra-driver";
+  static final String CASSANDRA_METRICS_GROUP = "cassandra-client";
   private final SessionMetricUpdater sessionMetricUpdater;
   private final NodeMetricUpdater nodeMetricUpdater;
 

--- a/kafka-client/src/main/resources/otel-jmx.config.yaml
+++ b/kafka-client/src/main/resources/otel-jmx.config.yaml
@@ -349,7 +349,7 @@ rules:
        unit: '{records}'
 
  # MongoDB Client Metrics
- - bean: dev.responsive:type=mongodb,command=*
+ - bean: dev.responsive:type=mongodb-client,command=*
    metricAttribute:
        command: param(command)
    mapping:
@@ -375,7 +375,7 @@ rules:
          unit: '{milliseconds}'
 
   # Cassandra Client Metrics
- - bean: dev.responsive:type=cassandra-driver
+ - bean: dev.responsive:type=cassandra-client
    mapping:
       bytes-sent:
         metric: cassandra.driver.bytes.sent.count

--- a/kafka-client/src/main/resources/otel-jmx.config.yaml
+++ b/kafka-client/src/main/resources/otel-jmx.config.yaml
@@ -347,3 +347,88 @@ rules:
        type: gauge
        desc: total records processed
        unit: '{records}'
+
+ # MongoDB Client Metrics
+ - bean: dev.responsive:type=mongodb,command=*
+   metricAttribute:
+       command: param(command)
+   mapping:
+       commands-succeeded-count:
+         metric: mongodb.client.commands.succeeded.count
+         type: gauge
+         desc: count of commands that succeeded
+         unit: '{commands}'
+       commands-succeeded-cumulative-latency:
+         metric: mongodb.client.commands.succeeded.cumulative.latency
+         type: gauge
+         desc: cumulative commands succeeded latency
+         unit: '{milliseconds}'
+       commands-failed-count:
+         metric: mongodb.client.commands.failed.count
+         type: gauge
+         desc: count of commands that failed
+         unit: '{commands}'
+       commands-failed-cumulative-latency:
+         metric: mongodb.client.commands.succeeded.failed.latency
+         type: gauge
+         desc: cumulative commands failed latency
+         unit: '{milliseconds}'
+
+  # Cassandra Client Metrics
+ - bean: dev.responsive:type=cassandra-driver
+   mapping:
+      bytes-sent:
+        metric: cassandra.driver.bytes.sent.count
+        type: gauge
+        desc: count of bytes sent
+        unit: '{bytes}'
+      bytes-received:
+        metric: cassandra.driver.bytes.received.count
+        type: gauge
+        desc: count of bytes received
+        unit: '{bytes}'
+      cql-requests-count:
+        metric: cassandra.driver.cql.request.count
+        type: gauge
+        desc: count of CQL requests
+        unit: '{requests}'
+      cql-requests-cumulative-latency:
+        metric: cassandra.driver.cql.request.cumulative.latency
+        type: gauge
+        desc: cumulative CQL request latency in milliseconds
+        unit: '{milliseconds}'
+      cql-request-errors-count:
+        metric: cassandra.driver.cql.request.errors
+        type: gauge
+        desc: count of all request errors
+        unit: '{errors}'
+      cql-request-timeouts-count:
+        metric: cassandra.driver.cql.request.timeout.count
+        type: gauge
+        desc: count of CQL request timeouts
+        unit: '{errors}'
+      cql-request-ignores-count:
+        metric: cassandra.driver.cql.request.ignores.count
+        type: gauge
+        desc: count of all request ignores
+        unit: '{errors}'
+      cql-request-retries-count:
+        metric: cassandra.driver.cql.request.retries.count
+        type: gauge
+        desc: count of all request retries
+        unit: '{errors}'
+      throttling-cumulative-delay:
+        metric: cassandra.driver.throttling.cumulative.delay
+        type: gauge
+        desc: cumulative throttling delay in milliseconds
+        unit: '{milliseconds}'
+      throttling-errors-count:
+        metric: cassandra.driver.throttling.errors.count
+        type: gauge
+        desc: count of throttling errors
+        unit: '{errors}'
+      connection-errors-count:
+        metric: cassandra.driver.connection.errors.count
+        type: gauge
+        desc: cumulative count of all connection errors
+        unit: '{errors}'

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/mongo/MongoTelemetryListenerTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/mongo/MongoTelemetryListenerTest.java
@@ -38,12 +38,12 @@ public class MongoTelemetryListenerTest {
   @Test
   public void shouldHaveCorrectNamesForSuccessMetrics() {
     final MetricName findSuccessCountName = commandsSucceededCount("find");
-    assertEquals("mongodb", findSuccessCountName.group());
+    assertEquals("mongodb-client", findSuccessCountName.group());
     assertEquals("commands-succeeded-count", findSuccessCountName.name());
     assertEquals(Collections.singletonMap("command", "find"), findSuccessCountName.tags());
 
     final MetricName findSuccessLatencyName = commandsSucceededLatency("find");
-    assertEquals("mongodb", findSuccessLatencyName.group());
+    assertEquals("mongodb-client", findSuccessLatencyName.group());
     assertEquals("commands-succeeded-cumulative-latency", findSuccessLatencyName.name());
     assertEquals(Collections.singletonMap("command", "find"), findSuccessLatencyName.tags());
   }
@@ -51,12 +51,12 @@ public class MongoTelemetryListenerTest {
   @Test
   public void shouldHaveCorrectNamesForFailureMetrics() {
     final MetricName findFailureCountName = commandsFailedCount("find");
-    assertEquals("mongodb", findFailureCountName.group());
+    assertEquals("mongodb-client", findFailureCountName.group());
     assertEquals("commands-failed-count", findFailureCountName.name());
     assertEquals(Collections.singletonMap("command", "find"), findFailureCountName.tags());
 
     final MetricName findFailureLatencyName = commandsFailedLatency("find");
-    assertEquals("mongodb", findFailureLatencyName.group());
+    assertEquals("mongodb-client", findFailureLatencyName.group());
     assertEquals("commands-failed-cumulative-latency", findFailureLatencyName.name());
     assertEquals(Collections.singletonMap("command", "find"), findFailureLatencyName.tags());
   }

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/metrics/CassandraMetricsFactoryTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/metrics/CassandraMetricsFactoryTest.java
@@ -329,7 +329,7 @@ class CassandraMetricsFactoryTest {
       String name
   ) {
     return metrics.metrics().entrySet().stream()
-        .filter(entry -> "cassandra-driver".equals(entry.getKey().group())
+        .filter(entry -> "cassandra-client".equals(entry.getKey().group())
             && name.equals(entry.getKey().name()))
         .findFirst()
         .orElseThrow(() -> new AssertionFailedError(


### PR DESCRIPTION
This patch updates the OTEL configuration to include collection of MongoDB (#361) and Cassandra (#363) metrics.
