### PR TITLE
Row-level TTL PR 5: automatically extract StateSerdes

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/api/stores/TtlProvider.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/stores/TtlProvider.java
@@ -21,7 +21,6 @@ import java.time.Duration;
 import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Function;
-import org.apache.kafka.common.serialization.Serde;
 
 public class TtlProvider<K, V> {
 
@@ -222,6 +221,7 @@ public class TtlProvider<K, V> {
   ) {
     final K key;
     final V value;
+
     switch (ttlType) {
       case DEFAULT_ONLY:
         key = null; //ignored

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/stores/TtlProvider.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/stores/TtlProvider.java
@@ -59,6 +59,9 @@ public class TtlProvider<K, V> {
   }
 
   /**
+   * @param computeTtlFromKey function that returns the ttl override for this specific key,
+   *                          or {@link Optional#empty()} to use the default ttl
+   *
    * @return the same TtlProvider with a key-based override function
    */
   public TtlProvider<K, V> fromKey(
@@ -76,6 +79,8 @@ public class TtlProvider<K, V> {
   }
 
   /**
+   * @param computeTtlFromValue function that returns the ttl override for this specific value,
+   *                            or {@link Optional#empty()} to use the default ttl
    * @return the same TtlProvider with a value-based override function
    */
   public TtlProvider<K, V> fromValue(
@@ -93,6 +98,8 @@ public class TtlProvider<K, V> {
   }
 
   /**
+   * @param computeTtlFromKeyAndValue function that returns the ttl override for this specific key
+   *                                  and value, or {@link Optional#empty()} to use the default ttl
    * @return the same TtlProvider with a key-and-value-based override function
    */
   public TtlProvider<K, V> fromKeyAndValue(

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/GlobalOperations.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/GlobalOperations.java
@@ -26,6 +26,7 @@ import dev.responsive.kafka.internal.db.RemoteTableSpecFactory;
 import dev.responsive.kafka.internal.metrics.ResponsiveRestoreListener;
 import dev.responsive.kafka.internal.utils.SessionClients;
 import java.util.Collection;
+import java.util.Optional;
 import java.util.concurrent.TimeoutException;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.TopicPartition;
@@ -67,7 +68,7 @@ public class GlobalOperations implements KeyValueOperations {
     final var spec = RemoteTableSpecFactory.fromKVParams(
         params,
         defaultPartitioner(),
-        TtlResolver.fromTtlProvider(false, changelogTopic.topic(), params.ttlProvider())
+        Optional.empty()
     );
 
     final var table = client.globalFactory().create(spec);

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/GlobalOperations.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/GlobalOperations.java
@@ -50,10 +50,11 @@ public class GlobalOperations implements KeyValueOperations {
 
   public static GlobalOperations create(
       final StateStoreContext storeContext,
-      final ResponsiveKeyValueParams params
+      final ResponsiveKeyValueParams params,
+      final Optional<TtlResolver<?, ?>> ttlResolver
   ) throws InterruptedException, TimeoutException {
 
-    if (params.ttlProvider().isPresent()) {
+    if (ttlResolver.isPresent()) {
       throw new UnsupportedOperationException("Global stores are not yet compatible with ttl");
     }
 
@@ -68,7 +69,7 @@ public class GlobalOperations implements KeyValueOperations {
     final var spec = RemoteTableSpecFactory.fromKVParams(
         params,
         defaultPartitioner(),
-        Optional.empty()
+        ttlResolver
     );
 
     final var table = client.globalFactory().create(spec);

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/KVOperationsProvider.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/KVOperationsProvider.java
@@ -20,13 +20,14 @@ import dev.responsive.kafka.api.stores.ResponsiveKeyValueParams;
 import java.util.concurrent.TimeoutException;
 import org.apache.kafka.streams.processor.StateStoreContext;
 import org.apache.kafka.streams.processor.internals.Task;
+import org.apache.kafka.streams.state.StateSerdes;
 
 @FunctionalInterface
 public interface KVOperationsProvider {
 
   KeyValueOperations provide(
       final ResponsiveKeyValueParams params,
-      final boolean isTimestamped,
+      final StateSerdes<?, ?> stateSerdes,
       final StateStoreContext context,
       final Task.TaskType type
   ) throws InterruptedException, TimeoutException;

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/KVOperationsProvider.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/KVOperationsProvider.java
@@ -17,17 +17,17 @@
 package dev.responsive.kafka.internal.stores;
 
 import dev.responsive.kafka.api.stores.ResponsiveKeyValueParams;
+import java.util.Optional;
 import java.util.concurrent.TimeoutException;
 import org.apache.kafka.streams.processor.StateStoreContext;
 import org.apache.kafka.streams.processor.internals.Task;
-import org.apache.kafka.streams.state.StateSerdes;
 
 @FunctionalInterface
 public interface KVOperationsProvider {
 
   KeyValueOperations provide(
       final ResponsiveKeyValueParams params,
-      final StateSerdes<?, ?> stateSerdes,
+      final Optional<TtlResolver<?, ?>> ttlResolver,
       final StateStoreContext context,
       final Task.TaskType type
   ) throws InterruptedException, TimeoutException;

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/PartitionedOperations.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/PartitionedOperations.java
@@ -53,7 +53,6 @@ import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.streams.processor.StateStoreContext;
 import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
 import org.apache.kafka.streams.state.KeyValueIterator;
-import org.apache.kafka.streams.state.StateSerdes;
 import org.slf4j.Logger;
 
 public class PartitionedOperations implements KeyValueOperations {
@@ -77,7 +76,7 @@ public class PartitionedOperations implements KeyValueOperations {
 
   public static PartitionedOperations create(
       final TableName name,
-      final StateSerdes<?, ?> stateSerdes,
+      final Optional<TtlResolver<?, ?>> ttlResolver,
       final StateStoreContext storeContext,
       final ResponsiveKeyValueParams params
   ) throws InterruptedException, TimeoutException {
@@ -97,12 +96,6 @@ public class PartitionedOperations implements KeyValueOperations {
     final TopicPartition changelog = new TopicPartition(
         changelogFor(storeContext, name.kafkaName(), false),
         context.taskId().partition()
-    );
-
-    final Optional<TtlResolver<?, ?>> ttlResolver = TtlResolver.fromTtlProvider(
-        stateSerdes,
-        changelog.topic(),
-        params.ttlProvider()
     );
 
     final RemoteKVTable<?> table;

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/PartitionedOperations.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/PartitionedOperations.java
@@ -53,6 +53,7 @@ import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.streams.processor.StateStoreContext;
 import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
 import org.apache.kafka.streams.state.KeyValueIterator;
+import org.apache.kafka.streams.state.StateSerdes;
 import org.slf4j.Logger;
 
 public class PartitionedOperations implements KeyValueOperations {
@@ -76,7 +77,7 @@ public class PartitionedOperations implements KeyValueOperations {
 
   public static PartitionedOperations create(
       final TableName name,
-      final boolean isTimestamped,
+      final StateSerdes<?, ?> stateSerdes,
       final StateStoreContext storeContext,
       final ResponsiveKeyValueParams params
   ) throws InterruptedException, TimeoutException {
@@ -99,7 +100,7 @@ public class PartitionedOperations implements KeyValueOperations {
     );
 
     final Optional<TtlResolver<?, ?>> ttlResolver = TtlResolver.fromTtlProvider(
-        isTimestamped,
+        stateSerdes,
         changelog.topic(),
         params.ttlProvider()
     );

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveKeyValueStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveKeyValueStore.java
@@ -141,7 +141,7 @@ public class ResponsiveKeyValueStore
       final TaskType taskType
   ) throws InterruptedException, TimeoutException {
     return (taskType == TaskType.GLOBAL)
-        ? GlobalOperations.create(context, params)
+        ? GlobalOperations.create(context, params, ttlResolver)
         : PartitionedOperations.create(params.name(), ttlResolver, context, params);
   }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/TtlResolver.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/TtlResolver.java
@@ -21,6 +21,7 @@ import dev.responsive.kafka.api.stores.TtlProvider.TtlDuration;
 import dev.responsive.kafka.internal.utils.StateDeserializer;
 import java.util.Optional;
 import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.state.StateSerdes;
 
 public class TtlResolver<K, V> {
 
@@ -29,26 +30,25 @@ public class TtlResolver<K, V> {
   private final StateDeserializer<K, V> stateDeserializer;
   private final TtlProvider<K, V> ttlProvider;
 
-  public static Optional<TtlResolver<?, ?>> fromTtlProvider(
-      final boolean isTimestamped,
+  public static <K, V> Optional<TtlResolver<K, V>> fromTtlProvider(
+      final StateSerdes<K, V> stateSerdes,
       final String changelogTopic,
-      final Optional<TtlProvider<?, ?>> ttlProvider
+      final Optional<TtlProvider<K, V>> ttlProvider
   ) {
     return ttlProvider.isPresent()
-        ? Optional.of(new TtlResolver<>(isTimestamped, changelogTopic, ttlProvider.get()))
+        ? Optional.of(new TtlResolver<>(stateSerdes, changelogTopic, ttlProvider.get()))
         : Optional.empty();
   }
 
   public TtlResolver(
-      final boolean isTimestamped,
+      final StateSerdes<K, V> stateSerdes,
       final String changelogTopic,
       final TtlProvider<K, V> ttlProvider
   ) {
     this.stateDeserializer = new StateDeserializer<>(
-        isTimestamped,
         changelogTopic,
-        ttlProvider.keySerde(),
-        ttlProvider.valueSerde()
+        stateSerdes.keyDeserializer(),
+        stateSerdes.valueDeserializer()
     );
     this.ttlProvider = ttlProvider;
   }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/TtlResolver.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/TtlResolver.java
@@ -30,26 +30,28 @@ public class TtlResolver<K, V> {
   private final StateDeserializer<K, V> stateDeserializer;
   private final TtlProvider<K, V> ttlProvider;
 
-  public static <K, V> Optional<TtlResolver<K, V>> fromTtlProvider(
-      final StateSerdes<K, V> stateSerdes,
-      final String changelogTopic,
-      final Optional<TtlProvider<K, V>> ttlProvider
+  @SuppressWarnings("unchecked")
+  public static <K, V> Optional<TtlResolver<?, ?>> fromTtlProviderAndStateSerdes(
+      final StateSerdes<?, ?> stateSerdes,
+      final Optional<TtlProvider<?, ?>> ttlProvider
   ) {
     return ttlProvider.isPresent()
-        ? Optional.of(new TtlResolver<>(stateSerdes, changelogTopic, ttlProvider.get()))
+        ? Optional.of(
+            new TtlResolver<>(
+                (StateDeserializer<K, V>) new StateDeserializer<>(
+                    stateSerdes.topic(),
+                    stateSerdes.keyDeserializer(),
+                    stateSerdes.valueDeserializer()),
+                (TtlProvider<K, V>) ttlProvider.get()
+            ))
         : Optional.empty();
   }
 
   public TtlResolver(
-      final StateSerdes<K, V> stateSerdes,
-      final String changelogTopic,
+      final StateDeserializer<K, V> stateDeserializer,
       final TtlProvider<K, V> ttlProvider
   ) {
-    this.stateDeserializer = new StateDeserializer<>(
-        changelogTopic,
-        stateSerdes.keyDeserializer(),
-        stateSerdes.valueDeserializer()
-    );
+    this.stateDeserializer = stateDeserializer;
     this.ttlProvider = ttlProvider;
   }
 

--- a/kafka-client/src/main/java/org/apache/kafka/streams/state/internals/StoreAccessorUtil.java
+++ b/kafka-client/src/main/java/org/apache/kafka/streams/state/internals/StoreAccessorUtil.java
@@ -5,12 +5,12 @@ import org.apache.kafka.streams.state.StateSerdes;
 
 public class StoreAccessorUtil {
 
-  @SuppressWarnings("unchecked")
-  public static <K, V> StateSerdes<K, V> extractKeyValueStoreSerdes(
+  @SuppressWarnings("rawtypes")
+  public static StateSerdes<?, ?> extractKeyValueStoreSerdes(
       final StateStore store
   ) {
     if (store instanceof MeteredKeyValueStore) {
-      return ((MeteredKeyValueStore<K, V>) store).serdes;
+      return ((MeteredKeyValueStore) store).serdes;
     } else {
       throw new IllegalStateException("Attempted to extract serdes from store of type "
                                           + store.getClass().getName());

--- a/kafka-client/src/main/java/org/apache/kafka/streams/state/internals/StoreAccessorUtil.java
+++ b/kafka-client/src/main/java/org/apache/kafka/streams/state/internals/StoreAccessorUtil.java
@@ -1,0 +1,19 @@
+package org.apache.kafka.streams.state.internals;
+
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.state.StateSerdes;
+
+public class StoreAccessorUtil {
+
+  @SuppressWarnings("unchecked")
+  public static <K, V> StateSerdes<K, V> extractKeyValueStoreSerdes(
+      final StateStore store
+  ) {
+    if (store instanceof MeteredKeyValueStore) {
+      return ((MeteredKeyValueStore<K, V>) store).serdes;
+    } else {
+      throw new IllegalStateException("Attempted to extract serdes from store of type "
+                                          + store.getClass().getName());
+    }
+  }
+}

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/CassandraFactTableIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/CassandraFactTableIntegrationTest.java
@@ -18,6 +18,8 @@ package dev.responsive.kafka.internal.db;
 
 import static dev.responsive.kafka.internal.db.partitioning.TablePartitioner.defaultPartitioner;
 import static dev.responsive.kafka.internal.stores.TtlResolver.NO_TTL;
+import static dev.responsive.kafka.testutils.IntegrationTestUtils.defaultOnlyTtl;
+import static dev.responsive.kafka.testutils.IntegrationTestUtils.withTtlProvider;
 import static dev.responsive.kafka.testutils.SerdeUtils.serializedKey;
 import static dev.responsive.kafka.testutils.SerdeUtils.serializedValue;
 import static java.util.concurrent.TimeUnit.MINUTES;
@@ -33,7 +35,6 @@ import dev.responsive.kafka.api.config.ResponsiveConfig;
 import dev.responsive.kafka.api.stores.ResponsiveKeyValueParams;
 import dev.responsive.kafka.api.stores.TtlProvider;
 import dev.responsive.kafka.api.stores.TtlProvider.TtlDuration;
-import dev.responsive.kafka.internal.stores.TtlResolver;
 import dev.responsive.kafka.testutils.ResponsiveConfigParam;
 import dev.responsive.kafka.testutils.ResponsiveExtension;
 import java.time.Duration;
@@ -42,6 +43,7 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
@@ -142,7 +144,7 @@ class CassandraFactTableIntegrationTest {
     client.factFactory().create(RemoteTableSpecFactory.fromKVParams(
         params,
         defaultPartitioner(),
-        Optional.of(new TtlResolver<>(false, "changelog-ignored", ttlProvider))
+        defaultOnlyTtl(Duration.ofMillis(ttlMs))
     ));
 
     // Then:
@@ -168,7 +170,7 @@ class CassandraFactTableIntegrationTest {
     final var table = client.factFactory().create(RemoteTableSpecFactory.fromKVParams(
         params,
         defaultPartitioner(),
-        Optional.of(new TtlResolver<>(false, "changelog-ignored", ttlProvider))
+        defaultOnlyTtl(Duration.ofMillis(ttlMs))
     ));
 
     final long insertTimeMs = 0L;
@@ -209,7 +211,7 @@ class CassandraFactTableIntegrationTest {
     final var table = client.factFactory().create(RemoteTableSpecFactory.fromKVParams(
         params,
         defaultPartitioner(),
-        Optional.of(new TtlResolver<>(false, "changelog-ignored", ttlProvider))
+        withTtlProvider(ttlProvider, Serdes.String(), Serdes.String())
     ));
 
     table.init(1);
@@ -274,8 +276,8 @@ class CassandraFactTableIntegrationTest {
     final var table = client.factFactory().create(RemoteTableSpecFactory.fromKVParams(
         params,
         defaultPartitioner(),
-        Optional.of(new TtlResolver<>(false, "changelog-ignored", ttlProvider))
-    ));
+        withTtlProvider(ttlProvider, Serdes.String(), Serdes.String()))
+    );
 
     table.init(1);
 
@@ -352,8 +354,8 @@ class CassandraFactTableIntegrationTest {
     final var table = client.factFactory().create(RemoteTableSpecFactory.fromKVParams(
         params,
         defaultPartitioner(),
-        Optional.of(new TtlResolver<>(false, "changelog-ignored", ttlProvider))
-    ));
+        withTtlProvider(ttlProvider, Serdes.String(), Serdes.String()))
+    );
 
     table.init(1);
 

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/CassandraFactTableIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/CassandraFactTableIntegrationTest.java
@@ -19,7 +19,6 @@ package dev.responsive.kafka.internal.db;
 import static dev.responsive.kafka.internal.db.partitioning.TablePartitioner.defaultPartitioner;
 import static dev.responsive.kafka.internal.stores.TtlResolver.NO_TTL;
 import static dev.responsive.kafka.testutils.IntegrationTestUtils.defaultOnlyTtl;
-import static dev.responsive.kafka.testutils.IntegrationTestUtils.withTtlProvider;
 import static dev.responsive.kafka.testutils.SerdeUtils.serializedKey;
 import static dev.responsive.kafka.testutils.SerdeUtils.serializedValue;
 import static java.util.concurrent.TimeUnit.MINUTES;
@@ -35,6 +34,8 @@ import dev.responsive.kafka.api.config.ResponsiveConfig;
 import dev.responsive.kafka.api.stores.ResponsiveKeyValueParams;
 import dev.responsive.kafka.api.stores.TtlProvider;
 import dev.responsive.kafka.api.stores.TtlProvider.TtlDuration;
+import dev.responsive.kafka.internal.stores.TtlResolver;
+import dev.responsive.kafka.internal.utils.StateDeserializer;
 import dev.responsive.kafka.testutils.ResponsiveConfigParam;
 import dev.responsive.kafka.testutils.ResponsiveExtension;
 import java.time.Duration;
@@ -43,7 +44,7 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.function.Function;
-import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
@@ -211,7 +212,9 @@ class CassandraFactTableIntegrationTest {
     final var table = client.factFactory().create(RemoteTableSpecFactory.fromKVParams(
         params,
         defaultPartitioner(),
-        withTtlProvider(ttlProvider, Serdes.String(), Serdes.String())
+        Optional.of(new TtlResolver<>(
+            new StateDeserializer<>("ignored", new StringDeserializer(), new StringDeserializer()),
+            ttlProvider))
     ));
 
     table.init(1);
@@ -276,8 +279,10 @@ class CassandraFactTableIntegrationTest {
     final var table = client.factFactory().create(RemoteTableSpecFactory.fromKVParams(
         params,
         defaultPartitioner(),
-        withTtlProvider(ttlProvider, Serdes.String(), Serdes.String()))
-    );
+        Optional.of(new TtlResolver<>(
+            new StateDeserializer<>("ignored", new StringDeserializer(), new StringDeserializer()),
+            ttlProvider))
+    ));
 
     table.init(1);
 
@@ -354,8 +359,10 @@ class CassandraFactTableIntegrationTest {
     final var table = client.factFactory().create(RemoteTableSpecFactory.fromKVParams(
         params,
         defaultPartitioner(),
-        withTtlProvider(ttlProvider, Serdes.String(), Serdes.String()))
-    );
+        Optional.of(new TtlResolver<>(
+            new StateDeserializer<>("ignored", new StringDeserializer(), new StringDeserializer()),
+            ttlProvider)
+    )));
 
     table.init(1);
 

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/CassandraFactTableIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/CassandraFactTableIntegrationTest.java
@@ -20,6 +20,7 @@ import static dev.responsive.kafka.internal.db.partitioning.TablePartitioner.def
 import static dev.responsive.kafka.internal.stores.TtlResolver.NO_TTL;
 import static dev.responsive.kafka.testutils.SerdeUtils.serializedKey;
 import static dev.responsive.kafka.testutils.SerdeUtils.serializedValue;
+import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.containsStringIgnoringCase;
@@ -41,7 +42,6 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiFunction;
 import java.util.function.Function;
-import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.utils.Bytes;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
@@ -159,9 +159,9 @@ class CassandraFactTableIntegrationTest {
 
 
   @Test
-  public void shouldRespectSemanticDefaultOnlyTtlForLookups() throws Exception {
+  public void shouldRespectSemanticDefaultOnlyTtl() throws Exception {
     // Given:
-    final long ttlMs = 100L;
+    final long ttlMs = MINUTES.toMillis(100);
     final var ttlProvider = TtlProvider.<String, String>withDefault(Duration.ofMillis(ttlMs));
     params = ResponsiveKeyValueParams.fact(storeName).withTtlProvider(ttlProvider);
 
@@ -190,20 +190,20 @@ class CassandraFactTableIntegrationTest {
   @Test
   public void shouldRespectSemanticKeyBasedTtl() throws Exception {
     // Given:
-    final var defaultTtl = Duration.ofMillis(30);
+    final var defaultTtl = Duration.ofMinutes(30);
     final Function<String, Optional<TtlDuration>> ttlForKey = k -> {
       if (k.equals("KEEP_FOREVER")) {
         return Optional.of(TtlDuration.noTtl());
       } else if (k.endsWith("DEFAULT_TTL")) {
         return Optional.empty();
       } else {
-        final long ttlMilliseconds = Long.parseLong(k);
-        return Optional.of(TtlDuration.of(Duration.ofMillis(ttlMilliseconds)));
+        final long ttlMinutes = Long.parseLong(k);
+        return Optional.of(TtlDuration.of(Duration.ofMinutes(ttlMinutes)));
       }
     };
     final TtlProvider<String, String> ttlProvider = TtlProvider
         .<String, String>withDefault(defaultTtl)
-        .fromKey(ttlForKey, Serdes.String());
+        .fromKey(ttlForKey);
     params = ResponsiveKeyValueParams.fact(storeName).withTtlProvider(ttlProvider);
 
     final var table = client.factFactory().create(RemoteTableSpecFactory.fromKVParams(
@@ -216,8 +216,8 @@ class CassandraFactTableIntegrationTest {
 
     final Bytes noTtlKey = serializedKey("KEEP_FOREVER");
     final Bytes defaultTtlKey = serializedKey("DEFAULT_TTL"); // default is 30ms
-    final Bytes tenMsTtlKey = serializedKey(String.valueOf(10L));
-    final Bytes fiftyMsTtlKey = serializedKey(String.valueOf(50L));
+    final Bytes tenMinTtlKey = serializedKey(String.valueOf(10L));
+    final Bytes fiftyMinTtlKey = serializedKey(String.valueOf(50L));
 
     final byte[] val = new byte[]{1};
 
@@ -225,49 +225,49 @@ class CassandraFactTableIntegrationTest {
     final long insertTimeMs = 0L;
     client.execute(table.insert(1, noTtlKey, val, insertTimeMs));
     client.execute(table.insert(1, defaultTtlKey, val, insertTimeMs));
-    client.execute(table.insert(1, tenMsTtlKey, val, insertTimeMs));
-    client.execute(table.insert(1, fiftyMsTtlKey, val, insertTimeMs));
+    client.execute(table.insert(1, tenMinTtlKey, val, insertTimeMs));
+    client.execute(table.insert(1, fiftyMinTtlKey, val, insertTimeMs));
 
     // Then
-    long lookupTime = Duration.ofMillis(11).toMillis();
-    assertThat(table.get(1, noTtlKey, lookupTime), is(val));
-    assertThat(table.get(1, defaultTtlKey, lookupTime), is(val));
-    assertThat(table.get(1, tenMsTtlKey, lookupTime), nullValue()); // expired
-    assertThat(table.get(1, fiftyMsTtlKey, lookupTime), is(val));
+    long lookupTimeMs = Duration.ofMinutes(11).toMillis();
+    assertThat(table.get(1, noTtlKey, lookupTimeMs), is(val));
+    assertThat(table.get(1, defaultTtlKey, lookupTimeMs), is(val));
+    assertThat(table.get(1, tenMinTtlKey, lookupTimeMs), nullValue()); // expired
+    assertThat(table.get(1, fiftyMinTtlKey, lookupTimeMs), is(val));
 
-    lookupTime = Duration.ofMillis(31).toMillis();
-    assertThat(table.get(1, noTtlKey, lookupTime), is(val));
-    assertThat(table.get(1, defaultTtlKey, lookupTime), nullValue());    // expired
-    assertThat(table.get(1, tenMsTtlKey, lookupTime), nullValue()); // expired
-    assertThat(table.get(1, fiftyMsTtlKey, lookupTime), is(val));
+    lookupTimeMs = Duration.ofMinutes(31).toMillis();
+    assertThat(table.get(1, noTtlKey, lookupTimeMs), is(val));
+    assertThat(table.get(1, defaultTtlKey, lookupTimeMs), nullValue());    // expired
+    assertThat(table.get(1, tenMinTtlKey, lookupTimeMs), nullValue()); // expired
+    assertThat(table.get(1, fiftyMinTtlKey, lookupTimeMs), is(val));
 
-    lookupTime = Duration.ofMillis(51).toMillis();
-    assertThat(table.get(1, noTtlKey, lookupTime), is(val));
-    assertThat(table.get(1, defaultTtlKey, lookupTime), nullValue());    // expired
-    assertThat(table.get(1, tenMsTtlKey, lookupTime), nullValue()); // expired
-    assertThat(table.get(1, fiftyMsTtlKey, lookupTime), nullValue());   // expired
+    lookupTimeMs = Duration.ofMinutes(51).toMillis();
+    assertThat(table.get(1, noTtlKey, lookupTimeMs), is(val));
+    assertThat(table.get(1, defaultTtlKey, lookupTimeMs), nullValue());    // expired
+    assertThat(table.get(1, tenMinTtlKey, lookupTimeMs), nullValue()); // expired
+    assertThat(table.get(1, fiftyMinTtlKey, lookupTimeMs), nullValue());   // expired
   }
 
   @Test
   public void shouldRespectSemanticKeyValueBasedTtl() throws Exception {
     // Given:
-    final var defaultTtl = Duration.ofMillis(30);
+    final var defaultTtl = Duration.ofMinutes(30);
     final BiFunction<String, String, Optional<TtlDuration>> ttlForKeyAndValue = (k, v) -> {
-      if (k.equals("10_MS_RETENTION")) {
-        return Optional.of(TtlDuration.of(Duration.ofMillis(10)));
+      if (k.equals("10_MIN_RETENTION")) {
+        return Optional.of(TtlDuration.of(Duration.ofMinutes(10)));
       } else {
         if (v.equals("DEFAULT")) {
           return Optional.empty();
         } else if (v.equals("NO_TTL")) {
           return Optional.of(TtlDuration.noTtl());
         } else {
-          return Optional.of(TtlDuration.of(Duration.ofMillis(Long.parseLong(v))));
+          return Optional.of(TtlDuration.of(Duration.ofMinutes(Long.parseLong(v))));
         }
       }
     };
     final TtlProvider<String, String> ttlProvider = TtlProvider
         .<String, String>withDefault(defaultTtl)
-        .fromKeyAndValue(ttlForKeyAndValue, Serdes.String(), Serdes.String());
+        .fromKeyAndValue(ttlForKeyAndValue);
     params = ResponsiveKeyValueParams.fact(storeName).withTtlProvider(ttlProvider);
 
 
@@ -279,73 +279,73 @@ class CassandraFactTableIntegrationTest {
 
     table.init(1);
 
-    final Bytes tenMsTtlKey = serializedKey("10_MS_RETENTION");
-    final Bytes defaultTtlKey = serializedKey("DEFAULT_30_MS_RETENTION");
+    final Bytes tenMinTtlKey = serializedKey("10_MIN_RETENTION");
+    final Bytes defaultTtlKey = serializedKey("DEFAULT_30_MIN_RETENTION");
     final Bytes noTtlKey = serializedKey("NO_TTL");
-    final Bytes twoMsTtlKey = serializedKey("2_MS_RETENTION");
-    final Bytes fiftyMsTtlKey = serializedKey("50_MS_RETENTION");
+    final Bytes twoMinTtlKey = serializedKey("2_MIN_RETENTION");
+    final Bytes fiftyMinTtlKey = serializedKey("50_MIN_RETENTION");
 
     final byte[] defaultTtlValue = serializedValue("DEFAULT"); // default is 30ms
     final byte[] noTtlValue = serializedValue("NO_TTL");
-    final byte[] twoMsTtlValue = serializedValue(String.valueOf(2));
-    final byte[] fiftyMsTtlValue = serializedValue(String.valueOf(50));
+    final byte[] twoMinTtlValue = serializedValue(String.valueOf(2));
+    final byte[] fiftyMinTtlValue = serializedValue(String.valueOf(50));
 
     final byte[] val = new byte[]{1};
 
     // When
     long insertTimeMs = 0L;
-    client.execute(table.insert(1, tenMsTtlKey, val, insertTimeMs));
+    client.execute(table.insert(1, tenMinTtlKey, val, insertTimeMs));
     client.execute(table.insert(1, defaultTtlKey, defaultTtlValue, insertTimeMs));
     client.execute(table.insert(1, noTtlKey, noTtlValue, insertTimeMs));
-    client.execute(table.insert(1, twoMsTtlKey, twoMsTtlValue, insertTimeMs));
-    client.execute(table.insert(1, fiftyMsTtlKey, fiftyMsTtlValue, insertTimeMs));
+    client.execute(table.insert(1, twoMinTtlKey, twoMinTtlValue, insertTimeMs));
+    client.execute(table.insert(1, fiftyMinTtlKey, fiftyMinTtlValue, insertTimeMs));
 
     // Then:
-    long lookupTime = Duration.ofMillis(3).toMillis();
-    assertThat(table.get(1, tenMsTtlKey, lookupTime), is(val));
-    assertThat(table.get(1, defaultTtlKey, lookupTime), is(defaultTtlValue));
-    assertThat(table.get(1, noTtlKey, lookupTime), is(noTtlValue));
-    assertThat(table.get(1, twoMsTtlKey, lookupTime), nullValue());            // expired
-    assertThat(table.get(1, fiftyMsTtlKey, lookupTime), is(fiftyMsTtlValue));
+    long lookupTimeMs = Duration.ofMinutes(3).toMillis();
+    assertThat(table.get(1, tenMinTtlKey, lookupTimeMs), is(val));
+    assertThat(table.get(1, defaultTtlKey, lookupTimeMs), is(defaultTtlValue));
+    assertThat(table.get(1, noTtlKey, lookupTimeMs), is(noTtlValue));
+    assertThat(table.get(1, twoMinTtlKey, lookupTimeMs), nullValue());            // expired
+    assertThat(table.get(1, fiftyMinTtlKey, lookupTimeMs), is(fiftyMinTtlValue));
 
-    lookupTime = Duration.ofMillis(11).toMillis();
-    assertThat(table.get(1, tenMsTtlKey, lookupTime), nullValue());            // expired
-    assertThat(table.get(1, defaultTtlKey, lookupTime), is(defaultTtlValue));
-    assertThat(table.get(1, noTtlKey, lookupTime), is(noTtlValue));
-    assertThat(table.get(1, twoMsTtlKey, lookupTime), nullValue());            // expired
-    assertThat(table.get(1, fiftyMsTtlKey, lookupTime), is(fiftyMsTtlValue));
+    lookupTimeMs = Duration.ofMinutes(11).toMillis();
+    assertThat(table.get(1, tenMinTtlKey, lookupTimeMs), nullValue());            // expired
+    assertThat(table.get(1, defaultTtlKey, lookupTimeMs), is(defaultTtlValue));
+    assertThat(table.get(1, noTtlKey, lookupTimeMs), is(noTtlValue));
+    assertThat(table.get(1, twoMinTtlKey, lookupTimeMs), nullValue());            // expired
+    assertThat(table.get(1, fiftyMinTtlKey, lookupTimeMs), is(fiftyMinTtlValue));
 
-    lookupTime = Duration.ofMillis(31).toMillis();
-    assertThat(table.get(1, tenMsTtlKey, lookupTime), nullValue());            // expired
-    assertThat(table.get(1, defaultTtlKey, lookupTime), nullValue());           // expired
-    assertThat(table.get(1, noTtlKey, lookupTime), is(noTtlValue));
-    assertThat(table.get(1, twoMsTtlKey, lookupTime), nullValue());            // expired
-    assertThat(table.get(1, fiftyMsTtlKey, lookupTime), is(fiftyMsTtlValue));
+    lookupTimeMs = Duration.ofMinutes(31).toMillis();
+    assertThat(table.get(1, tenMinTtlKey, lookupTimeMs), nullValue());            // expired
+    assertThat(table.get(1, defaultTtlKey, lookupTimeMs), nullValue());           // expired
+    assertThat(table.get(1, noTtlKey, lookupTimeMs), is(noTtlValue));
+    assertThat(table.get(1, twoMinTtlKey, lookupTimeMs), nullValue());            // expired
+    assertThat(table.get(1, fiftyMinTtlKey, lookupTimeMs), is(fiftyMinTtlValue));
 
-    lookupTime = Duration.ofMillis(51).toMillis();
-    assertThat(table.get(1, tenMsTtlKey, lookupTime), nullValue());            // expired
-    assertThat(table.get(1, defaultTtlKey, lookupTime), nullValue());           // expired
-    assertThat(table.get(1, noTtlKey, lookupTime), is(noTtlValue));
-    assertThat(table.get(1, twoMsTtlKey, lookupTime), nullValue());            // expired
-    assertThat(table.get(1, fiftyMsTtlKey, lookupTime), nullValue());          // expired
+    lookupTimeMs = Duration.ofMinutes(51).toMillis();
+    assertThat(table.get(1, tenMinTtlKey, lookupTimeMs), nullValue());            // expired
+    assertThat(table.get(1, defaultTtlKey, lookupTimeMs), nullValue());           // expired
+    assertThat(table.get(1, noTtlKey, lookupTimeMs), is(noTtlValue));
+    assertThat(table.get(1, twoMinTtlKey, lookupTimeMs), nullValue());            // expired
+    assertThat(table.get(1, fiftyMinTtlKey, lookupTimeMs), nullValue());          // expired
   }
 
   @Test
   public void shouldRespectOverridesWithValueBasedTtl() throws Exception {
     // Given:
-    final var defaultTtl = Duration.ofMillis(30);
+    final var defaultTtl = Duration.ofMinutes(30);
     final Function<String, Optional<TtlDuration>> ttlForValue = v -> {
       if (v.equals("DEFAULT")) {
         return Optional.empty();
       } else if (v.equals("NO_TTL")) {
         return Optional.of(TtlDuration.noTtl());
       } else {
-        return Optional.of(TtlDuration.of(Duration.ofMillis(Long.parseLong(v))));
+        return Optional.of(TtlDuration.of(Duration.ofMinutes(Long.parseLong(v))));
       }
     };
     final TtlProvider<String, String> ttlProvider = TtlProvider
         .<String, String>withDefault(defaultTtl)
-        .fromValue(ttlForValue, Serdes.String());
+        .fromValue(ttlForValue);
     params = ResponsiveKeyValueParams.fact(storeName).withTtlProvider(ttlProvider);
 
 
@@ -357,50 +357,49 @@ class CassandraFactTableIntegrationTest {
 
     table.init(1);
 
-
     final Bytes key = serializedKey("ignored");
 
     final byte[] defaultTtlValue = serializedValue("DEFAULT"); // default is 30ms
     final byte[] noTtlValue = serializedValue("NO_TTL");
-    final byte[] threeMsTtlValue = serializedValue(String.valueOf(3));
-    final byte[] tenMsTtlValue = serializedValue(String.valueOf(10));
+    final byte[] threeMinTtlValue = serializedValue(String.valueOf(3));
+    final byte[] tenMinTtlValue = serializedValue(String.valueOf(10));
 
     // When
-    long currentTime = 0L;
+    long currentTimeMs = 0L;
     // first record set to expire at 3ms
-    client.execute(table.insert(1, key, threeMsTtlValue, currentTime));
+    client.execute(table.insert(1, key, threeMinTtlValue, currentTimeMs));
 
     // Then:
-    currentTime = Duration.ofMillis(4).toMillis();
-    assertThat(table.get(1, key, currentTime), nullValue()); // expired
+    currentTimeMs = Duration.ofMinutes(4).toMillis();
+    assertThat(table.get(1, key, currentTimeMs), nullValue()); // expired
 
     // insert new record with 3ms ttl -- now set to expire at 10ms
-    currentTime = Duration.ofMillis(7).toMillis();
-    client.execute(table.insert(1, key, threeMsTtlValue, currentTime));
+    currentTimeMs = Duration.ofMinutes(7).toMillis();
+    client.execute(table.insert(1, key, threeMinTtlValue, currentTimeMs));
 
     // override with 10ms ttl -- now set to expire at 18ms
-    currentTime = Duration.ofMillis(8).toMillis();
-    client.execute(table.insert(1, key, tenMsTtlValue, currentTime));
+    currentTimeMs = Duration.ofMinutes(8).toMillis();
+    client.execute(table.insert(1, key, tenMinTtlValue, currentTimeMs));
 
     // record should still exist after 10ms
-    currentTime = Duration.ofMillis(11).toMillis();
-    assertThat(table.get(1, key, currentTime), is(tenMsTtlValue));
+    currentTimeMs = Duration.ofMinutes(11).toMillis();
+    assertThat(table.get(1, key, currentTimeMs), is(tenMinTtlValue));
 
     // override with default ttl (30ms) -- now set to expire at 45ms
-    currentTime = Duration.ofMillis(15).toMillis();
-    client.execute(table.insert(1, key, defaultTtlValue, currentTime));
+    currentTimeMs = Duration.ofMinutes(15).toMillis();
+    client.execute(table.insert(1, key, defaultTtlValue, currentTimeMs));
 
     // record should still exist after 18ms
-    currentTime = Duration.ofMillis(20).toMillis();
-    assertThat(table.get(1, key, currentTime), is(defaultTtlValue));
+    currentTimeMs = Duration.ofMinutes(20).toMillis();
+    assertThat(table.get(1, key, currentTimeMs), is(defaultTtlValue));
 
     // override with no ttl -- now set to never expire
-    currentTime = Duration.ofMillis(30).toMillis();
-    client.execute(table.insert(1, key, noTtlValue, currentTime));
+    currentTimeMs = Duration.ofMinutes(30).toMillis();
+    client.execute(table.insert(1, key, noTtlValue, currentTimeMs));
 
     // record should still exist after 45ms
-    currentTime = Duration.ofMillis(50).toMillis();
-    assertThat(table.get(1, key, currentTime), is(noTtlValue));
+    currentTimeMs = Duration.ofMinutes(50).toMillis();
+    assertThat(table.get(1, key, currentTimeMs), is(noTtlValue));
   }
 
 }

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/CassandraKVTableIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/CassandraKVTableIntegrationTest.java
@@ -53,9 +53,6 @@ import org.testcontainers.containers.CassandraContainer;
 @ExtendWith(ResponsiveExtension.class)
 public class CassandraKVTableIntegrationTest {
 
-  private static final long CURRENT_TS = 100L;
-  private static final long MIN_VALID_TS = 0L;
-
   // Set up with 4 subpartitions per kafka partition
   private static final int NUM_SUBPARTITIONS_TOTAL = 8;
   private static final int NUM_KAFKA_PARTITIONS = NUM_SUBPARTITIONS_TOTAL / 4;
@@ -131,19 +128,19 @@ public class CassandraKVTableIntegrationTest {
     final RemoteKVTable<BoundStatement> table = createTable();
 
     final List<BoundStatement> inserts = List.of(
-        table.insert(0, Bytes.wrap(new byte[]{0x0, 0x1}), new byte[]{0x1}, CURRENT_TS),
-        table.insert(0, Bytes.wrap(new byte[]{0x1, 0x0}), new byte[]{0x1}, CURRENT_TS),
-        table.insert(0, Bytes.wrap(new byte[]{0x2, 0x0}), new byte[]{0x1}, CURRENT_TS),
-        table.insert(0, Bytes.wrap(new byte[]{0x2, 0x2}), new byte[]{0x1}, CURRENT_TS),
-        table.insert(0, Bytes.wrap(new byte[]{0x1, 0x1}), new byte[]{0x1}, CURRENT_TS),
-        table.insert(0, Bytes.wrap(new byte[]{0x0, 0x2}), new byte[]{0x1}, CURRENT_TS),
-        table.insert(0, Bytes.wrap(new byte[]{0x2}), new byte[]{0x1}, CURRENT_TS),
-        table.insert(0, Bytes.wrap(new byte[]{0x0}), new byte[]{0x1}, CURRENT_TS)
+        table.insert(0, Bytes.wrap(new byte[]{0x0, 0x1}), new byte[]{0x1}, 0L),
+        table.insert(0, Bytes.wrap(new byte[]{0x1, 0x0}), new byte[]{0x1}, 0L),
+        table.insert(0, Bytes.wrap(new byte[]{0x2, 0x0}), new byte[]{0x1}, 0L),
+        table.insert(0, Bytes.wrap(new byte[]{0x2, 0x2}), new byte[]{0x1}, 0L),
+        table.insert(0, Bytes.wrap(new byte[]{0x1, 0x1}), new byte[]{0x1}, 0L),
+        table.insert(0, Bytes.wrap(new byte[]{0x0, 0x2}), new byte[]{0x1}, 0L),
+        table.insert(0, Bytes.wrap(new byte[]{0x2}), new byte[]{0x1}, 0L),
+        table.insert(0, Bytes.wrap(new byte[]{0x0}), new byte[]{0x1}, 0L)
     );
     inserts.forEach(client::execute);
 
     // When:
-    final KeyValueIterator<Bytes, byte[]> all = table.all(0, MIN_VALID_TS);
+    final KeyValueIterator<Bytes, byte[]> all = table.all(0, 0L);
 
     // Then:
     Bytes old = all.next().key;
@@ -160,18 +157,18 @@ public class CassandraKVTableIntegrationTest {
     final RemoteKVTable<BoundStatement> table = createTable();
 
     final List<BoundStatement> inserts = List.of(
-        table.insert(0, Bytes.wrap("A".getBytes()), new byte[]{0x1}, CURRENT_TS),
-        table.insert(0, Bytes.wrap("B".getBytes()), new byte[]{0x1}, CURRENT_TS),
-        table.insert(0, Bytes.wrap("C".getBytes()), new byte[]{0x1}, CURRENT_TS),
-        table.insert(0, Bytes.wrap("CC".getBytes()), new byte[]{0x1}, CURRENT_TS),
-        table.insert(0, Bytes.wrap("CCC".getBytes()), new byte[]{0x1}, CURRENT_TS),
-        table.insert(0, Bytes.wrap("CD".getBytes()), new byte[]{0x1}, CURRENT_TS),
-        table.insert(0, Bytes.wrap("D".getBytes()), new byte[]{0x1}, CURRENT_TS),
-        table.insert(0, Bytes.wrap("E".getBytes()), new byte[]{0x1}, CURRENT_TS),
-        table.insert(0, Bytes.wrap("F".getBytes()), new byte[]{0x1}, CURRENT_TS),
-        table.insert(0, Bytes.wrap("G".getBytes()), new byte[]{0x1}, CURRENT_TS),
-        table.insert(0, Bytes.wrap("H".getBytes()), new byte[]{0x1}, CURRENT_TS),
-        table.insert(0, Bytes.wrap("I".getBytes()), new byte[]{0x1}, CURRENT_TS)
+        table.insert(0, Bytes.wrap("A".getBytes()), new byte[]{0x1}, 0L),
+        table.insert(0, Bytes.wrap("B".getBytes()), new byte[]{0x1}, 0L),
+        table.insert(0, Bytes.wrap("C".getBytes()), new byte[]{0x1}, 0L),
+        table.insert(0, Bytes.wrap("CC".getBytes()), new byte[]{0x1}, 0L),
+        table.insert(0, Bytes.wrap("CCC".getBytes()), new byte[]{0x1}, 0L),
+        table.insert(0, Bytes.wrap("CD".getBytes()), new byte[]{0x1}, 0L),
+        table.insert(0, Bytes.wrap("D".getBytes()), new byte[]{0x1}, 0L),
+        table.insert(0, Bytes.wrap("E".getBytes()), new byte[]{0x1}, 0L),
+        table.insert(0, Bytes.wrap("F".getBytes()), new byte[]{0x1}, 0L),
+        table.insert(0, Bytes.wrap("G".getBytes()), new byte[]{0x1}, 0L),
+        table.insert(0, Bytes.wrap("H".getBytes()), new byte[]{0x1}, 0L),
+        table.insert(0, Bytes.wrap("I".getBytes()), new byte[]{0x1}, 0L)
     );
     inserts.forEach(client::execute);
 
@@ -179,7 +176,7 @@ public class CassandraKVTableIntegrationTest {
         0,
         Bytes.wrap("B".getBytes()),
         Bytes.wrap("H".getBytes()),
-        MIN_VALID_TS)
+        0L)
     ) {
 
       // Then:
@@ -318,10 +315,10 @@ public class CassandraKVTableIntegrationTest {
     final RemoteKVTable<BoundStatement> table = createTable();
 
     final byte[] valBytes = new byte[]{0x1};
-    client.execute(table.insert(0, ColumnName.METADATA_KEY, valBytes, CURRENT_TS));
+    client.execute(table.insert(0, ColumnName.METADATA_KEY, valBytes, 0L));
 
     // When:
-    final byte[] val = table.get(0, ColumnName.METADATA_KEY, MIN_VALID_TS);
+    final byte[] val = table.get(0, ColumnName.METADATA_KEY, 0L);
 
     // Then:
     assertThat(val, Matchers.is(valBytes));

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/CassandraKVTableIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/CassandraKVTableIntegrationTest.java
@@ -19,6 +19,7 @@ package dev.responsive.kafka.internal.db;
 import static dev.responsive.kafka.api.config.ResponsiveConfig.CASSANDRA_DESIRED_NUM_PARTITION_CONFIG;
 import static dev.responsive.kafka.testutils.IntegrationTestUtils.copyConfigWithOverrides;
 import static java.util.Collections.singletonMap;
+import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
@@ -281,14 +282,14 @@ public class CassandraKVTableIntegrationTest {
   @Test
   public void shouldRespectSemanticDefaultOnlyTtlForAllQueries() {
     // Given:
-    final long ttlMs = 100L;
+    final long ttlMs = MINUTES.toMillis(100);
     final TtlProvider<?, ?> ttlProvider = TtlProvider.withDefault(Duration.ofMillis(ttlMs));
     final RemoteKVTable<BoundStatement> table = createTable(ttlProvider);
 
     final List<BoundStatement> inserts = List.of(
-        table.insert(0, Bytes.wrap(new byte[]{0x0, 0x0}), new byte[]{0x1}, 10L),
-        table.insert(0, Bytes.wrap(new byte[]{0x0, 0x1}), new byte[]{0x1}, 0L), // expired
-        table.insert(0, Bytes.wrap(new byte[]{0x0, 0x2}), new byte[]{0x1}, 20L)
+        table.insert(0, Bytes.wrap(new byte[]{0x0, 0x0}), new byte[]{0x1}, MINUTES.toMillis(10L)),
+        table.insert(0, Bytes.wrap(new byte[]{0x0, 0x1}), new byte[]{0x1}, MINUTES.toMillis(0L)), // expired
+        table.insert(0, Bytes.wrap(new byte[]{0x0, 0x2}), new byte[]{0x1}, MINUTES.toMillis(20L))
     );
     inserts.forEach(client::execute);
 

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/CassandraKVTableIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/CassandraKVTableIntegrationTest.java
@@ -18,7 +18,6 @@ package dev.responsive.kafka.internal.db;
 
 import static dev.responsive.kafka.api.config.ResponsiveConfig.CASSANDRA_DESIRED_NUM_PARTITION_CONFIG;
 import static dev.responsive.kafka.testutils.IntegrationTestUtils.copyConfigWithOverrides;
-import static dev.responsive.kafka.testutils.IntegrationTestUtils.withTtlProvider;
 import static java.util.Collections.singletonMap;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/CassandraKVTableIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/CassandraKVTableIntegrationTest.java
@@ -18,6 +18,7 @@ package dev.responsive.kafka.internal.db;
 
 import static dev.responsive.kafka.api.config.ResponsiveConfig.CASSANDRA_DESIRED_NUM_PARTITION_CONFIG;
 import static dev.responsive.kafka.testutils.IntegrationTestUtils.copyConfigWithOverrides;
+import static dev.responsive.kafka.testutils.IntegrationTestUtils.withTtlProvider;
 import static java.util.Collections.singletonMap;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/CassandraKVTableIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/CassandraKVTableIntegrationTest.java
@@ -288,7 +288,8 @@ public class CassandraKVTableIntegrationTest {
 
     final List<BoundStatement> inserts = List.of(
         table.insert(0, Bytes.wrap(new byte[]{0x0, 0x0}), new byte[]{0x1}, MINUTES.toMillis(10L)),
-        table.insert(0, Bytes.wrap(new byte[]{0x0, 0x1}), new byte[]{0x1}, MINUTES.toMillis(0L)), // expired
+        // expired
+        table.insert(0, Bytes.wrap(new byte[]{0x0, 0x1}), new byte[]{0x1}, MINUTES.toMillis(0L)),
         table.insert(0, Bytes.wrap(new byte[]{0x0, 0x2}), new byte[]{0x1}, MINUTES.toMillis(20L))
     );
     inserts.forEach(client::execute);

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/CassandraKVTableIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/CassandraKVTableIntegrationTest.java
@@ -18,6 +18,7 @@ package dev.responsive.kafka.internal.db;
 
 import static dev.responsive.kafka.api.config.ResponsiveConfig.CASSANDRA_DESIRED_NUM_PARTITION_CONFIG;
 import static dev.responsive.kafka.testutils.IntegrationTestUtils.copyConfigWithOverrides;
+import static dev.responsive.kafka.testutils.IntegrationTestUtils.withTtlProvider;
 import static java.util.Collections.singletonMap;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -112,8 +113,7 @@ public class CassandraKVTableIntegrationTest {
         storeName + "-changelog"
     );
 
-    final Optional<TtlResolver<?, ?>> ttlResolver =
-        TtlResolver.fromTtlProvider(false, "changelog-ignored", params.ttlProvider());
+    final Optional<TtlResolver<?, ?>> ttlResolver = withTtlProvider(params.ttlProvider());
 
     try {
       return CassandraKeyValueTable.create(

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/ResponsiveKeyValueStoreTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/ResponsiveKeyValueStoreTest.java
@@ -22,9 +22,9 @@ import static org.mockito.Mockito.when;
 
 import dev.responsive.kafka.api.stores.ResponsiveKeyValueParams;
 import org.apache.kafka.common.utils.Bytes;
-import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.StateStoreContext;
 import org.apache.kafka.streams.processor.internals.InternalProcessorContext;
+import org.apache.kafka.streams.state.internals.MeteredKeyValueStore;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -39,7 +39,7 @@ class ResponsiveKeyValueStoreTest {
   @Mock
   private InternalProcessorContext<?, ?> context;
   @Mock
-  private StateStore root;
+  private MeteredKeyValueStore<?, ?> root;
 
   @Test
   public void shouldPutIfAbsent() {

--- a/kafka-client/src/test/java/dev/responsive/kafka/testutils/IntegrationTestUtils.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/testutils/IntegrationTestUtils.java
@@ -54,7 +54,6 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.IsolationLevel;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
@@ -64,7 +63,7 @@ import org.apache.kafka.streams.KafkaStreams.State;
 import org.apache.kafka.streams.KafkaStreams.StateListener;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.Topology;
-import org.apache.kafka.streams.state.StateSerdes;
+
 import org.junit.jupiter.api.TestInfo;
 
 public final class IntegrationTestUtils {

--- a/kafka-client/src/test/java/dev/responsive/kafka/testutils/IntegrationTestUtils.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/testutils/IntegrationTestUtils.java
@@ -63,7 +63,6 @@ import org.apache.kafka.streams.KafkaStreams.State;
 import org.apache.kafka.streams.KafkaStreams.StateListener;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.Topology;
-
 import org.junit.jupiter.api.TestInfo;
 
 public final class IntegrationTestUtils {

--- a/kafka-client/src/test/java/dev/responsive/kafka/testutils/IntegrationTestUtils.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/testutils/IntegrationTestUtils.java
@@ -114,17 +114,6 @@ public final class IntegrationTestUtils {
         : Optional.empty();
   }
 
-  public static <K, V> Optional<TtlResolver<K, V>> withTtlProvider(
-      final TtlProvider<K, V> ttlProvider,
-      final Serde<K> keySerde,
-      final Serde<V> valueSerde
-  ) {
-    return Optional.of(new TtlResolver<>(
-        new StateDeserializer<>("ignored", keySerde.deserializer(), valueSerde.deserializer()),
-        ttlProvider)
-    );
-  }
-
   public static ResponsiveConfig copyConfigWithOverrides(
       final ResponsiveConfig original,
       final Map<String, Object> overrides


### PR DESCRIPTION
Avoid forcing the user to pass in their serdes again by extracting the StateSerdes from the MeteredKeyValueStore layer of the StateStore hierarchy.

Also addresses feedback from PR 4 to increase the ttl times used in the CassandraKV/FactTableIntegrationTest tests

PR 1: API https://github.com/responsivedev/responsive-pub/pull/370
PR 2: TtlResolver https://github.com/responsivedev/responsive-pub/pull/371
PR 3: compute minValidTs from TtlResolver https://github.com/responsivedev/responsive-pub/pull/373
PR 4: CassandraFactTable implementation https://github.com/responsivedev/responsive-pub/pull/374

Planned followup PRs (in order)
1. TopologyTestDriver <-- next/that before release cut
2. Mongo KV tables (insert/get/range/all)

Unplanned future work (can be picked up ad-hoc as needed)
1. Row-level ttl for Cassandra KVTables (insert/get/range/all)
2. Row-level ttl for in-memory KV tables
3. General ttl for global tables
4. Row-level ttl with migration mode