### PR TITLE
Throw exception on standbys and row-level ttl in MongoKVTable

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/api/stores/ResponsiveKeyValueBytesStoreSupplier.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/stores/ResponsiveKeyValueBytesStoreSupplier.java
@@ -47,7 +47,7 @@ public class ResponsiveKeyValueBytesStoreSupplier implements KeyValueBytesStoreS
     if (isTimestamped) {
       return new ResponsiveTimestampedKeyValueStore(params);
     } else {
-      return new ResponsiveKeyValueStore(params, false);
+      return new ResponsiveKeyValueStore(params);
     }
   }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoKVTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoKVTable.java
@@ -108,7 +108,11 @@ public class MongoKVTable implements RemoteKVTable<WriteModel<KVDoc>> {
     );
 
     if (ttlResolver.isPresent()) {
-      // TODO(sophie): account for infinite default ttl
+      // TODO(sophie): account for infinite default ttl when we add row-level ttl
+      if (!ttlResolver.get().hasDefaultOnly()) {
+        throw new UnsupportedOperationException("Row-level ttl is not yet supported with MongoDB");
+      }
+
       this.defaultTtlMs = ttlResolver.get().defaultTtl().toMillis();
       final long expireAfterMs = defaultTtlMs + Duration.ofHours(12).toMillis();
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveKeyValueStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveKeyValueStore.java
@@ -44,7 +44,6 @@ public class ResponsiveKeyValueStore
 
   private final ResponsiveKeyValueParams params;
   private final TableName name;
-  private final boolean isTimestamped;
   private final KVOperationsProvider opsProvider;
 
   private Position position; // TODO(IQ): update the position during restoration
@@ -56,12 +55,10 @@ public class ResponsiveKeyValueStore
   private StateStoreContext context;
 
   public ResponsiveKeyValueStore(
-      final ResponsiveKeyValueParams params,
-      final boolean isTimestamped
+      final ResponsiveKeyValueParams params
   ) {
     this(
         params,
-        isTimestamped,
         ResponsiveKeyValueStore::provideOperations
     );
   }
@@ -69,12 +66,10 @@ public class ResponsiveKeyValueStore
   // Visible for Testing
   public ResponsiveKeyValueStore(
       final ResponsiveKeyValueParams params,
-      final boolean isTimestamped,
       final KVOperationsProvider opsProvider
   ) {
     this.params = params;
     this.name = params.name();
-    this.isTimestamped = isTimestamped;
     this.position = Position.emptyPosition();
     this.opsProvider = opsProvider;
 
@@ -115,7 +110,8 @@ public class ResponsiveKeyValueStore
       context = storeContext;
 
       if (taskType == TaskType.STANDBY) {
-        log.warn("Unexpected standby task created, should transition to active shortly");
+        log.error("Unexpected standby task created");
+        throw new IllegalStateException("Store " + name() + " was opened as a standby");
       }
 
       final StateSerdes<?, ?> stateSerdes = StoreAccessorUtil.extractKeyValueStoreSerdes(root);

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveTimestampedKeyValueStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveTimestampedKeyValueStore.java
@@ -10,13 +10,13 @@ public class ResponsiveTimestampedKeyValueStore
   public ResponsiveTimestampedKeyValueStore(
       final ResponsiveKeyValueParams params
   ) {
-    super(params, true);
+    super(params);
   }
 
   public ResponsiveTimestampedKeyValueStore(
       final ResponsiveKeyValueParams params,
       final KVOperationsProvider opsProvider
   ) {
-    super(params, true, opsProvider);
+    super(params, opsProvider);
   }
 }

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/ResponsiveKeyValueStoreTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/ResponsiveKeyValueStoreTest.java
@@ -46,8 +46,7 @@ class ResponsiveKeyValueStoreTest {
     // Given:
     final var store = new ResponsiveKeyValueStore(
         ResponsiveKeyValueParams.keyValue("test"),
-        false,
-        (params, isTimestamped, context, type) -> ops
+        (params, ttlResolver, context, type) -> ops
     );
     store.init((StateStoreContext) context, root);
     when(ops.get(any())).thenReturn(null);
@@ -64,8 +63,7 @@ class ResponsiveKeyValueStoreTest {
     // Given:
     final var store = new ResponsiveKeyValueStore(
         ResponsiveKeyValueParams.keyValue("test"),
-        false,
-        (params, isTimestamped, context, type) -> ops
+        (params, ttlResolver, context, type) -> ops
     );
     store.init((StateStoreContext) context, root);
     when(ops.get(any())).thenReturn(new byte[]{125});


### PR DESCRIPTION
Minor followup PR to the ttl stuff plus something I noticed while working on that. Threw it all in one PR:

1. Throw an exception if we see a standby task (we've now upgraded to a version of Streams with my patch for the standby-creation edge case so this should never happen)
2. Until we implement row-level ttl for MongoKVTable, we should throw an exception here too (since this might not happen right away)
3. Some minor cleanup left over after the StateSerde refactor