### PR TITLE
Row-level TTL PR 8: end-to-end integration test and advance stream-time during #get

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/api/stores/TtlProvider.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/stores/TtlProvider.java
@@ -252,4 +252,31 @@ public class TtlProvider<K, V> {
     return computeTtl.apply(key, value);
   }
 
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    final TtlProvider<?, ?> that = (TtlProvider<?, ?>) o;
+
+    if (ttlType != that.ttlType) {
+      return false;
+    }
+    if (!defaultTtl.equals(that.defaultTtl)) {
+      return false;
+    }
+    return computeTtl.equals(that.computeTtl);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = ttlType.hashCode();
+    result = 31 * result + defaultTtl.hashCode();
+    result = 31 * result + computeTtl.hashCode();
+    return result;
+  }
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/PartitionedOperations.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/PartitionedOperations.java
@@ -300,6 +300,13 @@ public class PartitionedOperations implements KeyValueOperations {
 
   @Override
   public byte[] get(final Bytes key) {
+    final long currentRecordTimestamp = currentRecordTimestamp();
+
+    // streamTime is used for ttl so we want to advance it before/during the get, not only on put
+    if (streamTimeMs < currentRecordTimestamp) {
+      streamTimeMs = currentRecordTimestamp;
+    }
+
     if (migrationMode) {
       // we don't want to issue gets in migration mode since
       // we're just reading from the changelog. the problem is

--- a/kafka-client/src/test/java/dev/responsive/kafka/api/ResponsiveKeyValueParamsTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/api/ResponsiveKeyValueParamsTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024 Responsive Computing, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package dev.responsive.kafka.api;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import dev.responsive.kafka.api.stores.ResponsiveKeyValueParams;
+import dev.responsive.kafka.api.stores.TtlProvider;
+import java.time.Duration;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+public class ResponsiveKeyValueParamsTest {
+
+  private static final Duration DEFAULT_TTL = Duration.ofSeconds(5L);
+
+  @Test
+  public void shouldConvertWithTimeToLiveToTtlProvider() {
+    // Given/when:
+    final var params = ResponsiveKeyValueParams.fact("store")
+        .withTimeToLive(DEFAULT_TTL);
+
+    // Then:
+    assertThat(params.ttlProvider(), equalTo(Optional.of(TtlProvider.withDefault(DEFAULT_TTL))));
+  }
+
+  @Test
+  public void shouldConvertInfiniteDefaultOnlyTtlProviderToOptionalEmpty() {
+    // Given/when:
+    final var params = ResponsiveKeyValueParams.fact("store")
+            .withTtlProvider(TtlProvider.withNoDefault());
+
+    // Then:
+    assertThat(params.ttlProvider(), equalTo(Optional.empty()));
+  }
+
+}

--- a/kafka-client/src/test/java/dev/responsive/kafka/api/TtlProviderTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/api/TtlProviderTest.java
@@ -1,0 +1,202 @@
+/*
+ * Copyright 2024 Responsive Computing, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package dev.responsive.kafka.api;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import dev.responsive.kafka.api.stores.TtlProvider;
+import dev.responsive.kafka.api.stores.TtlProvider.TtlDuration;
+import dev.responsive.kafka.internal.utils.StateDeserializer;
+import java.time.Duration;
+import java.util.Optional;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.junit.jupiter.api.Test;
+
+public class TtlProviderTest {
+
+  private static final Deserializer<Object> THROWING_DESERIALIZER = (t, d) -> {
+    throw new AssertionError("this deserializer should not be invoked");
+  };
+
+  @Test
+  public void shouldReturnDefaultOnlyTtlProvider() {
+    // Given/when:
+    final var ttlProvider = TtlProvider.withDefault(Duration.ofSeconds(5L));
+
+    //Then:
+    assertThat(ttlProvider.hasDefaultOnly(), is(true));
+    assertThat(ttlProvider.needsValueToComputeTtl(), is(false));
+    assertThat(ttlProvider.defaultTtl(), equalTo(TtlDuration.of(Duration.ofSeconds(5L))));
+
+    final var defaultOnlyStateDeserializer = new StateDeserializer<>(
+        null,
+        THROWING_DESERIALIZER,
+        THROWING_DESERIALIZER
+    );
+    assertThat(
+        ttlProvider.computeTtl(null, null, defaultOnlyStateDeserializer),
+        equalTo(Optional.empty())
+    );
+  }
+
+  @Test
+  public void shouldReturnInfiniteDefaultOnlyTtlProvider() {
+    // Given/when:
+    final var ttlProvider = TtlProvider.withNoDefault();
+
+    //Then:
+    assertThat(ttlProvider.hasDefaultOnly(), is(true));
+    assertThat(ttlProvider.needsValueToComputeTtl(), is(false));
+    assertThat(ttlProvider.defaultTtl(), equalTo(TtlDuration.infinite()));
+
+    final var defaultOnlyStateDeserializer = new StateDeserializer<>(
+        null,
+        THROWING_DESERIALIZER,
+        THROWING_DESERIALIZER
+    );
+    assertThat(
+        ttlProvider.computeTtl(null, null, defaultOnlyStateDeserializer),
+        equalTo(Optional.empty())
+    );
+  }
+
+  @Test
+  public void shouldReturnKeyOnlyTtlProvider() {
+    // Given/when:
+    final TtlProvider<byte[], Object> ttlProvider = TtlProvider.<byte[], Object>withNoDefault()
+        .fromKey(k -> Optional.of(TtlDuration.of(Duration.ofSeconds(5L))));
+
+    //Then:
+    assertThat(ttlProvider.hasDefaultOnly(), is(false));
+    assertThat(ttlProvider.needsValueToComputeTtl(), is(false));
+    assertThat(ttlProvider.defaultTtl(), equalTo(TtlDuration.infinite()));
+
+    final var keyOnlyStateDeserializer = new StateDeserializer<>(
+        null,
+        new ByteArrayDeserializer(),
+        THROWING_DESERIALIZER
+    );
+    assertThat(
+        ttlProvider.computeTtl(new byte[]{}, null, keyOnlyStateDeserializer),
+        equalTo(Optional.of(TtlDuration.of(Duration.ofSeconds(5L))))
+    );
+
+
+    // if key is not provided this should throw
+    assertThrows(
+        IllegalStateException.class,
+        () -> ttlProvider.computeTtl(null, null, keyOnlyStateDeserializer)
+    );
+  }
+
+  @Test
+  public void shouldReturnValueOnlyTtlProvider() {
+    // Given/when:
+    final var ttlProvider = TtlProvider.<Object, byte[]>withNoDefault()
+        .fromValue(k -> Optional.of(TtlDuration.of(Duration.ofSeconds(5L))));
+
+    //Then:
+    assertThat(ttlProvider.hasDefaultOnly(), is(false));
+    assertThat(ttlProvider.needsValueToComputeTtl(), is(true));
+    assertThat(ttlProvider.defaultTtl(), equalTo(TtlDuration.infinite()));
+
+    final var valueOnlyStateDeserializer = new StateDeserializer<>(
+        null,
+        THROWING_DESERIALIZER,
+        new ByteArrayDeserializer()
+    );
+    assertThat(
+        ttlProvider.computeTtl(null, new byte[]{}, valueOnlyStateDeserializer),
+        equalTo(Optional.of(TtlDuration.of(Duration.ofSeconds(5L))))
+    );
+
+    // if value is not provided this should throw
+    assertThrows(
+        IllegalStateException.class,
+        () -> ttlProvider.computeTtl(null, null, valueOnlyStateDeserializer)
+    );
+  }
+
+  @Test
+  public void shouldReturnKeyAndValueTtlProvider() {
+    // Given/when:
+    final var ttlProvider = TtlProvider.<byte[], byte[]>withNoDefault()
+        .fromKeyAndValue((k, v) -> Optional.of(TtlDuration.of(Duration.ofSeconds(5L))));
+
+    //Then:
+    assertThat(ttlProvider.hasDefaultOnly(), is(false));
+    assertThat(ttlProvider.needsValueToComputeTtl(), is(true));
+    assertThat(ttlProvider.defaultTtl(), equalTo(TtlDuration.infinite()));
+
+    final var keyAndValueStateDeserializer = new StateDeserializer<>(
+        null,
+        new ByteArrayDeserializer(),
+        new ByteArrayDeserializer()
+    );
+    assertThat(
+        ttlProvider.computeTtl(new byte[]{}, new byte[]{}, keyAndValueStateDeserializer),
+        equalTo(Optional.of(TtlDuration.of(Duration.ofSeconds(5L))))
+    );
+
+    // if key OR value is not provided this should throw
+    assertThrows(
+        IllegalStateException.class,
+        () -> ttlProvider.computeTtl(new byte[]{}, null, keyAndValueStateDeserializer)
+    );
+    assertThrows(
+        IllegalStateException.class,
+        () -> ttlProvider.computeTtl(null, new byte[]{}, keyAndValueStateDeserializer)
+    );
+  }
+
+  @Test
+  public void shouldConvertFiniteTtlDuration() {
+    // Given/when:
+    final var ttlDuration = TtlDuration.of(Duration.ofSeconds(1L));
+
+    //Then:
+    assertThat(ttlDuration.isFinite(), is(true));
+    assertThat(ttlDuration.toSeconds(), equalTo(1L));
+    assertThat(ttlDuration.toMillis(), equalTo(1000L));
+    assertThat(ttlDuration.duration(), equalTo(Duration.ofSeconds(1L)));
+
+    final var equivalentTtlDuration = TtlDuration.of(Duration.ofMillis(1000L));
+
+    assertThat(ttlDuration, equalTo(equivalentTtlDuration));
+  }
+
+  @Test
+  public void shouldNotConvertInfiniteTtlDuration() {
+    // Given/when:
+    final var ttlDuration = TtlDuration.infinite();
+
+    //Then:
+    assertThat(ttlDuration.isFinite(), is(false));
+    assertThrows(IllegalStateException.class, ttlDuration::toSeconds);
+    assertThrows(IllegalStateException.class, ttlDuration::toMillis);
+    assertThrows(IllegalStateException.class, ttlDuration::duration);
+
+    final var equivalentTtlDuration = TtlDuration.infinite();
+
+    assertThat(ttlDuration, equalTo(equivalentTtlDuration));
+  }
+
+}

--- a/kafka-client/src/test/java/dev/responsive/kafka/integration/RowLevelTtlIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/integration/RowLevelTtlIntegrationTest.java
@@ -1,0 +1,321 @@
+/*
+ * Copyright 2024 Responsive Computing, Inc.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package dev.responsive.kafka.integration;
+
+import static dev.responsive.kafka.api.config.ResponsiveConfig.STORE_FLUSH_RECORDS_TRIGGER_CONFIG;
+import static dev.responsive.kafka.testutils.IntegrationTestUtils.createTopicsAndWait;
+import static dev.responsive.kafka.testutils.IntegrationTestUtils.pipeTimestampedRecords;
+import static dev.responsive.kafka.testutils.IntegrationTestUtils.readOutputWithTimestamps;
+import static dev.responsive.kafka.testutils.IntegrationTestUtils.startAppAndAwaitRunning;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.consumer.ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.clients.producer.ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.APPLICATION_ID_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.COMMIT_INTERVAL_MS_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.NUM_STREAM_THREADS_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.STATESTORE_CACHE_MAX_BYTES_CONFIG;
+import static org.apache.kafka.streams.StreamsConfig.consumerPrefix;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+
+import dev.responsive.kafka.api.ResponsiveKafkaStreams;
+import dev.responsive.kafka.api.config.ResponsiveConfig;
+import dev.responsive.kafka.api.config.StorageBackend;
+import dev.responsive.kafka.api.stores.ResponsiveKeyValueParams;
+import dev.responsive.kafka.api.stores.ResponsiveStores;
+import dev.responsive.kafka.api.stores.TtlProvider;
+import dev.responsive.kafka.api.stores.TtlProvider.TtlDuration;
+import dev.responsive.kafka.testutils.KeyValueTimestamp;
+import dev.responsive.kafka.testutils.ResponsiveConfigParam;
+import dev.responsive.kafka.testutils.ResponsiveExtension;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.processor.api.Processor;
+import org.apache.kafka.streams.processor.api.ProcessorContext;
+import org.apache.kafka.streams.processor.api.ProcessorSupplier;
+import org.apache.kafka.streams.processor.api.Record;
+import org.apache.kafka.streams.state.StoreBuilder;
+import org.apache.kafka.streams.state.TimestampedKeyValueStore;
+import org.apache.kafka.streams.state.ValueAndTimestamp;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+public class RowLevelTtlIntegrationTest {
+
+  @RegisterExtension
+  static ResponsiveExtension EXTENSION = new ResponsiveExtension(StorageBackend.CASSANDRA);
+
+  private static final String INPUT_TOPIC = "input";
+  private static final String OUTPUT_TOPIC = "output";
+  private static final String STORE_NAME = "store";
+
+  private static final Duration DEFAULT_TTL = Duration.ofSeconds(10);
+
+  private static final String KEEP_FOREVER = "KEEP_FOREVER";
+  private static final String TTL_5s = "TTL_5s";
+  private static final String TTL_20s = "TTL_20s";
+
+  private final Map<String, Object> responsiveProps = new HashMap<>();
+
+  private String name;
+  private Admin admin;
+
+  @BeforeEach
+  public void before(
+      final TestInfo info,
+      final Admin admin,
+      @ResponsiveConfigParam final Map<String, Object> responsiveProps
+  ) {
+    // add displayName to name to account for parameterized tests
+    name = info.getDisplayName().replace("()", "");
+
+    this.responsiveProps.putAll(responsiveProps);
+
+    this.admin = admin;
+    createTopicsAndWait(admin, Map.of(inputTopic(), 1, outputTopic(), 1));
+  }
+
+  @AfterEach
+  public void after() {
+    admin.deleteTopics(List.of(inputTopic(), outputTopic()));
+  }
+
+  private String inputTopic() {
+    return name + "." + INPUT_TOPIC;
+  }
+
+  private String outputTopic() {
+    return name + "." + OUTPUT_TOPIC;
+  }
+
+  @Test
+  public void shouldApplyRowLevelTtlForKeyAndValue() throws Exception {
+    // Given:
+    final Map<String, Object> properties = getMutableProperties();
+    final KafkaProducer<String, String> producer = new KafkaProducer<>(properties);
+    try (final ResponsiveKafkaStreams streams = buildStreams(properties)) {
+      startAppAndAwaitRunning(Duration.ofSeconds(20), streams);
+
+      // First pipe the "base data" all at t=0, all of which should produce output
+      pipeTimestampedRecords(producer, inputTopic(), List.of(
+          new KeyValueTimestamp<>(KEEP_FOREVER, "ignored", 0L),
+          new KeyValueTimestamp<>(TTL_5s, "ignored", 0L),
+          new KeyValueTimestamp<>(TTL_20s, "ignored", 0L),
+          new KeyValueTimestamp<>("ignored_key(ttl=infinite)", KEEP_FOREVER, 0L),
+          new KeyValueTimestamp<>("ignored_key(ttl=5s)", TTL_5s, 0L),
+          new KeyValueTimestamp<>("ignored_key(ttl=20s)", TTL_20s, 0L),
+          new KeyValueTimestamp<>("ignored_key(defaultTtl=10s)", "ignored", 0L),
+
+          // Then start testing ttl deduplicator by advancing streamTime and sending duplicate keys
+          // Now only records whose previous value has expired should produce output
+
+          // streamTime = 6s
+          new KeyValueTimestamp<>(KEEP_FOREVER, "ignored", 6_000L),
+          new KeyValueTimestamp<>(TTL_5s, "ignored", 6_000L), // forwarded
+          new KeyValueTimestamp<>(TTL_20s, "ignored", 6_000L),
+          new KeyValueTimestamp<>("ignored_key(ttl=infinite)", KEEP_FOREVER, 6_000L),
+          new KeyValueTimestamp<>("ignored_key(ttl=5s)", TTL_5s, 6_000L), // forwarded
+          new KeyValueTimestamp<>("ignored_key(ttl=20s)", TTL_20s, 6_000L),
+          new KeyValueTimestamp<>("ignored_key(defaultTtl=10s)", "ignored", 6_000L),
+
+
+          // streamTime = 12s
+          new KeyValueTimestamp<>(KEEP_FOREVER, "ignored", 12_000L),
+          new KeyValueTimestamp<>(TTL_5s, "ignored", 12_000L), // forwarded
+          new KeyValueTimestamp<>(TTL_20s, "ignored", 12_000L),
+          new KeyValueTimestamp<>("ignored_key(ttl=infinite)", KEEP_FOREVER, 12_000L),
+          new KeyValueTimestamp<>("ignored_key(ttl=5s)", TTL_5s, 12_000L), // forwarded
+          new KeyValueTimestamp<>("ignored_key(ttl=20s)", TTL_20s, 12_000L),
+          new KeyValueTimestamp<>("ignored_key(defaultTtl=10s)", "ignored", 12_000L), // forwarded
+
+          // streamTime = 300s
+          new KeyValueTimestamp<>(KEEP_FOREVER, "ignored", 300_000L),
+          new KeyValueTimestamp<>(TTL_5s, "ignored", 300_000L), // forwarded
+          new KeyValueTimestamp<>(TTL_20s, "ignored", 300_000L), // forwarded
+          new KeyValueTimestamp<>("ignored_key(ttl=infinite)", KEEP_FOREVER, 300_000L),
+          new KeyValueTimestamp<>("ignored_key(ttl=5s)", TTL_5s, 300_000L), // forwarded
+          new KeyValueTimestamp<>("ignored_key(ttl=20s)", TTL_20s, 300_000L), // forwarded
+          new KeyValueTimestamp<>("ignored_key(defaultTtl=10s)", "ignored", 300_000L) // forwarded
+      ));
+
+      final var kvs = readOutputWithTimestamps(outputTopic(), 0, 17, 1, true, properties);
+      assertThat(
+          kvs,
+          equalTo(List.of(
+              // base records (streamTime = 0)
+              new KeyValueTimestamp<>(KEEP_FOREVER, "ignored", 0L),
+              new KeyValueTimestamp<>(TTL_5s, "ignored", 0L),
+              new KeyValueTimestamp<>(TTL_20s, "ignored", 0L),
+              new KeyValueTimestamp<>("ignored_key(ttl=infinite)", KEEP_FOREVER, 0L),
+              new KeyValueTimestamp<>("ignored_key(ttl=5s)", TTL_5s, 0L),
+              new KeyValueTimestamp<>("ignored_key(ttl=20s)", TTL_20s, 0L),
+              new KeyValueTimestamp<>("ignored_key(defaultTtl=10s)", "ignored", 0L),
+              // first wave (streamTime = 6s)
+              new KeyValueTimestamp<>(TTL_5s, "ignored", 6_000L),
+              new KeyValueTimestamp<>("ignored_key(ttl=5s)", TTL_5s, 6_000L),
+              // second wave (streamTime = 12s)
+              new KeyValueTimestamp<>(TTL_5s, "ignored", 12_000L),
+              new KeyValueTimestamp<>("ignored_key(ttl=5s)", TTL_5s, 12_000L),
+              new KeyValueTimestamp<>("ignored_key(defaultTtl=10s)", "ignored", 12_000L),
+              // third wave (streamTime = 300s)
+              new KeyValueTimestamp<>(TTL_5s, "ignored", 300_000L),
+              new KeyValueTimestamp<>(TTL_20s, "ignored", 300_000L),
+              new KeyValueTimestamp<>("ignored_key(ttl=5s)", TTL_5s, 300_000L),
+              new KeyValueTimestamp<>("ignored_key(ttl=20s)", TTL_20s, 300_000L),
+              new KeyValueTimestamp<>("ignored_key(defaultTtl=10s)", "ignored", 300_000L)
+          )
+      ));
+    }
+  }
+
+  private ResponsiveKafkaStreams buildStreams(final Map<String, Object> properties) {
+    final StreamsBuilder builder = new StreamsBuilder();
+
+    final KStream<String, String> input = builder.stream(inputTopic());
+    input.process(new TtlProcessorSupplier(), STORE_NAME)
+        .to(outputTopic());
+
+    return new ResponsiveKafkaStreams(builder.build(), properties);
+  }
+
+  @SuppressWarnings("checkstyle:linelength")
+  private static class TtlProcessorSupplier implements ProcessorSupplier<String, String, String, String> {
+
+    @Override
+    public Processor<String, String, String, String> get() {
+      return new TtlDeduplicator();
+    }
+
+    @Override
+    public Set<StoreBuilder<?>> stores() {
+      return Collections.singleton(ResponsiveStores.timestampedKeyValueStoreBuilder(
+          ResponsiveStores.keyValueStore(
+              ResponsiveKeyValueParams.fact(STORE_NAME).withTtlProvider(
+                  TtlProvider.<String, ValueAndTimestamp<String>>withDefault(DEFAULT_TTL)
+                      .fromKeyAndValue(RowLevelTtlIntegrationTest::ttlForKeyAndValue)
+              )),
+          Serdes.String(),
+          Serdes.String()
+      ));
+    }
+  }
+
+  private static Optional<TtlDuration> ttlForKeyAndValue(
+      final String key,
+      final ValueAndTimestamp<String> valueAndTimestamp
+  ) {
+    // key takes precedence when resolving ttl
+    switch (key) {
+      case KEEP_FOREVER:
+        return Optional.of(TtlDuration.infinite());
+      case TTL_5s:
+        return Optional.of(TtlDuration.of((Duration.ofSeconds(5))));
+      case TTL_20s:
+        return Optional.of(TtlDuration.of((Duration.ofSeconds(20))));
+      default:
+        // do nothing
+    }
+
+    // if key does not specify ttl then value is checked
+    final String value = valueAndTimestamp.value();
+    switch (value) {
+      case KEEP_FOREVER:
+        return Optional.of(TtlDuration.infinite());
+      case TTL_5s:
+        return Optional.of(TtlDuration.of((Duration.ofSeconds(5))));
+      case TTL_20s:
+        return Optional.of(TtlDuration.of((Duration.ofSeconds(20))));
+      default:
+        // do nothing
+    }
+
+    // finally, just fall back to default ttl (10s)
+    return Optional.empty();
+  }
+
+  private static class TtlDeduplicator implements Processor<String, String, String, String> {
+
+    private ProcessorContext<String, String> context;
+    private TimestampedKeyValueStore<String, String> ttlStore;
+
+    @Override
+    public void init(final ProcessorContext<String, String> context) {
+      this.context = context;
+      this.ttlStore = context.getStateStore(STORE_NAME);
+    }
+
+    @Override
+    public void process(final Record<String, String> record) {
+      final ValueAndTimestamp<String> previous = ttlStore.putIfAbsent(
+          record.key(),
+          ValueAndTimestamp.make(record.value(), record.timestamp())
+      );
+
+      if (previous == null) {
+        context.forward(record);
+      }
+
+    }
+  }
+
+  private Map<String, Object> getMutableProperties() {
+    final Map<String, Object> properties = new HashMap<>(responsiveProps);
+
+    properties.put(KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    properties.put(VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+    properties.put(KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+    properties.put(VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+
+    properties.put(APPLICATION_ID_CONFIG, name);
+    properties.put(DEFAULT_KEY_SERDE_CLASS_CONFIG, Serdes.StringSerde.class.getName());
+    properties.put(DEFAULT_VALUE_SERDE_CLASS_CONFIG, Serdes.StringSerde.class.getName());
+    properties.put(NUM_STREAM_THREADS_CONFIG, 1);
+    properties.put(STATESTORE_CACHE_MAX_BYTES_CONFIG, 0);
+    properties.put(STORE_FLUSH_RECORDS_TRIGGER_CONFIG, 1);
+    properties.put(COMMIT_INTERVAL_MS_CONFIG, 0);
+
+    properties.put(
+        ResponsiveConfig.MONGO_ADDITIONAL_CONNECTION_STRING_PARAMS_CONFIG, "maxIdleTimeMs=60000"
+    );
+
+    properties.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 1);
+    properties.put(consumerPrefix(ConsumerConfig.METADATA_MAX_AGE_CONFIG), "1000");
+    properties.put(consumerPrefix(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG), "earliest");
+
+    return properties;
+  }
+
+}

--- a/responsive-test-utils/src/test/java/dev/responsive/kafka/api/ResponsiveTopologyTestDriverKeyValueStoreTest.java
+++ b/responsive-test-utils/src/test/java/dev/responsive/kafka/api/ResponsiveTopologyTestDriverKeyValueStoreTest.java
@@ -117,16 +117,14 @@ public class ResponsiveTopologyTestDriverKeyValueStoreTest {
     bids.pipeInput("a", "a,100,1", 10);      // streamTime = 10 -- result as alice is not expired
     bids.pipeInput("b", "b,101,2", 10);      // streamTime = 10 -- result as bob is not expired
 
-    people.pipeInput("4", "4,dean-ignored,VA", 20); // advances streamTime to 20
-
+    // advance streamTime to 20
     bids.pipeInput("c", "c,102,1", 20);      // streamTime = 20 -- no result b/c alice has expired
     bids.pipeInput("d", "d,103,3", 20);      // streamTime = 20 -- result as carol is not expired
 
     people.pipeInput("1", "1,alex,CA", 20);  // insert streamTime = 20
     bids.pipeInput("e", "e,104,1", 20);      // streamTime = 20 -- yes result as alex replaced alice
 
-    people.pipeInput("4", "4,ignored,VA", 30); // advances streamTime to 30
-
+    // advance streamTime to 30
     bids.pipeInput("f", "f,105,3", 30);      // streamTime = 30 -- no result b/c carol has expired
 
     bids.pipeInput("g", "g,106,0", 30);      // streamTime = 30 -- yes result b/c id 0 is infinite


### PR DESCRIPTION
This PR contains a small fix (more of a quality-of-life improvement for testing than a true bug) where we now advance stream-time during a `#get` operation, not only a `#put`, and expands the test coverage with unit tests for all the API classes and a full end-to-end integration test for the full feature.

PR 1: API https://github.com/responsivedev/responsive-pub/pull/370
PR 2: TtlResolver https://github.com/responsivedev/responsive-pub/pull/371
PR 3: compute minValidTs from TtlResolver https://github.com/responsivedev/responsive-pub/pull/373
PR 4: CassandraFactTable implementation https://github.com/responsivedev/responsive-pub/pull/374
PR 5: extract StateSerdes https://github.com/responsivedev/responsive-pub/pull/375
PR 6: support for ResponsiveTopologyTestDriver https://github.com/responsivedev/responsive-pub/pull/376
PR 7: TopologyTestDriver#advanceWallClockTime https://github.com/responsivedev/responsive-pub/pull/379