### PR TITLE
support prefix scans in ResponsiveKeyValueStore

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraFactTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraFactTable.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import javax.annotation.CheckReturnValue;
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.slf4j.Logger;
@@ -427,6 +428,16 @@ public class CassandraFactTable implements RemoteKVTable<BoundStatement> {
       long streamTimeMs
   ) {
     throw new UnsupportedOperationException("all is not supported on fact tables");
+  }
+
+  @Override
+  public <PS extends Serializer<P>, P> KeyValueIterator<Bytes, byte[]> prefix(
+      final P prefix,
+      final PS prefixKeySerializer,
+      final int kafkaPartition,
+      final long streamTimeMs
+  ) {
+    throw new UnsupportedOperationException("prefix scans are not supported on fact tables.");
   }
 
   private static String metadataTable(final String tableName) {

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraKeyValueTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraKeyValueTable.java
@@ -38,6 +38,7 @@ import dev.responsive.kafka.internal.db.partitioning.SubPartitioner;
 import dev.responsive.kafka.internal.db.spec.RemoteTableSpec;
 import dev.responsive.kafka.internal.stores.TtlResolver;
 import dev.responsive.kafka.internal.utils.Iterators;
+import dev.responsive.kafka.internal.utils.Utils;
 import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.time.Instant;
@@ -46,6 +47,7 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.TimeoutException;
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.errors.TaskMigratedException;
@@ -74,6 +76,7 @@ public class CassandraKeyValueTable implements RemoteKVTable<BoundStatement> {
   private final PreparedStatement fetchEpoch;
   private final PreparedStatement reserveEpoch;
   private final PreparedStatement ensureEpoch;
+  private final PreparedStatement prefix;
 
   public static CassandraKeyValueTable create(
       final RemoteTableSpec spec,
@@ -121,8 +124,21 @@ public class CassandraKeyValueTable implements RemoteKVTable<BoundStatement> {
             .where(DATA_KEY.relation().isGreaterThanOrEqualTo(bindMarker(FROM_BIND)))
             .where(DATA_KEY.relation().isLessThanOrEqualTo(bindMarker(TO_BIND)))
             .where(TIMESTAMP.relation().isGreaterThanOrEqualTo(bindMarker(TIMESTAMP.bind())))
-            // ALLOW FILTERING is OK b/c the query only scans one partition
-            .allowFiltering()
+            .allowFiltering() // required for range
+            .build(),
+        QueryOp.READ
+    );
+
+    final var prefix = client.prepare(
+        QueryBuilder
+            .selectFrom(name)
+            .columns(DATA_KEY.column(), DATA_VALUE.column(), TIMESTAMP.column())
+            .where(ROW_TYPE.relation().isEqualTo(DATA_ROW.literal()))
+            .where(PARTITION_KEY.relation().isEqualTo(bindMarker(PARTITION_KEY.bind())))
+            .where(DATA_KEY.relation().isGreaterThanOrEqualTo(bindMarker(FROM_BIND)))
+            .where(DATA_KEY.relation().isLessThan(bindMarker(TO_BIND)))
+            .where(TIMESTAMP.relation().isGreaterThanOrEqualTo(bindMarker(TIMESTAMP.bind())))
+            .allowFiltering() // required for prefix
             .build(),
         QueryOp.READ
     );
@@ -214,6 +230,7 @@ public class CassandraKeyValueTable implements RemoteKVTable<BoundStatement> {
         ttlResolver,
         get,
         range,
+        prefix,
         all,
         insert,
         delete,
@@ -256,6 +273,7 @@ public class CassandraKeyValueTable implements RemoteKVTable<BoundStatement> {
       final Optional<TtlResolver<?, ?>> ttlResolver,
       final PreparedStatement get,
       final PreparedStatement range,
+      final PreparedStatement prefix,
       final PreparedStatement all,
       final PreparedStatement insert,
       final PreparedStatement delete,
@@ -271,6 +289,7 @@ public class CassandraKeyValueTable implements RemoteKVTable<BoundStatement> {
     this.ttlResolver = ttlResolver;
     this.get = get;
     this.range = range;
+    this.prefix = prefix;
     this.all = all;
     this.insert = insert;
     this.delete = delete;
@@ -383,6 +402,27 @@ public class CassandraKeyValueTable implements RemoteKVTable<BoundStatement> {
       final Bytes to,
       final long streamTimeMs
   ) {
+    return doRange(kafkaPartition, from, to, streamTimeMs, range);
+  }
+
+  @Override
+  public <PS extends Serializer<P>, P> KeyValueIterator<Bytes, byte[]> prefix(
+      final P prefix,
+      final PS prefixKeySerializer,
+      final int kafkaPartition,
+      final long streamTimeMs
+  ) {
+    final Bytes from = Bytes.wrap(prefixKeySerializer.serialize(null, prefix));
+    final Bytes to = Utils.incrementWithoutOverflow(from);
+    return doRange(kafkaPartition, from, to, streamTimeMs, this.prefix);
+  }
+
+  private KeyValueIterator<Bytes, byte[]> doRange(
+      final int kafkaPartition,
+      final Bytes from,
+      final Bytes to,
+      final long streamTimeMs,
+      final PreparedStatement rangeStatement) {
     final long minValidTs = ttlResolver.isEmpty()
         ? -1L
         : streamTimeMs - ttlResolver.get().defaultTtl().toMillis();
@@ -394,7 +434,7 @@ public class CassandraKeyValueTable implements RemoteKVTable<BoundStatement> {
     //  for range queries with a Comparator-aware key-->subpartition mapping strategy.
     final List<KeyValueIterator<Bytes, byte[]>> resultsPerPartition = new LinkedList<>();
     for (final int partition : partitioner.allTablePartitions(kafkaPartition)) {
-      final BoundStatement range = this.range
+      final BoundStatement range = rangeStatement
           .bind()
           .setInt(PARTITION_KEY.bind(), partition)
           .setByteBuffer(FROM_BIND, ByteBuffer.wrap(from.get()))

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/RemoteKVTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/RemoteKVTable.java
@@ -12,6 +12,7 @@
 
 package dev.responsive.kafka.internal.db;
 
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.state.KeyValueIterator;
 
@@ -77,6 +78,13 @@ public interface RemoteKVTable<S> extends RemoteTable<Bytes, S> {
    * @return an iterator of all key-value pairs
    */
   KeyValueIterator<Bytes, byte[]> all(int kafkaPartition, long streamTimeMs);
+
+  <PS extends Serializer<P>, P> KeyValueIterator<Bytes, byte[]> prefix(
+      P prefix,
+      PS prefixKeySerializer,
+      int kafkaPartition,
+      long streamTimeMs
+  );
 
   /**
    *  An approximate count of the total number of entries across all sub-partitions

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/inmemory/InMemoryKVTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/inmemory/InMemoryKVTable.java
@@ -22,6 +22,7 @@ import dev.responsive.kafka.internal.stores.RemoteWriteResult;
 import dev.responsive.kafka.internal.stores.ResponsiveStoreRegistration;
 import dev.responsive.kafka.internal.stores.TtlResolver;
 import dev.responsive.kafka.internal.utils.Iterators;
+import dev.responsive.kafka.internal.utils.Utils;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Objects;
@@ -30,6 +31,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.state.KeyValueIterator;
@@ -86,16 +88,39 @@ public class InMemoryKVTable implements RemoteKVTable<BoundStatement> {
       final Bytes to,
       final long streamTimeMs
   ) {
+    return doRange(kafkaPartition, from, to, streamTimeMs, true);
+  }
+
+  @Override
+  public <PS extends Serializer<P>, P> KeyValueIterator<Bytes, byte[]> prefix(
+      final P prefix,
+      final PS prefixKeySerializer,
+      final int kafkaPartition,
+      final long streamTimeMs
+  ) {
+    final Bytes from = Bytes.wrap(prefixKeySerializer.serialize(null, prefix));
+    final Bytes to = Utils.incrementWithoutOverflow(from);
+
+    return doRange(kafkaPartition, from, to, streamTimeMs, false);
+  }
+
+  private KeyValueIterator<Bytes, byte[]> doRange(
+      final int kafkaPartition,
+      final Bytes from,
+      final Bytes to,
+      final long streamTimeMs,
+      final boolean endInclusive
+  ) {
     if (ttlResolver.isPresent() && !ttlResolver.get().hasDefaultOnly()) {
       throw new UnsupportedOperationException("Row-level ttl is not yet supported for range "
-                                                  + "queries on in-memory tables or TTD");
+          + "queries or prefix scans on in-memory tables or TTD");
     }
 
     checkKafkaPartition(kafkaPartition);
 
     final var iter = store
         .tailMap(from, true)
-        .headMap(to, true)
+        .headMap(to, endInclusive)
         .entrySet()
         .iterator();
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/inmemory/InMemoryKVTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/inmemory/InMemoryKVTable.java
@@ -118,11 +118,15 @@ public class InMemoryKVTable implements RemoteKVTable<BoundStatement> {
 
     checkKafkaPartition(kafkaPartition);
 
-    final var iter = store
-        .tailMap(from, true)
-        .headMap(to, endInclusive)
-        .entrySet()
-        .iterator();
+    var view = store;
+    if (from != null) {
+      view = view.tailMap(from, true);
+    }
+    if (to != null) {
+      view = view .headMap(to, endInclusive);
+    }
+
+    final var iter = view.entrySet().iterator();
 
     final long minValidTs = ttlResolver.isEmpty()
         ? -1L

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/inmemory/InMemoryKVTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/inmemory/InMemoryKVTable.java
@@ -123,7 +123,7 @@ public class InMemoryKVTable implements RemoteKVTable<BoundStatement> {
       view = view.tailMap(from, true);
     }
     if (to != null) {
-      view = view .headMap(to, endInclusive);
+      view = view.headMap(to, endInclusive);
     }
 
     final var iter = view.entrySet().iterator();

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoKVTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoKVTable.java
@@ -36,18 +36,21 @@ import dev.responsive.kafka.internal.db.MongoKVFlushManager;
 import dev.responsive.kafka.internal.db.RemoteKVTable;
 import dev.responsive.kafka.internal.stores.TtlResolver;
 import dev.responsive.kafka.internal.utils.Iterators;
+import dev.responsive.kafka.internal.utils.Utils;
 import java.time.Duration;
 import java.util.Date;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.TimeUnit;
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.bson.codecs.configuration.CodecProvider;
 import org.bson.codecs.configuration.CodecRegistry;
 import org.bson.codecs.pojo.PojoCodecProvider;
+import org.bson.conversions.Bson;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -172,12 +175,35 @@ public class MongoKVTable implements RemoteKVTable<WriteModel<KVDoc>> {
       final Bytes to,
       final long streamTimeMs
   ) {
+    return doRange(kafkaPartition, from, Filters.lte(KVDoc.ID, keyCodec.encode(to)), streamTimeMs);
+  }
+
+
+  @Override
+  public <PS extends Serializer<P>, P> KeyValueIterator<Bytes, byte[]> prefix(
+      final P prefix,
+      final PS prefixKeySerializer,
+      final int kafkaPartition,
+      final long streamTimeMs
+  ) {
+    final Bytes from = Bytes.wrap(prefixKeySerializer.serialize(null, prefix));
+    final Bytes to = Utils.incrementWithoutOverflow(from);
+
+    return doRange(kafkaPartition, from, Filters.lt(KVDoc.ID, keyCodec.encode(to)), streamTimeMs);
+  }
+
+  private KeyValueIterator<Bytes, byte[]> doRange(
+      final int kafkaPartition,
+      final Bytes from,
+      final Bson toFilter,
+      final long streamTimeMs
+  ) {
     final Date minValidTs = new Date(ttlResolver.isEmpty() ? -1L : streamTimeMs - defaultTtlMs);
 
     final FindIterable<KVDoc> result = docs.find(
         Filters.and(
             Filters.gte(KVDoc.ID, keyCodec.encode(from)),
-            Filters.lte(KVDoc.ID, keyCodec.encode(to)),
+            toFilter,
             Filters.not(Filters.exists(KVDoc.TOMBSTONE_TS)),
             Filters.gte(KVDoc.TIMESTAMP, minValidTs),
             Filters.eq(KVDoc.KAFKA_PARTITION, kafkaPartition)

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/rs3/RS3KVTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/rs3/RS3KVTable.java
@@ -24,6 +24,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.state.KeyValueIterator;
 import org.slf4j.Logger;
@@ -117,7 +118,17 @@ public class RS3KVTable implements RemoteKVTable<WalEntry> {
       final int kafkaPartition,
       final Bytes from,
       final Bytes to,
-      final long minValidTs
+      final long streamTimeMs
+  ) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public <PS extends Serializer<P>, P> KeyValueIterator<Bytes, byte[]> prefix(
+      final P prefix,
+      final PS prefixKeySerializer,
+      final int kafkaPartition,
+      final long streamTimeMs
   ) {
     throw new UnsupportedOperationException();
   }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/GlobalOperations.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/GlobalOperations.java
@@ -27,6 +27,7 @@ import java.util.Optional;
 import java.util.concurrent.TimeoutException;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.processor.StateStoreContext;
 import org.apache.kafka.streams.processor.internals.GlobalProcessorContextImpl;
@@ -160,6 +161,14 @@ public class GlobalOperations implements KeyValueOperations {
   @Override
   public void close() {
     restoreListener.onStoreClosed(changelog, storeName);
+  }
+
+  @Override
+  public <PS extends Serializer<P>, P> KeyValueIterator<Bytes, byte[]> prefix(
+      final P prefix,
+      final PS prefixKeySerializer
+  ) {
+    throw new UnsupportedOperationException("Prefix scans on global tables is not yet supported.");
   }
 
   @Override

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/KeyValueOperations.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/KeyValueOperations.java
@@ -13,6 +13,7 @@
 package dev.responsive.kafka.internal.stores;
 
 import java.io.Closeable;
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.processor.internals.RecordBatchingStateRestoreCallback;
 import org.apache.kafka.streams.state.KeyValueIterator;
@@ -37,4 +38,9 @@ public interface KeyValueOperations extends Closeable, RecordBatchingStateRestor
 
   @Override
   void close();
+
+  <PS extends Serializer<P>, P> KeyValueIterator<Bytes, byte[]> prefix(
+      P prefix,
+      PS prefixKeySerializer
+  );
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/PartitionedOperations.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/PartitionedOperations.java
@@ -44,6 +44,7 @@ import java.util.concurrent.TimeoutException;
 import java.util.function.Supplier;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.streams.processor.StateStoreContext;
@@ -368,6 +369,14 @@ public class PartitionedOperations implements KeyValueOperations {
   public KeyValueIterator<Bytes, byte[]> reverseRange(final Bytes from, final Bytes to) {
     // TODO: add a reverseRange API to RemoteKVTable (or add an iteration order param to #range)
     throw new UnsupportedOperationException("Not yet implemented.");
+  }
+
+  @Override
+  public <PS extends Serializer<P>, P> KeyValueIterator<Bytes, byte[]> prefix(
+      final P prefix,
+      final PS prefixKeySerializer
+  ) {
+    return table.prefix(prefix, prefixKeySerializer, changelog.partition(), streamTimeMs);
   }
 
   @Override

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveKeyValueStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveKeyValueStore.java
@@ -19,6 +19,7 @@ import dev.responsive.kafka.internal.utils.TableName;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeoutException;
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.common.utils.LogContext;
 import org.apache.kafka.streams.KeyValue;
@@ -195,6 +196,14 @@ public class ResponsiveKeyValueStore
   @Override
   public KeyValueIterator<Bytes, byte[]> range(final Bytes from, final Bytes to) {
     return operations.range(from, to);
+  }
+
+  @Override
+  public <PS extends Serializer<P>, P> KeyValueIterator<Bytes, byte[]> prefixScan(
+      final P prefix,
+      final PS prefixKeySerializer
+  ) {
+    return operations.prefix(prefix, prefixKeySerializer);
   }
 
   @Override

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/utils/Utils.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/utils/Utils.java
@@ -13,6 +13,7 @@
 package dev.responsive.kafka.internal.utils;
 
 import java.util.regex.Pattern;
+import org.apache.kafka.common.utils.Bytes;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -116,5 +117,13 @@ public final class Utils {
 
     LOG.warn("Unable to parse the stream thread id, falling back to thread name {}", threadName);
     return threadName;
+  }
+
+  public static Bytes incrementWithoutOverflow(final Bytes input) {
+    try {
+      return Bytes.increment(input);
+    } catch (final IndexOutOfBoundsException e) {
+      return null;
+    }
   }
 }

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/LwtWriterTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/LwtWriterTest.java
@@ -150,6 +150,7 @@ class LwtWriterTest {
           null,
           null,
           null,
+          null,
           null
       );
     }

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/inmemory/InMemoryKVTableTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/inmemory/InMemoryKVTableTest.java
@@ -22,6 +22,7 @@ import static org.hamcrest.Matchers.nullValue;
 import dev.responsive.kafka.internal.db.KVFlushManager;
 import dev.responsive.kafka.internal.db.RemoteWriter;
 import java.time.Duration;
+import org.apache.kafka.common.serialization.BytesSerializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
 import org.junit.jupiter.api.Test;
@@ -72,6 +73,27 @@ class InMemoryKVTableTest {
         iter.next(),
         sameKeyValue(new KeyValue<>(Bytes.wrap("cc".getBytes()), "val3".getBytes()))
     );
+    assertThat(iter.hasNext(), is(false));
+    iter.close();
+  }
+
+  @Test
+  public void shouldDoPrefixScan() {
+    // given:
+    writer.insert(bytes(1, 2), new byte[]{0x1}, 100);
+    writer.insert(bytes(2), new byte[]{0x1}, 100);
+    writer.insert(bytes(2, 2), new byte[]{0x1}, 100);
+    writer.insert(bytes(2, 2, 3), new byte[]{0x1}, 100);
+    writer.insert(bytes(3), new byte[]{0x1}, 100);
+    writer.flush();
+
+    // when:
+    final var iter = table.prefix(bytes(2), new BytesSerializer(), 0, 0);
+
+    // then:
+    assertThat(iter.next(), sameKeyValue(new KeyValue<>(bytes(2), new byte[] {0x1})));
+    assertThat(iter.next(), sameKeyValue(new KeyValue<>(bytes(2, 2), new byte[] {0x1})));
+    assertThat(iter.next(), sameKeyValue(new KeyValue<>(bytes(2, 2, 3), new byte[] {0x1})));
     assertThat(iter.hasNext(), is(false));
     iter.close();
   }
@@ -181,5 +203,17 @@ class InMemoryKVTableTest {
     );
     assertThat(iter.hasNext(), is(false));
     iter.close();
+  }
+
+  private byte[] byteArray(int... bytes) {
+    byte[] byteArray = new byte[bytes.length];
+    for (int i = 0; i < bytes.length; i++) {
+      byteArray[i] = (byte) bytes[i];
+    }
+    return byteArray;
+  }
+
+  private Bytes bytes(int... bytes) {
+    return Bytes.wrap(byteArray(bytes));
   }
 }

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/inmemory/InMemoryKVTableTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/inmemory/InMemoryKVTableTest.java
@@ -78,6 +78,84 @@ class InMemoryKVTableTest {
   }
 
   @Test
+  public void shouldDoRangeScanWithNullFrom() {
+    // given:
+    writer.insert(Bytes.wrap("aa".getBytes()), "val0".getBytes(), 100);
+    writer.insert(Bytes.wrap("aaa".getBytes()), "val1".getBytes(), 100);
+    writer.insert(Bytes.wrap("bbbb".getBytes()), "val2".getBytes(), 100);
+    writer.insert(Bytes.wrap("cc".getBytes()), "val3".getBytes(), 100);
+    writer.insert(Bytes.wrap("ccddd".getBytes()), "val4".getBytes(), 100);
+    writer.flush();
+
+    // when:
+    final var iter = table.range(
+        0,
+        null,
+        Bytes.wrap("cc".getBytes()),
+        0
+    );
+
+    // then:
+    assertThat(
+        iter.next(),
+        sameKeyValue(new KeyValue<>(Bytes.wrap("aa".getBytes()), "val0".getBytes()))
+    );
+    assertThat(
+        iter.next(),
+        sameKeyValue(new KeyValue<>(Bytes.wrap("aaa".getBytes()), "val1".getBytes()))
+    );
+    assertThat(
+        iter.next(),
+        sameKeyValue(new KeyValue<>(Bytes.wrap("bbbb".getBytes()), "val2".getBytes()))
+    );
+    assertThat(
+        iter.next(),
+        sameKeyValue(new KeyValue<>(Bytes.wrap("cc".getBytes()), "val3".getBytes()))
+    );
+    assertThat(iter.hasNext(), is(false));
+    iter.close();
+  }
+
+  @Test
+  public void shouldDoRangeScanWithNullTo() {
+    // given:
+    writer.insert(Bytes.wrap("aa".getBytes()), "val0".getBytes(), 100);
+    writer.insert(Bytes.wrap("aaa".getBytes()), "val1".getBytes(), 100);
+    writer.insert(Bytes.wrap("bbbb".getBytes()), "val2".getBytes(), 100);
+    writer.insert(Bytes.wrap("cc".getBytes()), "val3".getBytes(), 100);
+    writer.insert(Bytes.wrap("ccddd".getBytes()), "val4".getBytes(), 100);
+    writer.flush();
+
+    // when:
+    final var iter = table.range(
+        0,
+        Bytes.wrap("aaa".getBytes()),
+        null,
+        0
+    );
+
+    // then:
+    assertThat(
+        iter.next(),
+        sameKeyValue(new KeyValue<>(Bytes.wrap("aaa".getBytes()), "val1".getBytes()))
+    );
+    assertThat(
+        iter.next(),
+        sameKeyValue(new KeyValue<>(Bytes.wrap("bbbb".getBytes()), "val2".getBytes()))
+    );
+    assertThat(
+        iter.next(),
+        sameKeyValue(new KeyValue<>(Bytes.wrap("cc".getBytes()), "val3".getBytes()))
+    );
+    assertThat(
+        iter.next(),
+        sameKeyValue(new KeyValue<>(Bytes.wrap("ccddd".getBytes()), "val4".getBytes()))
+    );
+    assertThat(iter.hasNext(), is(false));
+    iter.close();
+  }
+
+  @Test
   public void shouldDoPrefixScan() {
     // given:
     writer.insert(bytes(1, 2), new byte[]{0x1}, 100);
@@ -94,6 +172,23 @@ class InMemoryKVTableTest {
     assertThat(iter.next(), sameKeyValue(new KeyValue<>(bytes(2), new byte[] {0x1})));
     assertThat(iter.next(), sameKeyValue(new KeyValue<>(bytes(2, 2), new byte[] {0x1})));
     assertThat(iter.next(), sameKeyValue(new KeyValue<>(bytes(2, 2, 3), new byte[] {0x1})));
+    assertThat(iter.hasNext(), is(false));
+    iter.close();
+  }
+
+  @Test
+  public void shouldDoPrefixScanWithOverflow() {
+    // given:
+    writer.insert(bytes(-1, -1, -1), new byte[]{0x1}, 100);
+    writer.insert(bytes(-1), new byte[]{0x1}, 100);
+    writer.flush();
+
+    // when:
+    final var iter = table.prefix(bytes(-1), new BytesSerializer(), 0, 0);
+
+    // then:
+    assertThat(iter.next(), sameKeyValue(new KeyValue<>(bytes(-1), new byte[] {0x1})));
+    assertThat(iter.next(), sameKeyValue(new KeyValue<>(bytes(-1, -1, -1), new byte[] {0x1})));
     assertThat(iter.hasNext(), is(false));
     iter.close();
   }

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/mongo/MongoKVTableTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/mongo/MongoKVTableTest.java
@@ -271,7 +271,7 @@ class MongoKVTableTest {
   @Test
   public void shouldHandlePartitionedPrefixScansCorrectly() {
     // Given:
-    final MongoKVTable table = new MongoKVTable(client, name, UNSHARDED, NO_TTL);
+    final MongoKVTable table = new MongoKVTable(client, name, UNSHARDED, NO_TTL, config);
 
     final var writerFactory0 = table.init(0);
     final var writer0 = writerFactory0.createWriter(0, 0);

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/internal/db/TTDKeyValueTable.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/internal/db/TTDKeyValueTable.java
@@ -15,6 +15,8 @@ package dev.responsive.kafka.internal.db;
 import dev.responsive.kafka.internal.clients.TTDCassandraClient;
 import dev.responsive.kafka.internal.db.inmemory.InMemoryKVTable;
 import dev.responsive.kafka.internal.db.spec.RemoteTableSpec;
+import dev.responsive.kafka.internal.utils.Utils;
+import org.apache.kafka.common.serialization.Serializer;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.state.KeyValueIterator;
 
@@ -52,6 +54,18 @@ public class TTDKeyValueTable extends InMemoryKVTable {
     final long currentTimeMs = Math.max(streamTimeMs, client.currentWallClockTimeMs());
 
     return super.range(kafkaPartition, from, to, currentTimeMs);
+  }
+
+  @Override
+  public <PS extends Serializer<P>, P> KeyValueIterator<Bytes, byte[]> prefix(
+      final P prefix,
+      final PS prefixKeySerializer,
+      final int kafkaPartition,
+      final long streamTimeMs
+  ) {
+    final Bytes from = Bytes.wrap(prefixKeySerializer.serialize(null, prefix));
+    final Bytes to = Utils.incrementWithoutOverflow(from);
+    return range(kafkaPartition, from, to, streamTimeMs);
   }
 
   @Override


### PR DESCRIPTION
fixes #408 

Support prefix scans on:
- `CassandraKeyValueTable`
- `MongoKeyValueTable`
- `InMemoryKeyValueTable`

We don't support range scans on Global tables (yet), `CassandraFactTable` or `RS3KeyValueTable` yet.