### PR TITLE
DSL w/ async: e2e implementation for stream-table join 

### DIFF
--- a/kafka-client-bootstrap/build.gradle.kts
+++ b/kafka-client-bootstrap/build.gradle.kts
@@ -15,6 +15,10 @@ plugins {
     id("responsive.docker")
 }
 
+repositories {
+    mavenLocal()
+}
+
 application {
     mainClass.set("dev.responsive.kafka.bootstrap.main.Main")
 }

--- a/kafka-client-examples/e2e-test/build.gradle.kts
+++ b/kafka-client-examples/e2e-test/build.gradle.kts
@@ -15,6 +15,10 @@ plugins {
     id("responsive.docker")
 }
 
+repositories {
+    mavenLocal()
+}
+
 application {
     mainClass.set("dev.responsive.examples.e2etest.Main")
 }

--- a/kafka-client-examples/simple-example/build.gradle.kts
+++ b/kafka-client-examples/simple-example/build.gradle.kts
@@ -19,12 +19,16 @@ application {
     mainClass.set("dev.responsive.examples.simpleapp.Main")
 }
 
+repositories {
+    mavenLocal()
+}
+
 dependencies {
     // todo: how to set the version here?
     implementation(project(":kafka-client"))
     implementation("com.google.guava:guava:32.1.1-jre")
-    implementation("org.apache.kafka:kafka-clients:3.4.0")
-    implementation("org.apache.kafka:kafka-streams:3.4.0")
+    implementation(libs.kafka.clients)
+    implementation(libs.kafka.streams)
     implementation("io.opentelemetry.javaagent:opentelemetry-javaagent:1.25.0")
     implementation("org.apache.logging.log4j:log4j-slf4j-impl:2.20.0")
     implementation("org.apache.commons:commons-text:1.10.0")

--- a/kafka-client/build.gradle.kts
+++ b/kafka-client/build.gradle.kts
@@ -33,6 +33,10 @@ plugins {
     id("java")
 }
 
+repositories {
+    mavenLocal()
+}
+
 /*********** Generated Resources ***********/
 
 val gitCommitId: String by lazy {

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveKafkaStreams.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveKafkaStreams.java
@@ -284,16 +284,16 @@ public class ResponsiveKafkaStreams extends KafkaStreams {
       return propsWithOverrides;
     }
 
-    final Object o = configs.originals().get(InternalConfig.INTERNAL_TASK_ASSIGNOR_CLASS);
+    final Object o = configs.originals().get(StreamsConfig.TASK_ASSIGNOR_CLASS_CONFIG);
     if (o == null) {
       propsWithOverrides.put(
-          InternalConfig.INTERNAL_TASK_ASSIGNOR_CLASS,
+          StreamsConfig.TASK_ASSIGNOR_CLASS_CONFIG,
           TASK_ASSIGNOR_CLASS_OVERRIDE
       );
     } else if (!TASK_ASSIGNOR_CLASS_OVERRIDE.equals(o.toString())) {
       final String errorMsg = String.format(
           "Invalid Streams configuration value for '%s': got %s, expected '%s'",
-          InternalConfig.INTERNAL_TASK_ASSIGNOR_CLASS,
+          StreamsConfig.TASK_ASSIGNOR_CLASS_CONFIG,
           o,
           TASK_ASSIGNOR_CLASS_OVERRIDE
       );

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/async/AsyncProcessorWrapper.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/async/AsyncProcessorWrapper.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2024 Responsive Computing, Inc.
+ *
+ * This source code is licensed under the Responsive Business Source License Agreement v1.0
+ * available at:
+ *
+ * https://www.responsive.dev/legal/responsive-bsl-10
+ *
+ * This software requires a valid Commercial License Key for production use. Trial and commercial
+ * licenses can be obtained at https://www.responsive.dev
+ */
+
+package dev.responsive.kafka.api.async;
+
+import org.apache.kafka.streams.ProcessorWrapper;
+import org.apache.kafka.streams.processor.api.FixedKeyProcessorSupplier;
+import org.apache.kafka.streams.processor.api.ProcessorSupplier;
+
+public class AsyncProcessorWrapper implements ProcessorWrapper {
+
+
+  @Override
+  public <KIn, VIn, KOut, VOut> ProcessorSupplier<KIn, VIn, KOut, VOut> wrapProcessorSupplier(
+      final String processorName,
+      final ProcessorSupplier<KIn, VIn, KOut, VOut> processorSupplier
+  ) {
+    return AsyncProcessorSupplier.createAsyncProcessorSupplier(processorSupplier);
+  }
+
+  @Override
+  public <KIn, VIn, VOut> FixedKeyProcessorSupplier<KIn, VIn, VOut> wrapFixedKeyProcessorSupplier(
+      final String processorName,
+      final FixedKeyProcessorSupplier<KIn, VIn, VOut> fixedKeyProcessorSupplier
+  ) {
+    return AsyncFixedKeyProcessorSupplier.createAsyncProcessorSupplier(fixedKeyProcessorSupplier);
+  }
+}

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/AsyncUtils.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/AsyncUtils.java
@@ -16,16 +16,26 @@ import static dev.responsive.kafka.api.async.internals.AsyncThreadPool.ASYNC_THR
 
 import dev.responsive.kafka.api.async.internals.stores.AbstractAsyncStoreBuilder;
 import dev.responsive.kafka.internal.stores.ResponsiveStoreBuilder;
-import dev.responsive.kafka.internal.stores.ResponsiveStoreBuilder.StoreType;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.processor.internals.ProcessorRecordContext;
+import org.apache.kafka.streams.processor.internals.StoreFactory.FactoryWrappingStoreBuilder;
+import org.apache.kafka.streams.state.KeyValueStore;
 import org.apache.kafka.streams.state.StoreBuilder;
+import org.apache.kafka.streams.state.StoreBuilder.StoreType;
 import org.apache.kafka.streams.state.internals.AsyncKeyValueStoreBuilder;
 import org.apache.kafka.streams.state.internals.AsyncTimestampedKeyValueStoreBuilder;
+import org.apache.kafka.streams.state.internals.CachingKeyValueStore;
+import org.apache.kafka.streams.state.internals.ChangeLoggingKeyValueBytesStore;
+import org.apache.kafka.streams.state.internals.DelayedAsyncStoreBuilder;
+import org.apache.kafka.streams.state.internals.KeyValueStoreBuilder;
+import org.apache.kafka.streams.state.internals.MeteredKeyValueStore;
+import org.apache.kafka.streams.state.internals.TimestampedKeyValueStoreBuilder;
 
 public class AsyncUtils {
 
@@ -70,33 +80,12 @@ public class AsyncUtils {
     final Map<String, AbstractAsyncStoreBuilder<?, ?, ?>> asyncStoreBuilders = new HashMap<>();
     for (final StoreBuilder<?> builder : userConnectedStores) {
       final String storeName = builder.name();
-      if (builder instanceof ResponsiveStoreBuilder) {
-        final ResponsiveStoreBuilder<?, ?, ?> responsiveBuilder =
-            (ResponsiveStoreBuilder<?, ?, ?>) builder;
 
-        final StoreType storeType = responsiveBuilder.storeType();
+      asyncStoreBuilders.put(
+          storeName,
+          new DelayedAsyncStoreBuilder<>(builder)
+      );
 
-        final AbstractAsyncStoreBuilder<?, ?, ?> storeBuilder;
-        if (storeType.equals(StoreType.TIMESTAMPED_KEY_VALUE)) {
-          storeBuilder = new AsyncTimestampedKeyValueStoreBuilder<>(responsiveBuilder);
-        } else if (storeType.equals(StoreType.KEY_VALUE)) {
-          storeBuilder = new AsyncKeyValueStoreBuilder<>(responsiveBuilder);
-        } else {
-          throw new UnsupportedOperationException(
-              "Only key-value stores are supported by async processors at this time");
-        }
-
-        asyncStoreBuilders.put(
-            storeName,
-            storeBuilder
-        );
-
-      } else {
-        throw new IllegalStateException(String.format(
-            "Detected the StoreBuilder for %s was not created via the ResponsiveStores factory, "
-                + "please ensure that all store builders and suppliers are provided through the "
-                + "appropriate API from ResponsiveStores", storeName));
-      }
     }
     return asyncStoreBuilders;
   }

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/contexts/DelegatingProcessorContext.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/contexts/DelegatingProcessorContext.java
@@ -259,8 +259,8 @@ public abstract class DelegatingProcessorContext<KOut, VOut, D
   }
 
   @Override
-  public ProcessorMetadata getProcessorMetadata() {
-    return delegate().getProcessorMetadata();
+  public ProcessorMetadata processorMetadata() {
+    return delegate().processorMetadata();
   }
 
   @Override

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/stores/AbstractAsyncStoreBuilder.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/stores/AbstractAsyncStoreBuilder.java
@@ -33,9 +33,9 @@ public abstract class AbstractAsyncStoreBuilder<K, V, T extends StateStore>
     implements StoreBuilder<T> {
 
   protected final String name;
-  protected final Serde<K> keySerde;
-  protected final Serde<V> valueSerde;
-  protected final Time time;
+  protected Serde<K> keySerde;
+  protected Serde<V> valueSerde;
+  protected Time time;
   protected final Map<String, String> logConfig = new HashMap<>();
 
   private boolean cachingEnabled = false;
@@ -48,14 +48,17 @@ public abstract class AbstractAsyncStoreBuilder<K, V, T extends StateStore>
       new ConcurrentHashMap<>();
 
   public AbstractAsyncStoreBuilder(
-      final String name,
-      final Serde<K> keySerde,
-      final Serde<V> valueSerde,
-      final Time time
+      final String name
   ) {
     Objects.requireNonNull(name, "name cannot be null");
-    Objects.requireNonNull(time, "time cannot be null");
     this.name = name;
+  }
+
+  public void initialize(final Serde<K> keySerde,
+                         final Serde<V> valueSerde,
+                         final Time time) {
+    Objects.requireNonNull(time, "time cannot be null");
+
     this.keySerde = keySerde;
     this.valueSerde = valueSerde;
     this.time = time;

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/stores/AsyncKeyValueStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/async/internals/stores/AsyncKeyValueStore.java
@@ -18,7 +18,6 @@ import java.util.List;
 import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.streams.KeyValue;
-import org.apache.kafka.streams.processor.StateStore;
 import org.apache.kafka.streams.query.PositionBound;
 import org.apache.kafka.streams.query.Query;
 import org.apache.kafka.streams.query.QueryConfig;
@@ -113,16 +112,6 @@ public class AsyncKeyValueStore<KS, VS>
   @Override
   public String name() {
     return userDelegate.name();
-  }
-
-  @Override
-  @Deprecated
-  public void init(
-      final org.apache.kafka.streams.processor.ProcessorContext context,
-      final StateStore root
-  ) {
-    throw new UnsupportedOperationException("This init method is deprecated, please implement"
-                                                + "init(StateStoreContext, StateStore) instead");
   }
 
   @Override

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
@@ -29,7 +29,7 @@ import org.apache.kafka.common.config.ConfigDef.Type;
 import org.apache.kafka.common.config.ConfigDef.Validator;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.config.types.Password;
-import org.apache.kafka.streams.processor.internals.assignment.StickyTaskAssignor;
+import org.apache.kafka.streams.processor.assignment.assignors.StickyTaskAssignor;
 
 /**
  * Configurations for {@link ResponsiveKafkaStreams}

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/DelegatingConsumer.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/DelegatingConsumer.java
@@ -31,6 +31,7 @@ import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
+import org.apache.kafka.common.metrics.KafkaMetric;
 
 public abstract class DelegatingConsumer<K, V> implements Consumer<K, V> {
 
@@ -78,12 +79,6 @@ public abstract class DelegatingConsumer<K, V> implements Consumer<K, V> {
   @Override
   public void unsubscribe() {
     delegate.unsubscribe();
-  }
-
-  @Override
-  @Deprecated
-  public ConsumerRecords<K, V> poll(final long timeout) {
-    return delegate.poll(timeout);
   }
 
   @Override
@@ -156,18 +151,6 @@ public abstract class DelegatingConsumer<K, V> implements Consumer<K, V> {
   @Override
   public long position(final TopicPartition partition, final Duration timeout) {
     return delegate.position(partition, timeout);
-  }
-
-  @Override
-  @Deprecated
-  public OffsetAndMetadata committed(final TopicPartition partition) {
-    return delegate.committed(partition);
-  }
-
-  @Override
-  @Deprecated
-  public OffsetAndMetadata committed(final TopicPartition partition, final Duration timeout) {
-    return delegate.committed(partition, timeout);
   }
 
   @Override
@@ -293,5 +276,15 @@ public abstract class DelegatingConsumer<K, V> implements Consumer<K, V> {
   @Override
   public Uuid clientInstanceId(final Duration duration) {
     return delegate.clientInstanceId(duration);
+  }
+
+  @Override
+  public void registerMetricForSubscription(final KafkaMetric metric) {
+    delegate.registerMetricForSubscription(metric);
+  }
+
+  @Override
+  public void unregisterMetricFromSubscription(final KafkaMetric metric) {
+    delegate.unregisterMetricFromSubscription(metric);
   }
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/DelegatingProducer.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/DelegatingProducer.java
@@ -28,10 +28,11 @@ import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.errors.ProducerFencedException;
+import org.apache.kafka.common.metrics.KafkaMetric;
 
 public abstract class DelegatingProducer<K, V> implements Producer<K, V> {
 
-  private final Producer<K, V> delegate;
+  protected final Producer<K, V> delegate;
 
   public DelegatingProducer(final Producer<K, V> delegate) {
     this.delegate = delegate;
@@ -112,6 +113,16 @@ public abstract class DelegatingProducer<K, V> implements Producer<K, V> {
   @Override
   public void close(final Duration timeout) {
     delegate.close();
+  }
+
+  @Override
+  public void registerMetricForSubscription(final KafkaMetric metric) {
+    delegate.registerMetricForSubscription(metric);
+  }
+
+  @Override
+  public void unregisterMetricFromSubscription(final KafkaMetric metric) {
+    delegate.unregisterMetricFromSubscription(metric);
   }
 
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/ResponsiveGlobalConsumer.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/ResponsiveGlobalConsumer.java
@@ -15,6 +15,7 @@ package dev.responsive.kafka.internal.clients;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -182,7 +183,8 @@ public class ResponsiveGlobalConsumer extends DelegatingConsumer<byte[], byte[]>
     public SingletonConsumerRecords(
         final Map<TopicPartition, List<ConsumerRecord<byte[], byte[]>>> records
     ) {
-      super(records);
+      super(records, Collections.emptyMap());
+      // TODO(sophie): need to pass in the actual next offsets here?
     }
 
     @Override

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/ResponsiveProducer.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/ResponsiveProducer.java
@@ -32,11 +32,11 @@ import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.Uuid;
 import org.apache.kafka.common.errors.ProducerFencedException;
+import org.apache.kafka.common.metrics.KafkaMetric;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class ResponsiveProducer<K, V> implements Producer<K, V> {
-  private final Producer<K, V> wrapped;
+public class ResponsiveProducer<K, V> extends DelegatingProducer<K, V> {
   private final List<Listener> listeners;
   private final Logger logger;
 
@@ -65,21 +65,12 @@ public class ResponsiveProducer<K, V> implements Producer<K, V> {
       final Producer<K, V> wrapped,
       final List<Listener> listeners
   ) {
+    super(wrapped);
     this.logger = LoggerFactory.getLogger(
         ResponsiveProducer.class.getName() + "." + Objects.requireNonNull(clientid));
-    this.wrapped = Objects.requireNonNull(wrapped);
     this.listeners = Objects.requireNonNull(listeners);
   }
 
-  @Override
-  public void initTransactions() {
-    wrapped.initTransactions();
-  }
-
-  @Override
-  public void beginTransaction() throws ProducerFencedException {
-    wrapped.beginTransaction();
-  }
 
   @Override
   @SuppressWarnings("deprecation")
@@ -87,7 +78,7 @@ public class ResponsiveProducer<K, V> implements Producer<K, V> {
       final Map<TopicPartition, OffsetAndMetadata> offsets,
       final String consumerGroupId
   ) throws ProducerFencedException {
-    wrapped.sendOffsetsToTransaction(offsets, consumerGroupId);
+    delegate.sendOffsetsToTransaction(offsets, consumerGroupId);
     for (final var l : listeners) {
       l.onSendOffsetsToTransaction(offsets, consumerGroupId);
     }
@@ -98,7 +89,7 @@ public class ResponsiveProducer<K, V> implements Producer<K, V> {
       final Map<TopicPartition, OffsetAndMetadata> offsets,
       final ConsumerGroupMetadata groupMetadata
   ) throws ProducerFencedException {
-    wrapped.sendOffsetsToTransaction(offsets, groupMetadata);
+    delegate.sendOffsetsToTransaction(offsets, groupMetadata);
     for (final var l : listeners) {
       l.onSendOffsetsToTransaction(offsets, groupMetadata.groupId());
     }
@@ -106,57 +97,38 @@ public class ResponsiveProducer<K, V> implements Producer<K, V> {
 
   @Override
   public void commitTransaction() throws ProducerFencedException {
-    wrapped.commitTransaction();
+    delegate.commitTransaction();
     listeners.forEach(Listener::onCommit);
   }
 
   @Override
   public void abortTransaction() throws ProducerFencedException {
-    wrapped.abortTransaction();
+    delegate.abortTransaction();
     listeners.forEach(Listener::onAbort);
   }
 
   @Override
   public Future<RecordMetadata> send(final ProducerRecord<K, V> record) {
-    return new RecordingFuture(wrapped.send(record), listeners);
+    return new RecordingFuture(delegate.send(record), listeners);
   }
 
   @Override
   public Future<RecordMetadata> send(final ProducerRecord<K, V> record, final Callback callback) {
     return new RecordingFuture(
-        wrapped.send(record, new RecordingCallback(callback, listeners)), listeners
+        delegate.send(record, new RecordingCallback(callback, listeners)), listeners
     );
   }
 
-  @Override
-  public void flush() {
-    wrapped.flush();
-  }
-
-  @Override
-  public List<PartitionInfo> partitionsFor(final String topic) {
-    return wrapped.partitionsFor(topic);
-  }
-
-  @Override
-  public Map<MetricName, ? extends Metric> metrics() {
-    return wrapped.metrics();
-  }
-
-  @Override
-  public Uuid clientInstanceId(final Duration duration) {
-    return wrapped.clientInstanceId(duration);
-  }
 
   @Override
   public void close() {
-    wrapped.close();
+    delegate.close();
     closeListeners();
   }
 
   @Override
   public void close(final Duration timeout) {
-    wrapped.close();
+    delegate.close(timeout);
     closeListeners();
   }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/config/ResponsiveStreamsConfig.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/config/ResponsiveStreamsConfig.java
@@ -36,7 +36,6 @@ public class ResponsiveStreamsConfig extends StreamsConfig {
 
   public static void validateStreamsConfig(final StreamsConfig streamsConfig) {
     verifyNoStandbys(streamsConfig);
-    verifyNotEosV1(streamsConfig);
   }
 
   static void verifyNoStandbys(final StreamsConfig config) throws ConfigException {
@@ -52,13 +51,6 @@ public class ResponsiveStreamsConfig extends StreamsConfig {
       );
       LOG.error(errorMsg);
       throw new ConfigException(errorMsg);
-    }
-  }
-
-  @SuppressWarnings("deprecation")
-  static void verifyNotEosV1(final StreamsConfig config) throws ConfigException {
-    if (EXACTLY_ONCE.equals(config.getString(StreamsConfig.PROCESSING_GUARANTEE_CONFIG))) {
-      throw new ConfigException("Responsive driver can only be used with ALOS/EOS-V2");
     }
   }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveKeyValueStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveKeyValueStore.java
@@ -80,18 +80,6 @@ public class ResponsiveKeyValueStore
   }
 
   @Override
-  @Deprecated
-  public void init(final ProcessorContext context, final StateStore root) {
-    if (context instanceof StateStoreContext) {
-      init((StateStoreContext) context, root);
-    } else {
-      throw new UnsupportedOperationException(
-          "Use ResponsiveStore#init(StateStoreContext, StateStore) instead."
-      );
-    }
-  }
-
-  @Override
   public void init(final StateStoreContext storeContext, final StateStore root) {
     try {
       final TaskType taskType = asInternalProcessorContext(storeContext).taskType();

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveSessionStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveSessionStore.java
@@ -62,18 +62,6 @@ public class ResponsiveSessionStore implements SessionStore<Bytes, byte[]> {
   }
 
   @Override
-  @Deprecated
-  public void init(final ProcessorContext context, final StateStore root) {
-    if (context instanceof StateStoreContext) {
-      init((StateStoreContext) context, root);
-    } else {
-      throw new UnsupportedOperationException(
-          "Use ResponsiveSessionStore#init(StateStoreContext, StateStore) instead."
-      );
-    }
-  }
-
-  @Override
   public void init(final StateStoreContext storeContext, final StateStore root) {
     log.info("Initializing state store");
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveStoreBuilder.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveStoreBuilder.java
@@ -72,10 +72,6 @@ public class ResponsiveStoreBuilder<K, V, T extends StateStore> implements Store
     this.time = time;
   }
 
-  public StoreType storeType() {
-    return storeType;
-  }
-
   public StoreSupplier<?> storeSupplier() {
     return userStoreSupplier;
   }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveWindowStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveWindowStore.java
@@ -82,18 +82,6 @@ public class ResponsiveWindowStore
   }
 
   @Override
-  @Deprecated
-  public void init(final ProcessorContext context, final StateStore root) {
-    if (context instanceof StateStoreContext) {
-      init((StateStoreContext) context, root);
-    } else {
-      throw new UnsupportedOperationException(
-          "Use ResponsiveWindowStore#init(StateStoreContext, StateStore) instead."
-      );
-    }
-  }
-
-  @Override
   public void init(final StateStoreContext storeContext, final StateStore root) {
     try {
       log.info("Initializing state store");

--- a/kafka-client/src/main/java/org/apache/kafka/streams/state/internals/DelayedAsyncStoreBuilder.java
+++ b/kafka-client/src/main/java/org/apache/kafka/streams/state/internals/DelayedAsyncStoreBuilder.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2024 Responsive Computing, Inc.
+ *
+ * This source code is licensed under the Responsive Business Source License Agreement v1.0
+ * available at:
+ *
+ * https://www.responsive.dev/legal/responsive-bsl-10
+ *
+ * This software requires a valid Commercial License Key for production use. Trial and commercial
+ * licenses can be obtained at https://www.responsive.dev
+ */
+
+package org.apache.kafka.streams.state.internals;
+
+import dev.responsive.kafka.api.async.internals.stores.AbstractAsyncStoreBuilder;
+import java.lang.reflect.Field;
+import org.apache.kafka.common.serialization.Serdes;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.streams.processor.StateStore;
+import org.apache.kafka.streams.processor.internals.StoreFactory.FactoryWrappingStoreBuilder;
+import org.apache.kafka.streams.state.KeyValueBytesStoreSupplier;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.StoreBuilder;
+import org.apache.kafka.streams.state.TimestampedBytesStore;
+
+public class DelayedAsyncStoreBuilder<K, V, T extends StateStore>
+    extends AbstractAsyncStoreBuilder<K, V, T> {
+
+  private final StoreBuilder<T> inner;
+  private StoreBuilder<T> innerResolved;
+
+  public DelayedAsyncStoreBuilder(final StoreBuilder<T> inner) {
+    super(inner.name());
+    this.inner = inner;
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  @Override
+  public T build() {
+    if (innerResolved == null) {
+      if (inner instanceof FactoryWrappingStoreBuilder) {
+        innerResolved = ((FactoryWrappingStoreBuilder) inner).resolveStoreBuilder();
+      } else {
+        innerResolved = inner;
+      }
+    }
+
+    if (innerResolved instanceof KeyValueStoreBuilder) {
+      return (T) getKeyValueStore((KeyValueStoreBuilder) innerResolved);
+    } else if (innerResolved instanceof TimestampedKeyValueStoreBuilder) {
+      return (T) getTimestampedKeyValueStore((TimestampedKeyValueStoreBuilder) innerResolved);
+    } else {
+      throw new UnsupportedOperationException("Other store types not yet supported");
+    }
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  private StateStore getKeyValueStore(final KeyValueStoreBuilder kvBuilder) {
+    try {
+      final Field storeSupplierField = KeyValueStoreBuilder.class.getDeclaredField(
+          "storeSupplier");
+
+      // Set the accessibility as true
+      storeSupplierField.setAccessible(true);
+
+      // Store the value of private field in variable
+      final KeyValueBytesStoreSupplier storeSupplier =
+          (KeyValueBytesStoreSupplier) storeSupplierField.get(kvBuilder);
+
+      final KeyValueStore store = storeSupplier.get();
+
+      return new MeteredKeyValueStore<>(
+          wrapAsyncFlushingKV(
+              maybeWrapCachingKV(
+                  maybeWrapLoggingKV(store))
+          ),
+          storeSupplier.metricsScope(),
+          kvBuilder.time,
+          kvBuilder.keySerde,
+          kvBuilder.valueSerde
+      );
+    } catch (final Exception e) {
+      throw new IllegalStateException("Failed to build async key-value store", e);
+    }
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  private StateStore getTimestampedKeyValueStore(
+      final TimestampedKeyValueStoreBuilder kvBuilder
+  ) {
+    try {
+      final Field storeSupplierField = TimestampedKeyValueStoreBuilder.class.getDeclaredField(
+          "storeSupplier");
+
+      // Set the accessibility as true
+      storeSupplierField.setAccessible(true);
+
+      // Store the value of private field in variable
+      final KeyValueBytesStoreSupplier storeSupplier =
+          (KeyValueBytesStoreSupplier) storeSupplierField.get(kvBuilder);
+
+      final KeyValueStore store = storeSupplier.get();
+
+      return new MeteredTimestampedKeyValueStore<>(
+          wrapAsyncFlushingKV(
+              maybeWrapCachingKV(
+                  maybeWrapLoggingTimestampedKV(store))
+          ),
+          storeSupplier.metricsScope(),
+          kvBuilder.time,
+          Serdes.String(),
+          kvBuilder.valueSerde
+      );
+    } catch (final Exception e) {
+      throw new IllegalStateException("Failed to build async key-value store", e);
+    }
+  }
+
+  private KeyValueStore<Bytes, byte[]> maybeWrapCachingKV(final KeyValueStore<Bytes, byte[]> inner) {
+    if (!cachingEnabled()) {
+      return inner;
+    }
+    return new CachingKeyValueStore(inner, true);
+  }
+
+  private KeyValueStore<Bytes, byte[]> maybeWrapLoggingKV(final KeyValueStore<Bytes, byte[]> inner) {
+    if (!loggingEnabled()) {
+      return inner;
+    }
+    return new ChangeLoggingKeyValueBytesStore(inner);
+  }
+
+  private KeyValueStore<Bytes, byte[]> maybeWrapLoggingTimestampedKV(final KeyValueStore<Bytes, byte[]> inner) {
+    if (!loggingEnabled()) {
+      return inner;
+    }
+    return new ChangeLoggingTimestampedKeyValueBytesStore(inner);
+  }
+
+}

--- a/kafka-client/src/test/java/dev/responsive/kafka/async/AsyncProcessorIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/async/AsyncProcessorIntegrationTest.java
@@ -52,7 +52,9 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Throwables;
 import dev.responsive.kafka.api.ResponsiveKafkaStreams;
+import dev.responsive.kafka.api.async.AsyncProcessorWrapper;
 import dev.responsive.kafka.api.config.StorageBackend;
+import dev.responsive.kafka.api.stores.ResponsiveDslStoreSuppliers;
 import dev.responsive.kafka.api.stores.ResponsiveKeyValueParams;
 import dev.responsive.kafka.api.stores.ResponsiveStores;
 import dev.responsive.kafka.testutils.ResponsiveConfigParam;
@@ -70,6 +72,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -85,10 +88,14 @@ import org.apache.kafka.common.serialization.StringSerializer;
 import org.apache.kafka.streams.KafkaStreams.State;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.Topology;
+import org.apache.kafka.streams.TopologyConfig;
 import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler;
 import org.apache.kafka.streams.errors.StreamsUncaughtExceptionHandler.StreamThreadExceptionResponse;
 import org.apache.kafka.streams.kstream.Consumed;
 import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.kstream.Named;
 import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.streams.processor.api.FixedKeyProcessor;
@@ -141,6 +148,7 @@ public class AsyncProcessorIntegrationTest {
   private static final int INPUT_RECORDS_PER_KEY = 10;
 
   private String inputTopic;
+  private String inputTableTopic;
   private String outputTopic;
 
   private String inKVStore;
@@ -165,6 +173,7 @@ public class AsyncProcessorIntegrationTest {
     this.name = info.getDisplayName().replace("()", "");
 
     this.inputTopic = name + "input";
+    this.inputTableTopic = name + "input-table";
     this.outputTopic = name + "output";
     this.inKVStore = name + "in";
     this.asyncStore1 = name + "a1";
@@ -179,21 +188,68 @@ public class AsyncProcessorIntegrationTest {
 
     createTopicsAndWait(
         admin,
-        Map.of(inputTopic(), numInputPartitions, outputTopic(), numOutputPartitions)
+        Map.of(
+            inputTopic, numInputPartitions,
+            inputTableTopic, numInputPartitions,
+            outputTopic, numOutputPartitions)
     );
   }
 
   @AfterEach
   public void after() {
-    admin.deleteTopics(List.of(inputTopic(), outputTopic()));
+    admin.deleteTopics(List.of(inputTopic, inputTableTopic, outputTopic));
   }
 
-  private String inputTopic() {
-    return name + "." + inputTopic;
-  }
 
-  private String outputTopic() {
-    return name + "." + outputTopic;
+  @Test
+  public void shouldWrapDSLWithAsync() throws Exception {
+    final Map<String, Object> properties = getMutableProperties();
+    properties.put(StreamsConfig.PROCESSOR_WRAPPER_CLASS_CONFIG, AsyncProcessorWrapper.class);
+    properties.put(StreamsConfig.DSL_STORE_SUPPLIERS_CLASS_CONFIG, ResponsiveDslStoreSuppliers.class);
+    properties.put(COMMIT_INTERVAL_MS_CONFIG, 0L);
+    properties.put(VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+
+    final StreamsBuilder builder = new StreamsBuilder(new TopologyConfig(new StreamsConfig(properties)));
+
+    final KStream<String, String> stream = builder.stream(inputTopic);
+    final KTable<String, String> table = builder.table(inputTableTopic);
+
+    stream
+        .join(table, (l, r) -> l + "-" + r)
+        .to(outputTopic);
+
+    final Properties props = new Properties();
+    props.putAll(properties);
+    final Topology topology = builder.build(props);
+
+    final KafkaProducer<String, String> producer = new KafkaProducer<>(properties);
+
+    final List<KeyValue<String, String>> tableInput = new LinkedList<>();
+    tableInput.add(new KeyValue<>("A", "a"));
+    tableInput.add(new KeyValue<>("B", "b"));
+    tableInput.add(new KeyValue<>("C", "c"));
+    pipeRecords(producer, inputTableTopic, tableInput);
+
+    final List<KeyValue<String, String>> streamInput = new LinkedList<>();
+    streamInput.add(new KeyValue<>("A", "a-joined"));
+    streamInput.add(new KeyValue<>("B", "b-joined"));
+    streamInput.add(new KeyValue<>("C", "c-joined"));
+    pipeRecords(producer, inputTopic, streamInput);
+
+    try (final var streams = new ResponsiveKafkaStreams(topology, properties)) {
+      startAppAndAwaitRunning(Duration.ofSeconds(60), streams);
+
+      final List<KeyValue<String, String>> kvs = readOutput(
+          outputTopic, 0, 3, numOutputPartitions, false, properties
+      );
+
+      final List<KeyValue<String, String>> expectedOutput = new LinkedList<>();
+      expectedOutput.add(new KeyValue<>("A", "a-joined-a"));
+      expectedOutput.add(new KeyValue<>("B", "b-joined-b"));
+      expectedOutput.add(new KeyValue<>("C", "c-joined-c"));
+
+      assertThat(kvs.containsAll(expectedOutput), is(true));
+    }
   }
 
   @Test
@@ -235,7 +291,7 @@ public class AsyncProcessorIntegrationTest {
 
     final StreamsBuilder builder = new StreamsBuilder();
     final KStream<String, InputRecord> input = builder.stream(
-        inputTopic(),
+        inputTopic,
         Consumed.with(
             Serdes.String(),
             Serdes.serdeFrom(new InputRecordSerializer(), new InputRecordDeserializer())
@@ -298,7 +354,7 @@ public class AsyncProcessorIntegrationTest {
                 )),
             Named.as("S2"),
             asyncStore2)
-        .to(outputTopic(), Produced.with(Serdes.String(), Serdes.String()));
+        .to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
 
     final List<Throwable> caughtExceptions = new LinkedList<>();
     try (final var streams = new ResponsiveKafkaStreams(builder.build(), properties)) {
@@ -309,11 +365,11 @@ public class AsyncProcessorIntegrationTest {
       startAppAndAwaitRunning(Duration.ofSeconds(30), streams);
 
       // When:
-      pipeRecords(producer, inputTopic(), inputRecords);
+      pipeRecords(producer, inputTopic, inputRecords);
 
       // Then:
       final List<KeyValue<String, String>> kvs = readOutput(
-          outputTopic(), 0, numInputRecords, numOutputPartitions, false, properties
+          outputTopic, 0, numInputRecords, numOutputPartitions, false, properties
       );
 
       final Map<String, List<String>> observedOutputValuesByKey = new HashMap<>(keys.size());
@@ -373,7 +429,7 @@ public class AsyncProcessorIntegrationTest {
 
     final StreamsBuilder builder = new StreamsBuilder();
     final KStream<String, InputRecord> input = builder.stream(
-        inputTopic(),
+        inputTopic,
         Consumed.with(
             Serdes.String(),
             Serdes.serdeFrom(new InputRecordSerializer(), new InputRecordDeserializer())
@@ -399,7 +455,7 @@ public class AsyncProcessorIntegrationTest {
                 latestValues,
                 inputRecordsLatch),
             outKVStore)
-        .to(outputTopic(), Produced.with(Serdes.String(), Serdes.String()));
+        .to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
 
     final List<Throwable> caughtExceptions = new LinkedList<>();
     try (final var streams = new ResponsiveKafkaStreams(builder.build(), properties)) {
@@ -410,7 +466,7 @@ public class AsyncProcessorIntegrationTest {
       startAppAndAwaitRunning(Duration.ofSeconds(30), streams);
 
       // When:
-      pipeRecords(producer, inputTopic(), inputRecords);
+      pipeRecords(producer, inputTopic, inputRecords);
 
       // Then:
       final long timeoutMs = 60_000L + DEFAULT_ASYNC_SLEEP_DURATION_MS * numInputRecords;
@@ -421,7 +477,7 @@ public class AsyncProcessorIntegrationTest {
       }
 
       final var kvs = readOutput(
-          outputTopic(), 0, numInputRecords, numOutputPartitions, false, properties
+          outputTopic, 0, numInputRecords, numOutputPartitions, false, properties
       );
 
       final Map<String, String> latestByKey = new HashMap<>();
@@ -492,7 +548,7 @@ public class AsyncProcessorIntegrationTest {
 
     final StreamsBuilder builder = new StreamsBuilder();
     final KStream<String, InputRecord> input = builder.stream(
-        inputTopic(),
+        inputTopic,
         Consumed.with(
             Serdes.String(),
             Serdes.serdeFrom(new InputRecordSerializer(), new InputRecordDeserializer())
@@ -523,7 +579,7 @@ public class AsyncProcessorIntegrationTest {
                 latestValues,
                 inputRecordsLatch),
             outKVStore)
-        .to(outputTopic(), Produced.with(Serdes.String(), Serdes.String()));
+        .to(outputTopic, Produced.with(Serdes.String(), Serdes.String()));
 
     final List<Throwable> caughtExceptions = new LinkedList<>();
     try (final var streams = new ResponsiveKafkaStreams(builder.build(), properties)) {
@@ -534,7 +590,7 @@ public class AsyncProcessorIntegrationTest {
       startAppAndAwaitRunning(Duration.ofSeconds(30), streams);
 
       // When:
-      pipeRecords(producer, inputTopic(), inputRecords);
+      pipeRecords(producer, inputTopic, inputRecords);
 
       // Then:
       final long timeout = 60_000L + DEFAULT_ASYNC_SLEEP_DURATION_MS * numInputRecords;
@@ -545,7 +601,7 @@ public class AsyncProcessorIntegrationTest {
       }
 
       final var kvs = readOutput(
-          outputTopic(), 0, numInputRecords, numOutputPartitions, false, properties
+          outputTopic, 0, numInputRecords, numOutputPartitions, false, properties
       );
 
       final Map<String, String> latestByKey = new HashMap<>();
@@ -570,7 +626,7 @@ public class AsyncProcessorIntegrationTest {
 
     final StreamsBuilder builder = new StreamsBuilder();
     final KStream<String, InputRecord> input = builder.stream(
-        inputTopic(),
+        inputTopic,
         Consumed.with(
             Serdes.String(),
             Serdes.serdeFrom(new InputRecordSerializer(), new InputRecordDeserializer())

--- a/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveKeyValueStoreRestoreIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveKeyValueStoreRestoreIntegrationTest.java
@@ -531,12 +531,6 @@ public class ResponsiveKeyValueStoreRestoreIntegrationTest {
     }
 
     @Override
-    @SuppressWarnings("deprecation")
-    public ConsumerRecords<byte[], byte[]> poll(long timeoutMs) {
-      return record(super.poll(timeoutMs));
-    }
-
-    @Override
     public ConsumerRecords<byte[], byte[]> poll(Duration timeout) {
       return record(super.poll(timeout));
     }

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/config/ResponsiveStreamsConfigTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/config/ResponsiveStreamsConfigTest.java
@@ -13,7 +13,6 @@
 package dev.responsive.kafka.internal.config;
 
 import static dev.responsive.kafka.internal.config.ResponsiveStreamsConfig.verifyNoStandbys;
-import static dev.responsive.kafka.internal.config.ResponsiveStreamsConfig.verifyNotEosV1;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Map;
@@ -56,16 +55,4 @@ class ResponsiveStreamsConfigTest {
     )));
   }
 
-  @SuppressWarnings("deprecation")
-  @Test
-  public void shouldThrowOnEOSV1() {
-    assertThrows(
-        ConfigException.class,
-        () -> verifyNotEosV1(new StreamsConfig(Map.of(
-            StreamsConfig.APPLICATION_ID_CONFIG, "foo",
-            CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, "foo.bar",
-            StreamsConfig.PROCESSING_GUARANTEE_CONFIG, StreamsConfig.EXACTLY_ONCE
-        )))
-    );
-  }
 }

--- a/kafka-client/src/test/java/dev/responsive/kafka/testutils/KeyValueStoreComparator.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/testutils/KeyValueStoreComparator.java
@@ -170,18 +170,6 @@ public class KeyValueStoreComparator<K, V> implements KeyValueStore<K, V> {
   }
 
   @Override
-  @Deprecated
-  public void init(final ProcessorContext context, final StateStore root) {
-    if (context instanceof StateStoreContext) {
-      init((StateStoreContext) context, root);
-    } else {
-      throw new UnsupportedOperationException(
-          "Use ResponsiveSessionStore#init(StateStoreContext, StateStore) instead."
-      );
-    }
-  }
-
-  @Override
   public void init(final StateStoreContext context, final StateStore root) {
     StateStoreContext proxy = (StateStoreContext) Proxy.newProxyInstance(
         InternalProcessorContext.class.getClassLoader(),

--- a/kafka-client/src/test/java/dev/responsive/kafka/testutils/SessionStoreComparator.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/testutils/SessionStoreComparator.java
@@ -79,18 +79,6 @@ public class SessionStoreComparator<K, V> implements SessionStore<K, V> {
   }
 
   @Override
-  @Deprecated
-  public void init(final ProcessorContext context, final StateStore root) {
-    if (context instanceof StateStoreContext) {
-      init((StateStoreContext) context, root);
-    } else {
-      throw new UnsupportedOperationException(
-          "Use ResponsiveSessionStore#init(StateStoreContext, StateStore) instead."
-      );
-    }
-  }
-
-  @Override
   public void flush() {
     this.sourceOfTruth.flush();
     this.candidate.flush();

--- a/kafka-client/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadIntegrationTest.java
+++ b/kafka-client/src/test/java/org/apache/kafka/streams/processor/internals/GlobalStreamThreadIntegrationTest.java
@@ -44,7 +44,6 @@ import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.apache.kafka.common.serialization.Serdes.ByteArraySerde;
 import org.apache.kafka.common.utils.Bytes;
-import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.processor.StateRestoreListener;
@@ -263,7 +262,7 @@ public class GlobalStreamThreadIntegrationTest {
       final TestStoreSupplier storeSupplier,
       final StateRestoreListener restoreListener,
       final File tempDir) {
-    final Time time = new SystemTime();
+    final Time time = Time.SYSTEM;
     final InternalTopologyBuilder builder = new InternalTopologyBuilder();
     builder.addGlobalStore(
         new StoreBuilderWrapper(
@@ -291,7 +290,8 @@ public class GlobalStreamThreadIntegrationTest {
           public void process(final Record<Object, Object> record) {
             global.put(record.key(), record.value());
           }
-        }
+        },
+        false
     );
 
     final String baseDirectoryName = tempDir.getAbsolutePath();

--- a/operator/build.gradle.kts
+++ b/operator/build.gradle.kts
@@ -16,6 +16,10 @@ plugins {
     id("responsive.helm")
 }
 
+repositories {
+    mavenLocal()
+}
+
 application {
     mainClass.set("dev.responsive.k8s.operator.OperatorMain")
 }

--- a/responsive-spring/build.gradle.kts
+++ b/responsive-spring/build.gradle.kts
@@ -39,6 +39,10 @@ java {
     }
 }
 
+repositories {
+    mavenLocal()
+}
+
 version = project(":kafka-client").version
 
 dependencies {

--- a/responsive-test-utils/build.gradle.kts
+++ b/responsive-test-utils/build.gradle.kts
@@ -14,6 +14,10 @@ plugins {
     id("responsive.java-library-conventions")
 }
 
+repositories {
+    mavenLocal()
+}
+
 version = project(":kafka-client").version
 
 dependencies {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -43,7 +43,7 @@ dependencyResolutionManagement {
     versionCatalogs {
         create("libs") {
             version("jackson", "2.15.2")
-            version("kafka", "3.7.1")
+            version("kafka", "4.0.0-SNAPSHOT")
             version("scylla", "4.15.0.0")
             version("javaoperatorsdk", "4.9.6")
             version("grpc", "1.52.1")


### PR DESCRIPTION
This PR is mainly a POC to show that it can be done -- we'll need to wait for 4.0 to be released before merging this. It also includes the changes we'll need to make for that upgrade (eg removal of deprecated APIs)

Until we can merge and release this new feature, it has to be run on top of my WIP KIP-1112 branch ([here](https://github.com/apache/kafka/pull/17833)).

Remaining work beyond this POC:
-AK: converting all of the other stateful DSL operators to implement the ProcessorSupplier#stores method
-Responsive: fill in the async store builders with all the store types (eg versioned stores, window and session stores)