### PR TITLE
Row-level TTL 10: expire based on event time

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/api/stores/TtlProvider.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/stores/TtlProvider.java
@@ -162,6 +162,10 @@ public class TtlProvider<K, V> {
       return duration().toMillis();
     }
 
+    public TtlDuration minus(final long otherMs) {
+      return TtlDuration.of(duration().minusMillis(otherMs));
+    }
+
     @Override
     public boolean equals(final Object o) {
       if (this == o) {

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/inmemory/InMemoryKVTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/inmemory/InMemoryKVTable.java
@@ -55,7 +55,7 @@ public class InMemoryKVTable implements RemoteKVTable<BoundStatement> {
     }
 
     if (ttlResolver.isPresent()) {
-      final TtlDuration rowTtl = ttlResolver.get().resolveTtl(key, value.value());
+      final TtlDuration rowTtl = ttlResolver.get().resolveRowTtl(key, value.value());
       if (rowTtl.isFinite()) {
         final long minValidTs = streamTimeMs - rowTtl.toMillis();
         if (value.epochMillis < minValidTs) {

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveKeyValueStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveKeyValueStore.java
@@ -98,7 +98,8 @@ public class ResponsiveKeyValueStore
   @Override
   public void init(final StateStoreContext storeContext, final StateStore root) {
     try {
-      final TaskType taskType = asInternalProcessorContext(storeContext).taskType();
+      final var internalProcessorContext = asInternalProcessorContext(storeContext);
+      final TaskType taskType = internalProcessorContext.taskType();
       log = new LogContext(
           String.format(
               "%sstore [%s] ",
@@ -117,7 +118,8 @@ public class ResponsiveKeyValueStore
       final StateSerdes<?, ?> stateSerdes = StoreAccessorUtil.extractKeyValueStoreSerdes(root);
       final Optional<TtlResolver<?, ?>> ttlResolver = TtlResolver.fromTtlProviderAndStateSerdes(
           stateSerdes,
-          params.ttlProvider()
+          params.ttlProvider(),
+          internalProcessorContext
       );
 
       operations = opsProvider.provide(params, ttlResolver, storeContext, taskType);

--- a/kafka-client/src/test/java/dev/responsive/kafka/testutils/IntegrationTestUtils.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/testutils/IntegrationTestUtils.java
@@ -90,7 +90,7 @@ public final class IntegrationTestUtils {
   public static Optional<TtlResolver<?, ?>> defaultOnlyTtl(final Duration ttl) {
     return Optional.of(new TtlResolver<>(
         new StateDeserializer<>("ignored", null, null),
-        TtlProvider.withDefault(ttl))
+        TtlProvider.withDefault(ttl), null)
     );
   }
 
@@ -99,7 +99,7 @@ public final class IntegrationTestUtils {
   ) {
     return Optional.of(new TtlResolver<>(
         new StateDeserializer<>("ignored", null, null),
-        ttlProvider)
+        ttlProvider, null)
     );
   }
 
@@ -108,7 +108,8 @@ public final class IntegrationTestUtils {
   ) {
     return ttlProvider.isPresent()
         ? Optional.of(
-            new TtlResolver<>(new StateDeserializer<>("ignored", null, null), ttlProvider.get()))
+            new TtlResolver<>(new StateDeserializer<>("ignored", null, null), ttlProvider.get(),
+                              null))
         : Optional.empty();
   }
 


### PR DESCRIPTION
Offset the actual row-level ttl set in the storage backend by the difference between the current system time and the record timestamp or "event time". This allows users to process historical data without holding seeing a spike in storage as the ttl will now expire records based on their timestamp rather than insertion time