### PR TITLE
Row-level TTL PR 7: TopologyTestDriver#advanceWallClockTime

### DIFF
--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/api/ResponsiveTopologyTestDriver.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/api/ResponsiveTopologyTestDriver.java
@@ -97,21 +97,22 @@ public class ResponsiveTopologyTestDriver extends TopologyTestDriver {
         topology,
         config,
         initialWallClockTime,
-        new TTDCassandraClient(new TTDMockAdmin(baseProps(config), topology))
+        new TTDCassandraClient(
+            new TTDMockAdmin(baseProps(config), topology),
+            mockTime(initialWallClockTime))
     );
   }
 
   /**
-   * Advances the internal mock time which can be used to trigger some Kafka Streams
-   * functionality such as wall-clock punctuators, or force Responsive to flush
-   * its internal buffers.
+   * Advances the internal mock time used for Responsive-specific features such as ttl, as well
+   * as the mock time used for various Kafka Streams functionality such as wall-clock punctuators.
    * See {@link TopologyTestDriver#advanceWallClockTime(Duration)} for more details.
    *
    * @param advance the amount of time to advance wall-clock time
    */
   @Override
   public void advanceWallClockTime(final Duration advance) {
-    client.flush();
+    client.advanceWallClockTime(advance);
     super.advanceWallClockTime(advance);
   }
 

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/internal/db/TTDKeyValueTable.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/internal/db/TTDKeyValueTable.java
@@ -36,7 +36,10 @@ public class TTDKeyValueTable extends InMemoryKVTable {
     // trigger flush before lookup since CommitBuffer doesn't apply ttl
     client.flush();
 
-    return super.get(kafkaPartition, key, streamTimeMs);
+    // take the max of mock "wallclock" time and stream-time since ttl is applied on both
+    final long currentTimeMs = Math.max(streamTimeMs, client.currentWallClockTimeMs());
+
+    return super.get(kafkaPartition, key, currentTimeMs);
   }
 
   @Override
@@ -49,7 +52,10 @@ public class TTDKeyValueTable extends InMemoryKVTable {
     // trigger flush before lookup since CommitBuffer doesn't apply ttl
     client.flush();
 
-    return super.range(kafkaPartition, from, to, streamTimeMs);
+    // take the max of mock "wallclock" time and stream-time since ttl is applied on both
+    final long currentTimeMs = Math.max(streamTimeMs, client.currentWallClockTimeMs());
+
+    return super.range(kafkaPartition, from, to, currentTimeMs);
   }
 
   @Override
@@ -57,7 +63,10 @@ public class TTDKeyValueTable extends InMemoryKVTable {
     // trigger flush before lookup since CommitBuffer doesn't apply ttl
     client.flush();
 
-    return super.all(kafkaPartition, streamTimeMs);
+    // take the max of mock "wallclock" time and stream-time since ttl is applied on both
+    final long currentTimeMs = Math.max(streamTimeMs, client.currentWallClockTimeMs());
+
+    return super.all(kafkaPartition, currentTimeMs);
   }
 
 }


### PR DESCRIPTION
Minor followup to [PR #6](https://github.com/responsivedev/responsive-pub/pull/376/files) where we changed the TTD so that only advancing stream-time by piping additional input records would apply ttl. Although this more closely matches how the TTD has to be used in vanilla Streams, it's a pain to be unable to advance the time on its own without being coupled to the input records. This PR restores the previous semantics of the ResponsiveTopologyTestDriver#advanceWallClockTime API so that this can be used to validate ttl in TTD tests

PR 1: API https://github.com/responsivedev/responsive-pub/pull/370
PR 2: TtlResolver https://github.com/responsivedev/responsive-pub/pull/371
PR 3: compute minValidTs from TtlResolver https://github.com/responsivedev/responsive-pub/pull/373
PR 4: CassandraFactTable implementation https://github.com/responsivedev/responsive-pub/pull/374
PR 5: extract StateSerdes https://github.com/responsivedev/responsive-pub/pull/375
PR 6: support for ResponsiveTopologyTestDriver  https://github.com/responsivedev/responsive-pub/pull/376