### PR TITLE
rs3 changes for soak workload

### DIFF
--- a/controller-api/build.gradle.kts
+++ b/controller-api/build.gradle.kts
@@ -14,13 +14,13 @@ import com.google.protobuf.gradle.id
 
 buildscript {
     dependencies {
-        classpath("com.google.protobuf:protobuf-gradle-plugin:0.8.8")
+        classpath("com.google.protobuf:protobuf-gradle-plugin:0.9.4")
     }
 }
 
 plugins {
     id("responsive.java-library-conventions")
-    id("com.google.protobuf").version("0.9.2")
+    id("com.google.protobuf").version("0.9.4")
 }
 
 sourceSets {
@@ -33,7 +33,7 @@ sourceSets {
 
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:3.22.3"
+        artifact = "com.google.protobuf:protoc:3.25.5"
     }
 
     plugins {

--- a/kafka-client/build.gradle.kts
+++ b/kafka-client/build.gradle.kts
@@ -32,14 +32,14 @@ import com.google.protobuf.gradle.id
 
 buildscript {
     dependencies {
-        classpath("com.google.protobuf:protobuf-gradle-plugin:0.8.8")
+        classpath("com.google.protobuf:protobuf-gradle-plugin:0.9.4")
     }
 }
 
 plugins {
     id("responsive.java-library-conventions")
     id("java")
-    id("com.google.protobuf").version("0.9.2")
+    id("com.google.protobuf").version("0.9.4")
 }
 
 sourceSets {
@@ -52,7 +52,7 @@ sourceSets {
 
 protobuf {
     protoc {
-        artifact = "com.google.protobuf:protoc:3.22.3"
+        artifact = "com.google.protobuf:protoc:3.25.5"
     }
 
     plugins {

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveKafkaStreams.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveKafkaStreams.java
@@ -18,6 +18,7 @@ import static dev.responsive.kafka.api.config.ResponsiveConfig.MONGO_CONNECTION_
 import static dev.responsive.kafka.api.config.ResponsiveConfig.MONGO_WINDOWED_KEY_TIMESTAMP_FIRST_CONFIG;
 import static dev.responsive.kafka.api.config.ResponsiveConfig.RS3_HOSTNAME_CONFIG;
 import static dev.responsive.kafka.api.config.ResponsiveConfig.RS3_PORT_CONFIG;
+import static dev.responsive.kafka.api.config.ResponsiveConfig.RS3_TLS_ENABLED_CONFIG;
 import static dev.responsive.kafka.api.config.ResponsiveConfig.TASK_ASSIGNOR_CLASS_OVERRIDE;
 import static dev.responsive.kafka.internal.config.ResponsiveStreamsConfig.validateNoStorageStreamsConfig;
 import static dev.responsive.kafka.internal.metrics.ResponsiveMetrics.RESPONSIVE_METRICS_NAMESPACE;
@@ -575,10 +576,11 @@ public class ResponsiveKafkaStreams extends KafkaStreams {
           LOG.info("Using rs3 responsive store");
           final var rs3Host = responsiveConfig.getString(RS3_HOSTNAME_CONFIG);
           final var rs3Port = responsiveConfig.getInt(RS3_PORT_CONFIG);
+          final var useTls = responsiveConfig.getBoolean(RS3_TLS_ENABLED_CONFIG);
           sessionClients = new SessionClients(
               Optional.empty(),
               Optional.empty(),
-              Optional.of(new RS3TableFactory(rs3Host, rs3Port)),
+              Optional.of(new RS3TableFactory(rs3Host, rs3Port, useTls)),
               storageBackend,
               admin
           );

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
@@ -131,6 +131,9 @@ public class ResponsiveConfig extends AbstractConfig {
   public static final String RS3_LOGICAL_STORE_MAPPING_CONFIG = "responsive.rs3.logical.store.mapping";
   public static final String RS3_LOGICAL_STORE_MAPPING_DOC = "Mapping from table name to RS3 logical store ID (e.g. 'table:b1a45157-e2f0-4698-be0e-5bf3a9b8e9d1,...')";
 
+  public static final String RS3_TLS_ENABLED_CONFIG = "responsive.rs3.tls.enabled";
+  private static final String RS3_TLS_ENABLED_DOC = "Enables/disable tls for rs3 connection";
+
   // ------------------ ScyllaDB specific configurations ----------------------
 
   public static final String CASSANDRA_USERNAME_CONFIG = "responsive.cassandra.username";
@@ -614,6 +617,12 @@ public class ResponsiveConfig extends AbstractConfig {
           "",
           Importance.HIGH,
           RS3_LOGICAL_STORE_MAPPING_DOC
+      ).define(
+          RS3_TLS_ENABLED_CONFIG,
+          Type.BOOLEAN,
+          true,
+          Importance.MEDIUM,
+          RS3_TLS_ENABLED_DOC
       );
 
   /**

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/rs3/client/MeteredRS3Client.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/rs3/client/MeteredRS3Client.java
@@ -1,0 +1,96 @@
+package dev.responsive.kafka.internal.db.rs3.client;
+
+import dev.responsive.kafka.internal.metrics.ResponsiveMetrics;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.stats.Avg;
+
+public class MeteredRS3Client implements RS3Client {
+  public static final String GROUP_NAME = "rs3-table-metrics";
+
+  private static final String GET_SENSOR_NAME = "get-sensor";
+  private static final String GET_LATENCY_NS_AVG = "get-latency-ns-avg";
+  private static final String GET_LATENCY_NS_AVG_DESC = "average rs3 get latency in nanos";
+
+  private final RS3Client delegate;
+
+  private final ResponsiveMetrics metrics;
+  private final Sensor getSensor;
+
+  public MeteredRS3Client(
+      final RS3Client delegate,
+      final ResponsiveMetrics metrics,
+      final ResponsiveMetrics.MetricScopeBuilder metricsScopeBuilder
+  ) {
+    this.delegate = Objects.requireNonNull(delegate, "delegate");
+    this.metrics = Objects.requireNonNull(metrics, "metrics");
+    ResponsiveMetrics.MetricScope metricScope = metricsScopeBuilder.build(GROUP_NAME);
+    this.getSensor = this.metrics.addSensor(metricScope.sensorName(GET_SENSOR_NAME));
+    getSensor.add(
+        metrics.metricName(GET_LATENCY_NS_AVG, GET_LATENCY_NS_AVG_DESC, metricScope),
+        new Avg()
+    );
+  }
+
+  @Override
+  public CurrentOffsets getCurrentOffsets(
+      final UUID storeId,
+      final LssId lssId,
+      final int pssId
+  ) {
+    return delegate.getCurrentOffsets(storeId, lssId, pssId);
+  }
+
+  @Override
+  public StreamSenderMessageReceiver<WalEntry, Optional<Long>> writeWalSegmentAsync(
+      final UUID storeId,
+      final LssId lssId,
+      final int pssId,
+      final Optional<Long> expectedWrittenOffset,
+      final long endOffset
+  ) {
+    return delegate.writeWalSegmentAsync(storeId, lssId, pssId, expectedWrittenOffset, endOffset);
+  }
+
+  @Override
+  public Optional<Long> writeWalSegment(
+      final UUID storeId,
+      final LssId lssId,
+      final int pssId,
+      final Optional<Long> expectedWrittenOffset,
+      final long endOffset,
+      final List<WalEntry> entries
+  ) {
+    return delegate.writeWalSegment(
+        storeId,
+        lssId,
+        pssId,
+        expectedWrittenOffset,
+        endOffset,
+        entries
+    );
+  }
+
+  @Override
+  public Optional<byte[]> get(
+      final UUID storeId,
+      final LssId lssId,
+      final int pssId,
+      final Optional<Long> expectedWrittenOffset,
+      final byte[] key
+  ) {
+    final Instant start = Instant.now();
+    final Optional<byte[]> result = delegate.get(storeId, lssId, pssId, expectedWrittenOffset, key);
+    getSensor.record(Duration.between(start, Instant.now()).toNanos());
+    return result;
+  }
+
+  public void close() {
+    this.metrics.removeSensor(GET_SENSOR_NAME);
+  }
+}

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/rs3/client/grpc/PssStubsProvider.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/rs3/client/grpc/PssStubsProvider.java
@@ -1,0 +1,108 @@
+package dev.responsive.kafka.internal.db.rs3.client.grpc;
+
+import com.google.common.annotations.VisibleForTesting;
+import dev.responsive.kafka.internal.db.rs3.client.grpc.middleware.PssHeadersInterceptor;
+import dev.responsive.rs3.RS3Grpc;
+import io.grpc.ChannelCredentials;
+import io.grpc.Grpc;
+import io.grpc.InsecureChannelCredentials;
+import io.grpc.ManagedChannel;
+import io.grpc.TlsChannelCredentials;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class PssStubsProvider {
+  private static final Logger LOG = LoggerFactory.getLogger(PssStubsProvider.class);
+
+  private final ManagedChannel channel;
+  private final ConcurrentMap<StubsKey, Stubs> stubs = new ConcurrentHashMap<>();
+
+  private PssStubsProvider(final ManagedChannel channel) {
+    this.channel = channel;
+  }
+
+  static PssStubsProvider connect(
+      final String target,
+      final boolean useTls
+  ) {
+    final ChannelCredentials channelCredentials;
+    if (useTls) {
+      channelCredentials = TlsChannelCredentials.create();
+    } else {
+      channelCredentials = InsecureChannelCredentials.create();
+    }
+    LOG.info("Connecting to {}...", target);
+    final ManagedChannel channel = Grpc.newChannelBuilder(target, channelCredentials)
+        .keepAliveTime(5, TimeUnit.SECONDS)
+        .build();
+    LOG.info("build grpc client with retries");
+    return new PssStubsProvider(channel);
+  }
+
+  void close() {
+    channel.shutdownNow();
+  }
+
+  Stubs stubs(final UUID storeId, final int pssId) {
+    final StubsKey key = new StubsKey(storeId, pssId);
+    return stubs.computeIfAbsent(key, k -> {
+      final RS3Grpc.RS3BlockingStub syncStub = RS3Grpc.newBlockingStub(channel)
+          .withInterceptors(new PssHeadersInterceptor(storeId, pssId));
+      final RS3Grpc.RS3Stub asyncStub = RS3Grpc.newStub(channel)
+          .withInterceptors(new PssHeadersInterceptor(storeId, pssId));
+      return new Stubs(syncStub, asyncStub);
+    });
+  }
+
+  @VisibleForTesting
+  static class Stubs {
+    private final RS3Grpc.RS3BlockingStub syncStub;
+    private final RS3Grpc.RS3Stub asyncStub;
+
+    @VisibleForTesting
+    Stubs(final RS3Grpc.RS3BlockingStub syncStub, final RS3Grpc.RS3Stub asyncStub) {
+      this.syncStub = syncStub;
+      this.asyncStub = asyncStub;
+    }
+
+    RS3Grpc.RS3BlockingStub syncStub() {
+      return syncStub;
+    }
+
+    RS3Grpc.RS3Stub asyncStub() {
+      return asyncStub;
+    }
+  }
+
+  private static class StubsKey {
+    private final UUID storeId;
+    private final int pssId;
+
+    private StubsKey(final UUID storeId, final int pssId) {
+      this.storeId = storeId;
+      this.pssId = pssId;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof StubsKey)) {
+        return false;
+      }
+      final StubsKey that = (StubsKey) o;
+      return pssId == that.pssId && Objects.equals(storeId, that.storeId);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(storeId, pssId);
+    }
+  }
+}

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/rs3/client/grpc/middleware/PssHeadersInterceptor.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/rs3/client/grpc/middleware/PssHeadersInterceptor.java
@@ -1,0 +1,46 @@
+package dev.responsive.kafka.internal.db.rs3.client.grpc.middleware;
+
+import io.grpc.CallOptions;
+import io.grpc.Channel;
+import io.grpc.ClientCall;
+import io.grpc.ClientInterceptor;
+import io.grpc.ForwardingClientCall;
+import io.grpc.Metadata;
+import io.grpc.MethodDescriptor;
+import java.util.Objects;
+import java.util.UUID;
+
+public class PssHeadersInterceptor implements ClientInterceptor {
+  private static final String STORE_ID = "store-id";
+  private static final Metadata.Key<String> STORE_ID_KEY
+      = Metadata.Key.of(STORE_ID, Metadata.ASCII_STRING_MARSHALLER);
+  private static final String PSS_ID = "pss-id";
+  private static final Metadata.Key<String> PSS_ID_KEY
+      = Metadata.Key.of(PSS_ID, Metadata.ASCII_STRING_MARSHALLER);
+
+  private final UUID storeId;
+  private final int pssId;
+
+  public PssHeadersInterceptor(final UUID storeId, final int pssId) {
+    this.storeId = Objects.requireNonNull(storeId);
+    this.pssId = pssId;
+  }
+
+  @Override
+  public <ReqT, RespT> ClientCall<ReqT, RespT> interceptCall(
+      final MethodDescriptor<ReqT, RespT> method,
+      final CallOptions callOptions,
+      final Channel next
+  ) {
+    return new ForwardingClientCall.SimpleForwardingClientCall<>(
+        next.newCall(method, callOptions)
+    ) {
+      @Override
+      public void start(Listener<RespT> responseListener, Metadata headers) {
+        headers.put(STORE_ID_KEY, storeId.toString());
+        headers.put(PSS_ID_KEY, Integer.toString(pssId));
+        super.start(responseListener, headers);
+      }
+    };
+  }
+}

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/rs3/metrics/RS3TableMetricsRecorder.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/rs3/metrics/RS3TableMetricsRecorder.java
@@ -1,0 +1,40 @@
+package dev.responsive.kafka.internal.db.rs3.metrics;
+
+import dev.responsive.kafka.internal.metrics.ResponsiveMetrics;
+import java.time.Duration;
+import java.util.Objects;
+import org.apache.kafka.common.metrics.Sensor;
+import org.apache.kafka.common.metrics.stats.Avg;
+
+public class RS3TableMetricsRecorder {
+  public static final String GROUP_NAME = "rs3-table-metrics";
+
+  private static final String GET_SENSOR_NAME = "get-sensor";
+  private static final String GET_LATENCY_NS_AVG = "get-latency-ns-avg";
+  private static final String GET_LATENCY_NS_AVG_DESC = "average rs3 get latency in nanos";
+
+  private final ResponsiveMetrics metrics;
+
+  private final Sensor getSensor;
+
+  public RS3TableMetricsRecorder(
+      final ResponsiveMetrics metrics,
+      final ResponsiveMetrics.MetricScopeBuilder metricsScopeBuilder
+  ) {
+    this.metrics = Objects.requireNonNull(metrics, "metrics");
+    ResponsiveMetrics.MetricScope metricScope = metricsScopeBuilder.build(GROUP_NAME);
+    this.getSensor = this.metrics.addSensor(metricScope.sensorName(GET_SENSOR_NAME));
+    getSensor.add(
+        metrics.metricName(GET_LATENCY_NS_AVG, GET_LATENCY_NS_AVG_DESC, metricScope),
+        new Avg()
+    );
+  }
+
+  public void recordGet(final Duration latency) {
+    getSensor.record(latency.toNanos());
+  }
+
+  public void close() {
+    this.metrics.removeSensor(GET_SENSOR_NAME);
+  }
+}

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/metrics/ResponsiveMetrics.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/metrics/ResponsiveMetrics.java
@@ -17,6 +17,7 @@ import dev.responsive.kafka.internal.metrics.exporter.NoopMetricsExporterService
 import java.io.Closeable;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import org.apache.kafka.common.MetricName;
 import org.apache.kafka.common.TopicPartition;
@@ -78,6 +79,18 @@ public class ResponsiveMetrics implements Closeable {
         streamsClientId,
         userTags
     );
+  }
+
+  public static class MetricScopeBuilder {
+    private final LinkedHashMap<String, String> tags;
+
+    private MetricScopeBuilder(final LinkedHashMap<String, String> tags) {
+      this.tags = Objects.requireNonNull(tags);
+    }
+
+    public MetricScope build(final String groupName) {
+      return new MetricScope(groupName, tags);
+    }
   }
 
   public static class MetricScope {
@@ -153,16 +166,24 @@ public class ResponsiveMetrics implements Closeable {
     );
   }
 
+  public MetricScopeBuilder storeLevelMetricScopeBuilder(
+      final String threadId,
+      final TopicPartition changelog,
+      final String storeName
+  ) {
+    return new MetricScopeBuilder(
+        orderedTagsSupplier.storeGroupTags(threadId, changelog, storeName)
+    );
+  }
+
   public MetricScope storeLevelMetric(
       final String group,
       final String threadId,
       final TopicPartition changelog,
       final String storeName
   ) {
-    return new MetricScope(
-        group,
-        orderedTagsSupplier.storeGroupTags(threadId, changelog, storeName)
-    );
+    return storeLevelMetricScopeBuilder(threadId, changelog, storeName)
+        .build(group);
   }
 
   /**

--- a/kafka-client/src/main/resources/otel-jmx.config.yaml
+++ b/kafka-client/src/main/resources/otel-jmx.config.yaml
@@ -384,6 +384,26 @@ rules:
          desc: cumulative commands failed latency
          unit: '{milliseconds}'
 
+ - bean: dev.responsive:type=rs3-table-metrics,responsive-version=*,responsive-commit-id=*,streams-version=*,streams-commit-id=*,consumer-group=*,streams-application-id=*,streams-client-id=*,thread-id=*,topic=*,partition=*,store=*
+   metricAttribute:
+     responsiveVersion: param(responsive-version)
+     responsiveCommitId: param(responsive-commit-id)
+     streamsVersion: param(streams-version)
+     streamsCommitId: param(streams-commit-id)
+     consumerGroup: param(consumer-group)
+     streamsApplicationId: param(streams-application-id)
+     streamsClientId: param(streams-client-id)
+     thread: param(thread-id)
+     partition: param(partition)
+     topic: param(topic)
+     store: param(store)
+   mapping:
+     get-latency-ns-avg:
+       metric: rs3.client.get.latency.ns.avg
+       type: gauge
+       desc: avg rs3 get latency
+       unit: '{nanoseconds}'
+
   # Cassandra Client Metrics
  - bean: dev.responsive:type=cassandra-client
    mapping:

--- a/kafka-client/src/test/java/dev/responsive/kafka/testutils/ResponsiveExtension.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/testutils/ResponsiveExtension.java
@@ -58,7 +58,7 @@ public class ResponsiveExtension
       .withInitScript("CassandraDockerInit.cql")
       .withReuse(true);
   public static RS3Container rs3
-      = new RS3Container("public.ecr.aws/j8q9y0n6/responsiveinc/rs3-server:latest")
+      = new RS3Container("public.ecr.aws/j8q9y0n6/responsiveinc/rs3:latest")
       .withExposedPorts(50051);
   public static KafkaContainer kafka = new KafkaContainer(TestConstants.KAFKA)
       .withEnv("KAFKA_GROUP_MIN_SESSION_TIMEOUT_MS", "1000")

--- a/operator/build.gradle.kts
+++ b/operator/build.gradle.kts
@@ -37,8 +37,7 @@ dependencies {
 
     testImplementation(testlibs.bundles.base)
     testImplementation(testlibs.bundles.testcontainers)
-    testImplementation("io.grpc:grpc-testing:1.53.0")
-    testImplementation("io.grpc:grpc-examples:0.15.0")
+    testImplementation(testlibs.bundles.grpctesting)
 
     testImplementation("org.bouncycastle:bcprov-jdk15on:1.70")
     testImplementation("org.bouncycastle:bcpkix-jdk15on:1.70")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -45,7 +45,7 @@ dependencyResolutionManagement {
             version("kafka", "3.8.1")
             version("scylla", "4.15.0.0")
             version("javaoperatorsdk", "4.9.6")
-            version("grpc", "1.52.1")
+            version("grpc", "1.69.1")
             version("protobuf-java", "3.22.3")
             version("slf4j", "1.7.5")
             version("log4j2", "2.20.0")

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -115,6 +115,7 @@ dependencyResolutionManagement {
 
         create("testlibs") {
             version("testcontainers", "1.17.6")
+            version("grpc", "1.69.1")
 
             library("junit", "org.junit.jupiter:junit-jupiter:5.9.1")
             library("hamcrest", "org.hamcrest:hamcrest:2.2")
@@ -143,6 +144,11 @@ dependencyResolutionManagement {
                     ))
 
             bundle("base", listOf("junit", "slf4j", "log4j-core", "hamcrest", "mockito", "mockito-jupiter"))
+
+            library("grpc-inprocess", "io.grpc", "grpc-inprocess").versionRef("grpc")
+            library("grpc-testing", "io.grpc", "grpc-testing").versionRef("grpc")
+            library("grpc-testing-proto", "io.grpc", "grpc-testing-proto").versionRef("grpc")
+            bundle("grpctesting", listOf("grpc-inprocess", "grpc-testing", "grpc-testing-proto"))
         }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -46,7 +46,7 @@ dependencyResolutionManagement {
             version("scylla", "4.15.0.0")
             version("javaoperatorsdk", "4.9.6")
             version("grpc", "1.69.1")
-            version("protobuf-java", "3.22.3")
+            version("protobuf-java", "3.25.5")
             version("slf4j", "1.7.5")
             version("log4j2", "2.20.0")
             version("mongoDB", "4.10.2")


### PR DESCRIPTION
some rs3 changes to get it going on the soak workload:
- adds tls support for the rs3 connection
- adds a metric that records the average get latency. This is done via a wrapper to the RS3 client so we can add more metrics easily later on.
- the rs3 protocol was updated to pass the pss/store id in headers, so we need to generate specific stubs for each pss (stubs are very cheap to create, and they all share a grpc channel). As such, the channel is moved into RemotePssStubsProvider, which now owns the channel and creates stubs for a given pss. When creating a stub, it adds an interceptor that adds the right headers for a given pss