### PR TITLE
RS3: Add static logical store mapping config

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
@@ -21,6 +21,8 @@ import dev.responsive.kafka.api.ResponsiveKafkaStreams;
 import dev.responsive.kafka.internal.db.partitioning.Murmur3Hasher;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigDef;
@@ -125,6 +127,9 @@ public class ResponsiveConfig extends AbstractConfig {
 
   public static final String RS3_PORT_CONFIG = "responsive.rs3.port";
   private static final String RS3_PORT_DOC = "The port to use when connecting to RS3.";
+
+  public static final String RS3_LOGICAL_STORE_MAPPING_CONFIG = "responsive.rs3.logical.store.mapping";
+  public static final String RS3_LOGICAL_STORE_MAPPING_DOC = "Mapping from table name to RS3 logical store ID";
 
   // ------------------ ScyllaDB specific configurations ----------------------
 
@@ -603,6 +608,12 @@ public class ResponsiveConfig extends AbstractConfig {
           50051,
           Importance.MEDIUM,
           RS3_PORT_DOC
+      ).define(
+          RS3_LOGICAL_STORE_MAPPING_CONFIG,
+          Type.STRING,
+          "",
+          Importance.HIGH,
+          RS3_LOGICAL_STORE_MAPPING_DOC
       );
 
   /**
@@ -649,4 +660,24 @@ public class ResponsiveConfig extends AbstractConfig {
     }
   }
 
+
+  public Map<String, String> getMap(String config) {
+    String configValue = getString(config);
+    if (configValue == null) {
+      throw new ConfigException("No value found for config " + config);
+    }
+
+    if (configValue.isEmpty()) {
+      return Collections.emptyMap();
+    }
+
+    Map<String, String> map = new HashMap<>();
+    for (String mapping : configValue.split("\\s*,\\s*")) {
+      int lio = mapping.lastIndexOf(":");
+      String key = mapping.substring(0,lio).trim();
+      String value = mapping.substring(lio + 1).trim();
+      map.put(key, value);
+    }
+    return map;
+  }
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
@@ -129,7 +129,7 @@ public class ResponsiveConfig extends AbstractConfig {
   private static final String RS3_PORT_DOC = "The port to use when connecting to RS3.";
 
   public static final String RS3_LOGICAL_STORE_MAPPING_CONFIG = "responsive.rs3.logical.store.mapping";
-  public static final String RS3_LOGICAL_STORE_MAPPING_DOC = "Mapping from table name to RS3 logical store ID";
+  public static final String RS3_LOGICAL_STORE_MAPPING_DOC = "Mapping from table name to RS3 logical store ID (e.g. 'table:b1a45157-e2f0-4698-be0e-5bf3a9b8e9d1,...')";
 
   // ------------------ ScyllaDB specific configurations ----------------------
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
@@ -674,7 +674,7 @@ public class ResponsiveConfig extends AbstractConfig {
     Map<String, String> map = new HashMap<>();
     for (String mapping : configValue.split("\\s*,\\s*")) {
       int lio = mapping.lastIndexOf(":");
-      String key = mapping.substring(0,lio).trim();
+      String key = mapping.substring(0, lio).trim();
       String value = mapping.substring(lio + 1).trim();
       map.put(key, value);
     }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/rs3/RS3KVTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/rs3/RS3KVTable.java
@@ -149,6 +149,10 @@ public class RS3KVTable implements RemoteKVTable<WalEntry> {
     return name;
   }
 
+  public UUID storedId() {
+    return storeId;
+  }
+
   @Override
   public WalEntry insert(
       final int kafkaPartition,

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/rs3/RS3TableFactory.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/rs3/RS3TableFactory.java
@@ -34,7 +34,8 @@ public class RS3TableFactory {
   }
 
   public RemoteKVTable<WalEntry> kvTable(final String name, final ResponsiveConfig config) {
-    Map<String, String> storeIdMapping = config.getMap(ResponsiveConfig.RS3_LOGICAL_STORE_MAPPING_CONFIG);
+    Map<String, String> storeIdMapping = config.getMap(
+        ResponsiveConfig.RS3_LOGICAL_STORE_MAPPING_CONFIG);
     final String storeIdHex = storeIdMapping.get(name);
     if (storeIdHex == null) {
       throw new ConfigException("Failed to find store ID mapping for table " + name);

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/rs3/RS3TableFactory.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/rs3/RS3TableFactory.java
@@ -16,8 +16,10 @@ import dev.responsive.kafka.api.config.ResponsiveConfig;
 import dev.responsive.kafka.internal.db.RemoteKVTable;
 import dev.responsive.kafka.internal.db.rs3.client.WalEntry;
 import dev.responsive.kafka.internal.db.rs3.client.grpc.GrpcRS3Client;
+import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
+import org.apache.kafka.common.config.ConfigException;
 
 public class RS3TableFactory {
   private final String rs3Host;
@@ -32,7 +34,13 @@ public class RS3TableFactory {
   }
 
   public RemoteKVTable<WalEntry> kvTable(final String name, final ResponsiveConfig config) {
-    final UUID storeId = new UUID(0, 0);
+    Map<String, String> storeIdMapping = config.getMap(ResponsiveConfig.RS3_LOGICAL_STORE_MAPPING_CONFIG);
+    final String storeIdHex = storeIdMapping.get(name);
+    if (storeIdHex == null) {
+      throw new ConfigException("Failed to find store ID mapping for table " + name);
+    }
+
+    final UUID storeId = UUID.fromString(storeIdHex);
     final PssPartitioner pssPartitioner = new PssDirectPartitioner();
     final var rs3Client = GrpcRS3Client.connect(
         String.format("%s:%d", rs3Host, rs3Port)

--- a/kafka-client/src/test/java/dev/responsive/kafka/api/config/ResponsiveConfigTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/api/config/ResponsiveConfigTest.java
@@ -1,0 +1,28 @@
+package dev.responsive.kafka.api.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class ResponsiveConfigTest {
+
+  @Test
+  public void testRs3TableMapping() {
+    String l1 = UUID.randomUUID().toString();
+    String l2 = UUID.randomUUID().toString();
+
+    Properties props = new Properties();
+    props.setProperty(ResponsiveConfig.RS3_LOGICAL_STORE_MAPPING_CONFIG, "t1:" + l1 + ",t2:" + l2);
+
+    final ResponsiveConfig config = ResponsiveConfig.responsiveConfig(props);
+    Map<String, String> expectedMapping = new HashMap<>();
+    expectedMapping.put("t1", l1);
+    expectedMapping.put("t2", l2);
+    assertEquals(expectedMapping, config.getMap(ResponsiveConfig.RS3_LOGICAL_STORE_MAPPING_CONFIG));
+  }
+
+}

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/rs3/RS3TableFactoryTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/rs3/RS3TableFactoryTest.java
@@ -1,0 +1,39 @@
+package dev.responsive.kafka.internal.db.rs3;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import dev.responsive.kafka.api.config.ResponsiveConfig;
+import java.util.Collections;
+import org.apache.kafka.common.config.ConfigException;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+class RS3TableFactoryTest {
+
+  @Test
+  public void testTableMapping() {
+    String table = "test-table";
+    String uuid = "b1a45157-e2f0-4698-be0e-5bf3a9b8e9d1";
+
+    ResponsiveConfig config = Mockito.mock(ResponsiveConfig.class);
+    Mockito.when(config.getMap(ResponsiveConfig.RS3_LOGICAL_STORE_MAPPING_CONFIG))
+        .thenReturn(Collections.singletonMap(table, uuid));
+
+    final RS3TableFactory factory = new RS3TableFactory("localhost", 9888);
+    final RS3KVTable rs3Table = (RS3KVTable) factory.kvTable(table, config);
+    assertEquals(uuid, rs3Table.storedId().toString());
+  }
+
+  @Test
+  public void testMissingTableMapping() {
+    String table = "test-table";
+    ResponsiveConfig config = Mockito.mock(ResponsiveConfig.class);
+    Mockito.when(config.getMap(ResponsiveConfig.RS3_LOGICAL_STORE_MAPPING_CONFIG))
+        .thenReturn(Collections.emptyMap());
+
+    final RS3TableFactory factory = new RS3TableFactory("localhost", 9888);
+    assertThrows(ConfigException.class, () -> factory.kvTable(table, config));
+  }
+
+}


### PR DESCRIPTION
Add a new config `responsive.rs3.logical.store.mapping` which stores a static mapping from the table name to the RS3 logical store ID in the form `[t1]:[id1],[t2]:[id2]`.