### PR TITLE
Row-level TTL PR 4: CassandraFactTable implementation

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraFactTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraFactTable.java
@@ -319,12 +319,12 @@ public class CassandraFactTable implements RemoteKVTable<BoundStatement> {
             ? (int) rowTtl.get().toSeconds()
             : 0;
 
-          return insertWithTtl
-              .bind()
-              .setByteBuffer(DATA_KEY.bind(), ByteBuffer.wrap(key.get()))
-              .setByteBuffer(DATA_VALUE.bind(), ByteBuffer.wrap(value))
-              .setInstant(TIMESTAMP.bind(), Instant.ofEpochMilli(epochMillis))
-              .setInt(TTL_SECONDS.bind(), rowTtlOverrideSeconds);
+        return insertWithTtl
+            .bind()
+            .setByteBuffer(DATA_KEY.bind(), ByteBuffer.wrap(key.get()))
+            .setByteBuffer(DATA_VALUE.bind(), ByteBuffer.wrap(value))
+            .setInstant(TIMESTAMP.bind(), Instant.ofEpochMilli(epochMillis))
+            .setInt(TTL_SECONDS.bind(), rowTtlOverrideSeconds);
       }
     }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraFactTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraFactTable.java
@@ -323,7 +323,7 @@ public class CassandraFactTable implements RemoteKVTable<BoundStatement> {
               .bind()
               .setByteBuffer(DATA_KEY.bind(), ByteBuffer.wrap(key.get()))
               .setByteBuffer(DATA_VALUE.bind(), ByteBuffer.wrap(value))
-              .setLong(TIMESTAMP.bind(), epochMillis)
+              .setInstant(TIMESTAMP.bind(), Instant.ofEpochMilli(epochMillis))
               .setInt(TTL_SECONDS.bind(), rowTtlOverrideSeconds);
       }
     }
@@ -370,7 +370,8 @@ public class CassandraFactTable implements RemoteKVTable<BoundStatement> {
     final BoundStatement getQuery = get
         .bind()
         .setByteBuffer(DATA_KEY.bind(), ByteBuffer.wrap(key.get()))
-        .setLong(TIMESTAMP.bind(), minValidTimeMs);
+        .setInstant(TIMESTAMP.bind(), Instant.ofEpochMilli(minValidTimeMs));
+
     final List<Row> result = client.execute(getQuery).all();
 
     if (result.size() > 1) {

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraFactTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraFactTable.java
@@ -402,7 +402,7 @@ public class CassandraFactTable implements RemoteKVTable<BoundStatement> {
 
     if (ttl.isFinite()) {
       final long minValidTsFromValue = streamTimeMs - ttl.toMillis();
-      final long recordTs = rowResult.getLong(TIMESTAMP.column());
+      final long recordTs = rowResult.getInstant(TIMESTAMP.column()).toEpochMilli();
       if (recordTs < minValidTsFromValue) {
         return null;
       }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraWindowedTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraWindowedTable.java
@@ -42,7 +42,6 @@ import com.datastax.oss.driver.api.core.type.DataTypes;
 import com.datastax.oss.driver.api.querybuilder.QueryBuilder;
 import com.datastax.oss.driver.api.querybuilder.SchemaBuilder;
 import com.datastax.oss.driver.api.querybuilder.schema.CreateTableWithOptions;
-import com.datastax.oss.driver.internal.querybuilder.schema.compaction.DefaultLeveledCompactionStrategy;
 import dev.responsive.kafka.internal.db.partitioning.Segmenter;
 import dev.responsive.kafka.internal.db.partitioning.WindowSegmentPartitioner;
 import dev.responsive.kafka.internal.db.spec.RemoteTableSpec;

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraWindowedTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraWindowedTable.java
@@ -425,8 +425,7 @@ public class CassandraWindowedTable implements RemoteWindowedTable<BoundStatemen
         .withColumn(DATA_VALUE.column(), DataTypes.BLOB)
         .withColumn(OFFSET.column(), DataTypes.BIGINT)
         .withColumn(EPOCH.column(), DataTypes.BIGINT)
-        .withColumn(STREAM_TIME.column(), DataTypes.BIGINT)
-        .withCompaction(new DefaultLeveledCompactionStrategy()); // TODO: create a LCSTableSpec?
+        .withColumn(STREAM_TIME.column(), DataTypes.BIGINT);
   }
 
   public CassandraWindowedTable(

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/ColumnName.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/ColumnName.java
@@ -40,7 +40,8 @@ public enum ColumnName {
   EPOCH("epoch", "epoch"),
   STREAM_TIME("streamTime", "streamtime"),
   WINDOW_START("windowStart", "windowstart", ts -> timestamp((long) ts)),
-  TIMESTAMP("ts", "ts", ts -> timestamp((long) ts));
+  TIMESTAMP("ts", "ts", ts -> timestamp((long) ts)),
+  TTL_SECONDS("ttl", "ttl", ttl -> ttlSeconds((int) ttl));
 
   static final Bytes METADATA_KEY
       = Bytes.wrap("_metadata".getBytes(StandardCharsets.UTF_8));
@@ -59,6 +60,10 @@ public enum ColumnName {
 
   private static Literal timestamp(final long ts) {
     return QueryBuilder.literal(Instant.ofEpochMilli(ts));
+  }
+
+  private static Literal ttlSeconds(final int ttl) {
+    return QueryBuilder.literal(ttl);
   }
 
   ColumnName(final String column, final String bind) {

--- a/kafka-client/src/test/java/dev/responsive/kafka/testutils/SerdeUtils.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/testutils/SerdeUtils.java
@@ -1,0 +1,32 @@
+package dev.responsive.kafka.testutils;
+
+import org.apache.kafka.common.serialization.Serde;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.state.ValueAndTimestamp;
+import org.apache.kafka.streams.state.internals.ValueAndTimestampSerde;
+
+public class SerdeUtils {
+
+  private static final Serde<String> STRING_SERDE = Serdes.String();
+  private static final Serde<ValueAndTimestamp<String>> VALUE_AND_TIMESTAMP_STRING_SERDE =
+      new ValueAndTimestampSerde<>(STRING_SERDE);
+
+  public static <D> byte[] serialize(final D data, final Serde<D> serde) {
+    return serde.serializer().serialize("ignored", data);
+  }
+
+  public static Bytes serializedKey(final String key) {
+    return Bytes.wrap(serialize(key, STRING_SERDE));
+  }
+
+  public static byte[] serializedValue(final String value) {
+    return serialize(value, STRING_SERDE);
+  }
+
+  public static byte[] serializedValueAndTimestamp(final String value, final long timestamp) {
+    final ValueAndTimestamp<String> valueAndTimestamp = ValueAndTimestamp.make(value, timestamp);
+    return serialize(valueAndTimestamp, VALUE_AND_TIMESTAMP_STRING_SERDE);
+  }
+
+}


### PR DESCRIPTION
Implement row-level ttl for Scylla fact tables

PR 1: API https://github.com/responsivedev/responsive-pub/pull/370
PR 2: TtlResolver https://github.com/responsivedev/responsive-pub/pull/371
PR 3: compute minValidTs from TtlResolver https://github.com/responsivedev/responsive-pub/pull/373

Planned followup PRs (in order)
1. TopologyTestDriver
2. Mongo KV tables (insert/get/range/all)

Unplanned future work (can be picked up ad-hoc as needed)
1. Row-level ttl for Cassandra KVTables (insert/get/range/all)
2. Row-level ttl for in-memory KV tables
3. General ttl for global tables
4. Row-level ttl with migration mode