### PR TITLE
use cluster default for compaction strategy

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/spec/DefaultTableSpec.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/spec/DefaultTableSpec.java
@@ -13,8 +13,6 @@
 package dev.responsive.kafka.internal.db.spec;
 
 import com.datastax.oss.driver.api.querybuilder.schema.CreateTableWithOptions;
-import com.datastax.oss.driver.api.querybuilder.schema.compaction.CompactionStrategy;
-import com.datastax.oss.driver.internal.querybuilder.schema.compaction.DefaultLeveledCompactionStrategy;
 import dev.responsive.kafka.internal.db.partitioning.TablePartitioner;
 import dev.responsive.kafka.internal.stores.TtlResolver;
 import java.util.Optional;

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/spec/DefaultTableSpec.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/spec/DefaultTableSpec.java
@@ -21,9 +21,6 @@ import java.util.Optional;
 
 public class DefaultTableSpec implements RemoteTableSpec {
 
-  private static final CompactionStrategy<?> DEFAULT_CASSANDRA_COMPACTION_STRATEGY =
-      new DefaultLeveledCompactionStrategy();
-
   private final String name;
   private final TablePartitioner<?, ?> partitioner;
   private final Optional<TtlResolver<?, ?>> ttlResolver;
@@ -55,6 +52,6 @@ public class DefaultTableSpec implements RemoteTableSpec {
 
   @Override
   public CreateTableWithOptions applyDefaultOptions(final CreateTableWithOptions base) {
-    return base.withCompaction(DEFAULT_CASSANDRA_COMPACTION_STRATEGY);
+    return base;
   }
 }


### PR DESCRIPTION
There was a regression in #371 where we started specifying LCS as the default compaction strategy. This change uses the cluster default instead, so that it will use ICS in scylla enterprise clusters (which ScyllaDB cloud are by default).

We can't test this easily since the scyllaDB public docker images don't have ICS, but I verified manually that this works.