### PR TITLE
validate that the maxReplicas field in the CRD is greater than minReplicas

### DIFF
--- a/operator/src/main/java/dev/responsive/k8s/crd/ResponsivePolicy.java
+++ b/operator/src/main/java/dev/responsive/k8s/crd/ResponsivePolicy.java
@@ -27,6 +27,7 @@ import io.fabric8.kubernetes.model.annotation.Version;
 @Version("v1")
 @Plural("responsivepolicies")
 @Singular("responsivepolicy")
+
 public class ResponsivePolicy extends CustomResource<ResponsivePolicySpec, ResponsivePolicyStatus>
     implements Namespaced {
 

--- a/operator/src/main/java/dev/responsive/k8s/crd/ResponsivePolicy.java
+++ b/operator/src/main/java/dev/responsive/k8s/crd/ResponsivePolicy.java
@@ -27,7 +27,6 @@ import io.fabric8.kubernetes.model.annotation.Version;
 @Version("v1")
 @Plural("responsivepolicies")
 @Singular("responsivepolicy")
-
 public class ResponsivePolicy extends CustomResource<ResponsivePolicySpec, ResponsivePolicyStatus>
     implements Namespaced {
 

--- a/operator/src/main/java/dev/responsive/k8s/crd/kafkastreams/KafkaStreamsPolicySpec.java
+++ b/operator/src/main/java/dev/responsive/k8s/crd/kafkastreams/KafkaStreamsPolicySpec.java
@@ -3,10 +3,12 @@ package dev.responsive.k8s.crd.kafkastreams;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import dev.responsive.k8s.crd.PolicyCooldownSpec;
+import io.fabric8.generator.annotation.ValidationRule;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 
+@ValidationRule(value = "self.maxReplicas >= self.minReplicas")
 public class KafkaStreamsPolicySpec {
 
   private final int maxReplicas;

--- a/operator/src/main/java/dev/responsive/k8s/operator/reconciler/ResponsivePolicyReconciler.java
+++ b/operator/src/main/java/dev/responsive/k8s/operator/reconciler/ResponsivePolicyReconciler.java
@@ -27,6 +27,7 @@ import dev.responsive.k8s.crd.ResponsivePolicyStatus;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.ControllerConfiguration;
 import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext;
 import io.javaoperatorsdk.operator.api.reconciler.EventSourceInitializer;
 import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
@@ -46,6 +47,7 @@ import responsive.controller.v1.controller.proto.ControllerOuterClass.Applicatio
 /**
  * Core reconciliation handler for operator
  */
+@ControllerConfiguration
 public class ResponsivePolicyReconciler implements
     Reconciler<ResponsivePolicy>, EventSourceInitializer<ResponsivePolicy> {
   private static final Logger LOG = LoggerFactory.getLogger(ResponsivePolicyReconciler.class);

--- a/operator/src/test/java/dev/responsive/k8s/operator/reconciler/KafkaStreamsPolicyPluginTest.java
+++ b/operator/src/test/java/dev/responsive/k8s/operator/reconciler/KafkaStreamsPolicyPluginTest.java
@@ -50,6 +50,7 @@ import io.fabric8.kubernetes.client.dsl.MixedOperation;
 import io.fabric8.kubernetes.client.dsl.NonNamespaceOperation;
 import io.fabric8.kubernetes.client.dsl.PodResource;
 import io.fabric8.kubernetes.client.dsl.RollableScalableResource;
+import io.javaoperatorsdk.operator.api.config.ConfigurationService;
 import io.javaoperatorsdk.operator.api.config.ControllerConfiguration;
 import io.javaoperatorsdk.operator.api.reconciler.Context;
 import io.javaoperatorsdk.operator.api.reconciler.EventSourceContext;
@@ -124,6 +125,8 @@ class KafkaStreamsPolicyPluginTest {
   private ArgumentCaptor<ControllerOuterClass.CurrentStateRequest> currentStateRequestCaptor;
   @Mock
   private ControllerClient controllerClient;
+  @Mock
+  private ConfigurationService configService;
   private final PodResource pod1 = mockPodResource("p1");
   private final PodResource pod2 = mockPodResource("p2");
 
@@ -194,6 +197,9 @@ class KafkaStreamsPolicyPluginTest {
     lenient().when(ctx.getSecondaryResource(
             ActionsWithTimestamp.class))
         .thenReturn(Optional.of(new ActionsWithTimestamp()));
+    lenient().when(controllerConfig.getConfigurationService()).thenReturn(configService);
+    lenient().when(configService.parseResourceVersionsForEventFilteringAndCaching())
+        .thenReturn(false);
   }
 
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -49,12 +49,13 @@ dependencyResolutionManagement {
             version("jackson", "2.15.2")
             version("kafka", "3.7.0")
             version("scylla", "4.15.0.0")
-            version("javaoperatorsdk", "4.3.0")
+            version("javaoperatorsdk", "4.9.6")
             version("grpc", "1.52.1")
             version("protobuf-java", "3.22.3")
             version("slf4j", "1.7.5")
             version("log4j2", "2.20.0")
             version("mongoDB", "4.10.2")
+            version("fabric8", "6.13.4")
 
             library("jackson", "com.fasterxml.jackson.datatype", "jackson-datatype-jdk8").versionRef("jackson")
 
@@ -81,7 +82,7 @@ dependencyResolutionManagement {
             bundle("grpc", listOf("grpc-netty", "grpc-protobuf", "grpc-stub", "javax-annotation-api"))
 
             library("protobuf-java-util", "com.google.protobuf", "protobuf-java-util").versionRef("protobuf-java")
-            library("crd-generator-atp", "io.fabric8", "crd-generator-apt").version("6.5.1")
+            library("crd-generator-atp", "io.fabric8", "crd-generator-apt").versionRef("fabric8")
 
             library("guava", "com.google.guava:guava:32.1.3-jre")
 


### PR DESCRIPTION
This patch adds a validation rule to the CRD to validate that the max replicas is greater than the minReplicas. The bulk
of the patch is actually bumping the java operator SDK version to 4.9 so that we can get the ValidationRule annotation. The only functional change is the addition of the annotation to `KafkaStreamsPolicySpec`