### PR TITLE
Row-level TTL PR 2.5: fix default ttl for CassandraKeyValueTable

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/api/stores/ResponsiveKeyValueBytesStoreSupplier.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/stores/ResponsiveKeyValueBytesStoreSupplier.java
@@ -47,7 +47,7 @@ public class ResponsiveKeyValueBytesStoreSupplier implements KeyValueBytesStoreS
     if (isTimestamped) {
       return new ResponsiveTimestampedKeyValueStore(params);
     } else {
-      return new ResponsiveKeyValueStore(params, isTimestamped);
+      return new ResponsiveKeyValueStore(params, false);
     }
   }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/stores/TtlProvider.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/stores/TtlProvider.java
@@ -110,6 +110,9 @@ public class TtlProvider<K, V> {
         valueSerde);
   }
 
+  /**
+   * @return the same TtlProvider with a key-and-value-based override function
+   */
   public TtlProvider<K, V> fromKeyAndValue(
       final BiFunction<K, V, Optional<TtlDuration>> computeTtlFromKeyAndValue,
       final Serde<K> keySerde,

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraFactTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraFactTable.java
@@ -82,11 +82,10 @@ public class CassandraFactTable implements RemoteKVTable<BoundStatement> {
       final CassandraClient client
   ) {
     final String name = spec.tableName();
-    final var ttlResolver = spec.ttlResolver();
     LOG.info("Creating fact data table {} in remote store.", name);
 
     final CreateTableWithOptions createTable = spec.applyDefaultOptions(
-        createTable(name, ttlResolver)
+        createTable(name, spec.ttlResolver())
     );
 
     // separate metadata from the main table for the fact schema, this is acceptable

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraFactTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraFactTable.java
@@ -82,10 +82,11 @@ public class CassandraFactTable implements RemoteKVTable<BoundStatement> {
       final CassandraClient client
   ) {
     final String name = spec.tableName();
+    final var ttlResolver = spec.ttlResolver();
     LOG.info("Creating fact data table {} in remote store.", name);
 
     final CreateTableWithOptions createTable = spec.applyDefaultOptions(
-        createTable(name, spec.ttlResolver())
+        createTable(name, ttlResolver)
     );
 
     // separate metadata from the main table for the fact schema, this is acceptable

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/CassandraFactTableIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/CassandraFactTableIntegrationTest.java
@@ -125,7 +125,7 @@ class CassandraFactTableIntegrationTest {
 
   @SuppressWarnings("OptionalGetWithoutIsPresent")
   @Test
-  public void shouldRespectSemanticDefaultOnlyTtl() throws Exception {
+  public void shouldConfigureDefaultTtl() throws Exception {
     // Given:
     final var defaultTtl = Duration.ofMinutes(30);
     final var ttlProvider = TtlProvider.<String, String>withDefault(defaultTtl);

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/CassandraKVTableIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/CassandraKVTableIntegrationTest.java
@@ -17,7 +17,6 @@
 package dev.responsive.kafka.internal.db;
 
 import static dev.responsive.kafka.api.config.ResponsiveConfig.CASSANDRA_DESIRED_NUM_PARTITION_CONFIG;
-import static dev.responsive.kafka.internal.db.partitioning.TablePartitioner.defaultPartitioner;
 import static dev.responsive.kafka.testutils.IntegrationTestUtils.copyConfigWithOverrides;
 import static java.util.Collections.singletonMap;
 import static org.hamcrest.MatcherAssert.assertThat;


### PR DESCRIPTION
Quick followup to PR #2 (https://github.com/responsivedev/responsive-pub/pull/371) which switched the method of setting a ttl from the old Spec layers to the new TtlResolver. Carried over the ttl to the CassandraFactTable but forgot to apply it for the CassandraKeyValueTable, which is done in this PR 