### PR TITLE
Use Date format for TTL fields in Mongo tables

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraFactTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraFactTable.java
@@ -301,7 +301,7 @@ public class CassandraFactTable implements RemoteKVTable<BoundStatement> {
       final int kafkaPartition,
       final Bytes key,
       final byte[] value,
-      final long epochMillis
+      final long timestampMs
   ) {
     if (ttlResolver.isPresent()) {
       final Optional<TtlDuration> rowTtl = ttlResolver.get().computeTtl(key, value);
@@ -319,7 +319,7 @@ public class CassandraFactTable implements RemoteKVTable<BoundStatement> {
             .bind()
             .setByteBuffer(DATA_KEY.bind(), ByteBuffer.wrap(key.get()))
             .setByteBuffer(DATA_VALUE.bind(), ByteBuffer.wrap(value))
-            .setInstant(TIMESTAMP.bind(), Instant.ofEpochMilli(epochMillis))
+            .setInstant(TIMESTAMP.bind(), Instant.ofEpochMilli(timestampMs))
             .setInt(TTL_SECONDS.bind(), rowTtlOverrideSeconds);
       }
     }
@@ -328,7 +328,7 @@ public class CassandraFactTable implements RemoteKVTable<BoundStatement> {
         .bind()
         .setByteBuffer(DATA_KEY.bind(), ByteBuffer.wrap(key.get()))
         .setByteBuffer(DATA_VALUE.bind(), ByteBuffer.wrap(value))
-        .setInstant(TIMESTAMP.bind(), Instant.ofEpochMilli(epochMillis));
+        .setInstant(TIMESTAMP.bind(), Instant.ofEpochMilli(timestampMs));
   }
 
   @Override

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraKeyValueTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraKeyValueTable.java
@@ -434,14 +434,14 @@ public class CassandraKeyValueTable implements RemoteKVTable<BoundStatement> {
       final int kafkaPartition,
       final Bytes key,
       final byte[] value,
-      final long epochMillis
+      final long timestampMs
   ) {
     final int tablePartition = partitioner.tablePartition(kafkaPartition, key);
     return insert
         .bind()
         .setInt(PARTITION_KEY.bind(), tablePartition)
         .setByteBuffer(DATA_KEY.bind(), ByteBuffer.wrap(key.get()))
-        .setInstant(TIMESTAMP.bind(), Instant.ofEpochMilli(epochMillis))
+        .setInstant(TIMESTAMP.bind(), Instant.ofEpochMilli(timestampMs))
         .setByteBuffer(DATA_VALUE.bind(), ByteBuffer.wrap(value));
   }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraWindowTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraWindowTable.java
@@ -748,7 +748,7 @@ public class CassandraWindowTable implements RemoteWindowTable<BoundStatement> {
    * @param kafkaPartition the kafka partition
    * @param key            the data key
    * @param value          the data value
-   * @param epochMillis    the timestamp of the event
+   * @param timestampMs    the timestamp of the event
    * @return a statement that, when executed, will insert the row
    *         matching {@code partitionKey} and {@code key} in the
    *         {@code table} with value {@code value}. Note that the
@@ -761,7 +761,7 @@ public class CassandraWindowTable implements RemoteWindowTable<BoundStatement> {
       final int kafkaPartition,
       final WindowedKey key,
       final byte[] value,
-      final long epochMillis
+      final long timestampMs
   ) {
     final Segmenter.SegmentPartition
         remotePartition = partitioner.tablePartition(kafkaPartition, key);

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/FactSchemaWriter.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/FactSchemaWriter.java
@@ -44,8 +44,8 @@ public class FactSchemaWriter<K> implements RemoteWriter<K, Integer> {
   }
 
   @Override
-  public void insert(final K key, final byte[] value, long epochMillis) {
-    statements.add(table.insert(kafkaPartition, key, value, epochMillis));
+  public void insert(final K key, final byte[] value, long timestampMs) {
+    statements.add(table.insert(kafkaPartition, key, value, timestampMs));
   }
 
   @Override

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/LwtWriter.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/LwtWriter.java
@@ -74,8 +74,8 @@ public class LwtWriter<K, P> implements RemoteWriter<K, P> {
   }
 
   @Override
-  public void insert(final K key, final byte[] value, long epochMillis) {
-    statements.add(table.insert(kafkaPartition, key, value, epochMillis));
+  public void insert(final K key, final byte[] value, long timestampMs) {
+    statements.add(table.insert(kafkaPartition, key, value, timestampMs));
   }
 
   @Override

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/RemoteTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/RemoteTable.java
@@ -31,8 +31,8 @@ public interface RemoteTable<K, S> {
    * @param kafkaPartition  the kafka partition
    * @param key             the data key
    * @param value           the data value
-   * @param epochMillis     the event time with which this event
-   *                      was inserted in epochMillis
+   * @param timestampMs     the timestamp of the event being processed that
+   *                        triggered this write
    *
    * @return a statement that, when executed, will insert the entry
    *         corresponding to the given {@code kafkaPartition} and
@@ -43,7 +43,7 @@ public interface RemoteTable<K, S> {
       final int kafkaPartition,
       final K key,
       final byte[] value,
-      final long epochMillis
+      final long timestampMs
   );
 
   /**

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/RemoteWriter.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/RemoteWriter.java
@@ -23,7 +23,7 @@ import java.util.concurrent.CompletionStage;
  */
 public interface RemoteWriter<K, P> {
 
-  void insert(final K key, final byte[] value, long epochMillis);
+  void insert(final K key, final byte[] value, long timestampMs);
 
   void delete(final K key);
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/inmemory/InMemoryKVTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/inmemory/InMemoryKVTable.java
@@ -195,8 +195,8 @@ public class InMemoryKVTable implements RemoteKVTable<BoundStatement> {
     ) {
       return new RemoteWriter<>() {
         @Override
-        public void insert(Bytes key, byte[] value, long epochMillis) {
-          InMemoryKVTable.this.insert(tablePartition, key, value, epochMillis);
+        public void insert(Bytes key, byte[] value, long timestampMs) {
+          InMemoryKVTable.this.insert(tablePartition, key, value, timestampMs);
         }
 
         @Override

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/inmemory/InMemoryKVTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/inmemory/InMemoryKVTable.java
@@ -135,10 +135,10 @@ public class InMemoryKVTable implements RemoteKVTable<BoundStatement> {
   }
 
   @Override
-  public BoundStatement insert(int kafkaPartition, Bytes key, byte[] value, long epochMillis) {
+  public BoundStatement insert(int kafkaPartition, Bytes key, byte[] value, long timestampMs) {
     checkKafkaPartition(kafkaPartition);
 
-    store.put(key, new Value(epochMillis, value));
+    store.put(key, new Value(timestampMs, value));
     return null;
   }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/KVDoc.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/KVDoc.java
@@ -34,7 +34,7 @@ public class KVDoc {
   String id;
   byte[] value;
   long epoch;
-  long timestamp;
+  Date timestamp;
   int kafkaPartition;
   Date tombstoneTs;
 
@@ -52,7 +52,7 @@ public class KVDoc {
     this.id = id;
     this.value = value;
     this.epoch = epoch;
-    this.timestamp = timestamp;
+    this.timestamp = new Date(timestamp);
     this.kafkaPartition = kafkaPartition;
   }
 
@@ -72,7 +72,7 @@ public class KVDoc {
     this.epoch = epoch;
   }
 
-  public void setTimestamp(final long timestamp) {
+  public void setTimestamp(final Date timestamp) {
     this.timestamp = timestamp;
   }
 
@@ -84,7 +84,7 @@ public class KVDoc {
     return epoch;
   }
 
-  public long getTimestamp() {
+  public Date getTimestamp() {
     return timestamp;
   }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/KVDoc.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/KVDoc.java
@@ -46,13 +46,13 @@ public class KVDoc {
       @BsonProperty(ID) String id,
       @BsonProperty(VALUE) byte[] value,
       @BsonProperty(EPOCH) long epoch,
-      @BsonProperty(TIMESTAMP) long timestamp,
+      @BsonProperty(TIMESTAMP) Date timestamp,
       @BsonProperty(KAFKA_PARTITION) int kafkaPartition
   ) {
     this.id = id;
     this.value = value;
     this.epoch = epoch;
-    this.timestamp = new Date(timestamp);
+    this.timestamp = timestamp;
     this.kafkaPartition = kafkaPartition;
   }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoKVTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoKVTable.java
@@ -246,7 +246,7 @@ public class MongoKVTable implements RemoteKVTable<WriteModel<KVDoc>> {
         Updates.combine(
             Updates.unset(KVDoc.VALUE),
             Updates.unset(KVDoc.TIMESTAMP),
-            Updates.set(KVDoc.TOMBSTONE_TS, Date.from(Instant.now())),
+            Updates.set(KVDoc.TOMBSTONE_TS, new Date()),
             Updates.set(KVDoc.EPOCH, epoch)
         ),
         new UpdateOptions().upsert(true)

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoKVTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoKVTable.java
@@ -37,7 +37,6 @@ import dev.responsive.kafka.internal.db.RemoteKVTable;
 import dev.responsive.kafka.internal.stores.TtlResolver;
 import dev.responsive.kafka.internal.utils.Iterators;
 import java.time.Duration;
-import java.time.Instant;
 import java.util.Date;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoSessionTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoSessionTable.java
@@ -277,7 +277,7 @@ public class MongoSessionTable implements RemoteSessionTable<WriteModel<SessionD
    * @param kafkaPartition the kafka partition
    * @param sessionKey     the windowed data key
    * @param value          the data value
-   * @param epochMillis    the timestamp of the event
+   * @param timestampMs    the timestamp of the event
    * @return a statement that, when executed, will insert the value
    * for this key and partition into the table.
    * Note that the key in this case is a "session" key, where
@@ -289,7 +289,7 @@ public class MongoSessionTable implements RemoteSessionTable<WriteModel<SessionD
       final int kafkaPartition,
       final SessionKey sessionKey,
       final byte[] value,
-      final long epochMillis
+      final long timestampMs
   ) {
     final var partitionSegments = kafkaPartitionToSegments.get(kafkaPartition);
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoWindowTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoWindowTable.java
@@ -385,7 +385,7 @@ public class MongoWindowTable implements RemoteWindowTable<WriteModel<WindowDoc>
    * @param kafkaPartition the kafka partition
    * @param windowedKey    the windowed data key
    * @param value          the data value
-   * @param epochMillis    the timestamp of the event
+   * @param timestampMs    the timestamp of the event
    * @return a statement that, when executed, will insert the value
    *         for this key and partition into the table.
    *         Note that the key in this case is a "windowed" key, where
@@ -397,7 +397,7 @@ public class MongoWindowTable implements RemoteWindowTable<WriteModel<WindowDoc>
       final int kafkaPartition,
       final WindowedKey windowedKey,
       final byte[] value,
-      final long epochMillis
+      final long timestampMs
   ) {
     final var partitionSegments = kafkaPartitionToSegments.get(kafkaPartition);
     final long epoch = partitionSegments.epoch;

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoWriter.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoWriter.java
@@ -50,8 +50,8 @@ public class MongoWriter<K, P, D> implements RemoteWriter<K, P> {
   }
 
   @Override
-  public void insert(final K key, final byte[] value, final long epochMillis) {
-    accumulatedWrites.add(table.insert(kafkaPartition, key, value, epochMillis));
+  public void insert(final K key, final byte[] value, final long timestampMs) {
+    accumulatedWrites.add(table.insert(kafkaPartition, key, value, timestampMs));
   }
 
   @Override

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/rs3/RS3KVFlushManager.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/rs3/RS3KVFlushManager.java
@@ -143,7 +143,7 @@ class RS3KVFlushManager extends KVFlushManager {
     }
 
     @Override
-    public void insert(final Bytes key, final byte[] value, final long epochMillis) {
+    public void insert(final Bytes key, final byte[] value, final long timestampMs) {
     }
 
     @Override
@@ -196,8 +196,8 @@ class RS3KVFlushManager extends KVFlushManager {
     }
 
     @Override
-    public void insert(final Bytes key, final byte[] value, final long epochMillis) {
-      streamSender.sendNext(table.insert(kafkaPartition, key, value, epochMillis));
+    public void insert(final Bytes key, final byte[] value, final long timestampMs) {
+      streamSender.sendNext(table.insert(kafkaPartition, key, value, timestampMs));
     }
 
     @Override

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/rs3/RS3KVTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/rs3/RS3KVTable.java
@@ -143,7 +143,7 @@ public class RS3KVTable implements RemoteKVTable<WalEntry> {
       final int kafkaPartition,
       final Bytes key,
       final byte[] value,
-      final long epochMillis
+      final long timestampMs
   ) {
     return new Put(
         key.get(),

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/LwtWriterTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/LwtWriterTest.java
@@ -159,7 +159,8 @@ class LwtWriterTest {
         final int kafkaPartition,
         final Bytes key,
         final byte[] value,
-        long epochMillis) {
+        long timestampMs
+    ) {
       return capturingStatement("insertData", new Object[]{name(), kafkaPartition, key, value});
     }
 

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/mongo/MongoKVTableTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/mongo/MongoKVTableTest.java
@@ -28,7 +28,6 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
 import com.mongodb.client.MongoClient;
-import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.Filters;
 import dev.responsive.kafka.api.config.ResponsiveConfig;
 import dev.responsive.kafka.api.config.StorageBackend;
@@ -460,7 +459,7 @@ class MongoKVTableTest {
       throw new AssertionError("Could not find tombstone record in database");
     } else {
       assertThat(deletedRecord.getTimestamp(), nullValue());
-      assertThat(deletedRecord.getTombstoneTs(), notNullValue()); // gets set to current time during delete
+      assertThat(deletedRecord.getTombstoneTs(), notNullValue()); // set to current time of delete
     }
   }
 

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/mongo/MongoKVTableTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/mongo/MongoKVTableTest.java
@@ -12,17 +12,24 @@
 
 package dev.responsive.kafka.internal.db.mongo;
 
+import static com.mongodb.MongoClientSettings.getDefaultCodecRegistry;
 import static dev.responsive.kafka.api.config.ResponsiveConfig.MONGO_ENDPOINT_CONFIG;
 import static dev.responsive.kafka.api.config.ResponsiveConfig.MONGO_TOMBSTONE_RETENTION_SEC_CONFIG;
 import static dev.responsive.kafka.internal.stores.TtlResolver.NO_TTL;
 import static dev.responsive.kafka.testutils.IntegrationTestUtils.defaultOnlyTtl;
 import static dev.responsive.kafka.testutils.Matchers.sameKeyValue;
+import static org.bson.codecs.configuration.CodecRegistries.fromProviders;
+import static org.bson.codecs.configuration.CodecRegistries.fromRegistries;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 
 import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.Filters;
 import dev.responsive.kafka.api.config.ResponsiveConfig;
 import dev.responsive.kafka.api.config.StorageBackend;
 import dev.responsive.kafka.internal.stores.RemoteWriteResult;
@@ -31,6 +38,7 @@ import dev.responsive.kafka.testutils.IntegrationTestUtils;
 import dev.responsive.kafka.testutils.ResponsiveConfigParam;
 import dev.responsive.kafka.testutils.ResponsiveExtension;
 import java.time.Duration;
+import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -39,6 +47,9 @@ import java.util.concurrent.ExecutionException;
 import java.util.function.BooleanSupplier;
 import org.apache.kafka.common.utils.Bytes;
 import org.apache.kafka.streams.KeyValue;
+import org.bson.codecs.configuration.CodecProvider;
+import org.bson.codecs.configuration.CodecRegistry;
+import org.bson.codecs.pojo.PojoCodecProvider;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -402,7 +413,66 @@ class MongoKVTableTest {
   }
 
   @Test
-  @Disabled("fix this when we fix https://github.com/slatedb/slatedb/issues/442")
+  public void shouldUseDateFormatForTtlFields() {
+    final var keyCodec = new StringKeyCodec();
+    final CodecProvider pojoCodecProvider = PojoCodecProvider.builder().automatic(true).build();
+    final CodecRegistry pojoCodecRegistry = fromRegistries(
+        getDefaultCodecRegistry(),
+        fromProviders(pojoCodecProvider)
+    );
+
+    final MongoKVTable table = new MongoKVTable(client, name, UNSHARDED, NO_TTL, config);
+    final var writerFactory = table.init(0);
+    final var writer = writerFactory.createWriter(0, 0);
+
+    final Bytes key = bytes(1);
+    final byte[] value = byteArray(1);
+    final long timestampMs = 100L;
+
+    writer.insert(key, value, timestampMs);
+    writer.flush();
+
+    final var database = client
+        .getDatabase(name)
+        .withCodecRegistry(pojoCodecRegistry)
+        .getCollection("kv_data", KVDoc.class);
+
+    final Date minValidTs = new Date(0L);
+
+    final KVDoc record = database.find(Filters.and(
+        Filters.eq(KVDoc.ID, keyCodec.encode(key)),
+        Filters.gte(KVDoc.TIMESTAMP, minValidTs)
+    )).first();
+
+    if (record == null) {
+      throw new AssertionError("Could not find record in database");
+    } else {
+      assertThat(record.getTimestamp(), equalTo(new Date(timestampMs)));
+      assertThat(record.getTombstoneTs(), nullValue());
+    }
+
+    writer.delete(key);
+    writer.flush();
+
+    final KVDoc deletedRecord = database.find(Filters.eq(KVDoc.ID, keyCodec.encode(key))).first();
+
+    if (deletedRecord == null) {
+      throw new AssertionError("Could not find tombstone record in database");
+    } else {
+      assertThat(deletedRecord.getTimestamp(), nullValue());
+      assertThat(deletedRecord.getTombstoneTs(), notNullValue()); // gets set to current time during delete
+    }
+  }
+
+  /**
+   * Leave this disabled since it takes about a full minute to run, and only really
+   * verifies that Mongo's internal TTL mechanism works on timestamps in the Date
+   * format, which is unlikely to change/break over time.
+   * Note that the above test #shouldUseDateFormatForTtlFields ensures that our
+   * Mongo implementation uses the Date format, and this test does run regularly.
+   */
+  @Disabled
+  @Test
   public void shouldExpireRecords() {
     props.put(MONGO_TOMBSTONE_RETENTION_SEC_CONFIG, 1);
     final ResponsiveConfig config = ResponsiveConfig.responsiveConfig(props);
@@ -423,9 +493,6 @@ class MongoKVTableTest {
     };
 
     // Then:
-    // TODO(agavra): we need to wait up to at least one minute to make sure that the ttl
-    // background job kicks in. Unfortunately I don't see a better way to do this so we
-    // may want to consider leaving this test disabled for CI/CD
     IntegrationTestUtils.awaitCondition(isExpired, Duration.ofMinutes(2), Duration.ofSeconds(1));
   }
 

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/internal/db/TTDWindowTable.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/internal/db/TTDWindowTable.java
@@ -65,7 +65,7 @@ public class TTDWindowTable extends TTDTable<WindowedKey>
       final int kafkaPartition,
       final WindowedKey key,
       final byte[] value,
-      final long epochMillis
+      final long timestampMs
   ) {
     stub.put(key, value);
     return null;

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/internal/db/TTDWriter.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/internal/db/TTDWriter.java
@@ -27,8 +27,8 @@ public class TTDWriter<K, P> implements RemoteWriter<K, P> {
 
   @SuppressWarnings("ResultOfMethodCallIgnored")
   @Override
-  public void insert(final K key, final byte[] value, long epochMillis) {
-    table.insert(0, key, value, epochMillis);
+  public void insert(final K key, final byte[] value, long timestampMs) {
+    table.insert(0, key, value, timestampMs);
   }
 
   @SuppressWarnings("ResultOfMethodCallIgnored")


### PR DESCRIPTION
fixes #410 

Need to use Date instead of long for ttl to work, apparently

Since java just stores `Date` as an "epoch millis" long the only overhead is in creating the objects themselves, so it should be pretty minimal