### PR TITLE
Row-level TTL PR 2: compute minValidTs from TtlResolver

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/api/stores/ResponsiveKeyValueParams.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/stores/ResponsiveKeyValueParams.java
@@ -71,13 +71,4 @@ public final class ResponsiveKeyValueParams {
     return ttlProvider;
   }
 
-  public Optional<TtlDuration> defaultTimeToLive() {
-    if (ttlProvider.isPresent()) {
-      return Optional.ofNullable(ttlProvider.get().defaultTtl());
-
-    } else {
-      return Optional.empty();
-    }
-  }
-
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/stores/TtlProvider.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/stores/TtlProvider.java
@@ -173,11 +173,11 @@ public class TtlProvider<K, V> {
     }
 
     public long toSeconds() {
-      return duration.toSeconds();
+      return duration().toSeconds();
     }
 
     public long toMillis() {
-      return duration.toMillis();
+      return duration().toMillis();
     }
 
     @Override

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/RemoteKVTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/RemoteKVTable.java
@@ -38,12 +38,11 @@ public interface RemoteKVTable<S> extends RemoteTable<Bytes, S> {
    *
    * @param kafkaPartition  the kafka partition
    * @param key             the data key
-   * @param minValidTs      the minimum valid timestamp to apply semantic TTL,
-   *                        in epochMillis
+   * @param streamTimeMs    the current streamTime
    *
    * @return the value previously set
    */
-  byte[] get(int kafkaPartition, Bytes key, long minValidTs);
+  byte[] get(int kafkaPartition, Bytes key, long streamTimeMs);
 
   /**
    * Retrieves a range of key value pairs from the given {@code partitionKey} and
@@ -57,7 +56,7 @@ public interface RemoteKVTable<S> extends RemoteTable<Bytes, S> {
    * @param kafkaPartition  the kafka partition
    * @param from            the starting key (inclusive)
    * @param to              the ending key (inclusive)
-   * @param minValidTs      the minimum timestamp, in epochMillis, to consider valid
+   * @param streamTimeMs    the current streamTime
    *
    * @return an iterator of all key-value pairs in the range
    */
@@ -65,7 +64,7 @@ public interface RemoteKVTable<S> extends RemoteTable<Bytes, S> {
       int kafkaPartition,
       Bytes from,
       Bytes to,
-      long minValidTs
+      long streamTimeMs
   );
 
   /**
@@ -77,11 +76,11 @@ public interface RemoteKVTable<S> extends RemoteTable<Bytes, S> {
    * session).
    *
    * @param kafkaPartition  the kafka partition
-   * @param minValidTs      the minimum valid timestamp, in epochMilliis, to return
+   * @param streamTimeMs    the current streamTime
    *
    * @return an iterator of all key-value pairs
    */
-  KeyValueIterator<Bytes, byte[]> all(int kafkaPartition, long minValidTs);
+  KeyValueIterator<Bytes, byte[]> all(int kafkaPartition, long streamTimeMs);
 
   /**
    *  An approximate count of the total number of entries across all sub-partitions

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/internal/db/TTDKeyValueTable.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/internal/db/TTDKeyValueTable.java
@@ -94,7 +94,7 @@ public class TTDKeyValueTable extends TTDTable<Bytes> implements RemoteKVTable<B
   }
 
   @Override
-  public byte[] get(final int kafkaPartition, final Bytes key, long minValidTs) {
+  public byte[] get(final int kafkaPartition, final Bytes key, long streamTimeMs) {
     return stub.get(key);
   }
 
@@ -103,7 +103,7 @@ public class TTDKeyValueTable extends TTDTable<Bytes> implements RemoteKVTable<B
       final int kafkaPartition,
       Bytes from,
       final Bytes to,
-      long minValidTs
+      long streamTimeMs
   ) {
     return stub.range(from, to);
   }
@@ -111,7 +111,7 @@ public class TTDKeyValueTable extends TTDTable<Bytes> implements RemoteKVTable<B
   @Override
   public KeyValueIterator<Bytes, byte[]> all(
       final int kafkaPartition,
-      long minValidTs
+      long streamTimeMs
   ) {
     return stub.all();
   }


### PR DESCRIPTION
Short PR to move the computation of `minValidTs` from the upper layer of the KV stores to the inner Table implementations where we can account for the TtlResolver

Introduces the TtlResolver used to hook everything up within Responsive. Also cleans up the RemoteTableSpec

PR 1: API https://github.com/responsivedev/responsive-pub/pull/370
PR 2: TtlResolver https://github.com/responsivedev/responsive-pub/pull/371

Future TODO (in order)
1. Cassandra Fact tables (insert/get) <--- this is the next PR
2. TopologyTestDriver
3. Mongo KV tables (insert/get/range/all)
4. Cassandra KVTables (insert/get/range/all)