### PR TITLE
Add retry logic for RS3 get/getoffsets requests

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/config/ResponsiveConfig.java
@@ -133,6 +133,11 @@ public class ResponsiveConfig extends AbstractConfig {
 
   public static final String RS3_TLS_ENABLED_CONFIG = "responsive.rs3.tls.enabled";
   private static final String RS3_TLS_ENABLED_DOC = "Enables/disable tls for rs3 connection";
+  public static final boolean RS3_TLS_ENABLED_DEFAULT = true;
+
+  public static final String RS3_RETRY_TIMEOUT_CONFIG = "responsive.rs3.retry.timeout.ms";
+  private static final String RS3_RETRY_TIMEOUT_DOC = "Timeout in milliseconds for retries when RS3 endpoint is unavailable";
+  public static final int RS3_RETRY_TIMEOUT_DEFAULT = 30000;
 
   // ------------------ ScyllaDB specific configurations ----------------------
 
@@ -620,9 +625,16 @@ public class ResponsiveConfig extends AbstractConfig {
       ).define(
           RS3_TLS_ENABLED_CONFIG,
           Type.BOOLEAN,
-          true,
+          RS3_TLS_ENABLED_DEFAULT,
           Importance.MEDIUM,
           RS3_TLS_ENABLED_DOC
+      ).define(
+          RS3_RETRY_TIMEOUT_CONFIG,
+          Type.LONG,
+          RS3_RETRY_TIMEOUT_DEFAULT,
+          atLeast(0),
+          Importance.MEDIUM,
+          RS3_RETRY_TIMEOUT_DOC
       );
 
   /**

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/rs3/RS3TableFactory.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/rs3/RS3TableFactory.java
@@ -18,23 +18,16 @@ import dev.responsive.kafka.internal.db.rs3.client.WalEntry;
 import dev.responsive.kafka.internal.db.rs3.client.grpc.GrpcRS3Client;
 import dev.responsive.kafka.internal.metrics.ResponsiveMetrics;
 import java.util.Map;
-import java.util.Objects;
 import java.util.UUID;
 import org.apache.kafka.common.config.ConfigException;
 
 public class RS3TableFactory {
-  private final String rs3Host;
-  private final int rs3Port;
-  private final boolean useTls;
+  private final GrpcRS3Client.Connector connector;
 
   public RS3TableFactory(
-      final String rs3Host,
-      final int rs3Port,
-      final boolean useTls
+      GrpcRS3Client.Connector connector
   ) {
-    this.rs3Host = Objects.requireNonNull(rs3Host);
-    this.rs3Port = rs3Port;
-    this.useTls = useTls;
+    this.connector = connector;
   }
 
   public RemoteKVTable<WalEntry> kvTable(
@@ -52,10 +45,7 @@ public class RS3TableFactory {
 
     final UUID storeId = UUID.fromString(storeIdHex);
     final PssPartitioner pssPartitioner = new PssDirectPartitioner();
-    final var rs3Client = GrpcRS3Client.connect(
-        String.format("%s:%d", rs3Host, rs3Port),
-        useTls
-    );
+    final var rs3Client = connector.connect();
     return new RS3KVTable(
         name,
         storeId,

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/rs3/client/RS3Exception.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/rs3/client/RS3Exception.java
@@ -16,6 +16,10 @@ package dev.responsive.kafka.internal.db.rs3.client;
 public class RS3Exception extends RuntimeException {
   private static final long serialVersionUID = 0L;
 
+  public RS3Exception(String message) {
+    super(message);
+  }
+
   public RS3Exception(final Throwable cause) {
     super(cause);
   }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/rs3/client/RS3TimeoutException.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/rs3/client/RS3TimeoutException.java
@@ -1,0 +1,14 @@
+package dev.responsive.kafka.internal.db.rs3.client;
+
+public class RS3TimeoutException extends RS3Exception {
+  private static final long serialVersionUID = 0L;
+
+  public RS3TimeoutException(final Throwable cause) {
+    super(cause);
+  }
+
+  public RS3TimeoutException(final String message) {
+    super(message);
+  }
+
+}

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/rs3/RS3KVTableTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/rs3/RS3KVTableTest.java
@@ -52,7 +52,7 @@ public class RS3KVTableTest {
   private static final int PARTITION_ID = 8;
 
   private String testName;
-  private RS3Client pocketClient;
+  private RS3Client rs3Client;
   private final PssPartitioner pssPartitioner = new PssDirectPartitioner();
   private final Metrics metrics = new Metrics();
 
@@ -74,7 +74,7 @@ public class RS3KVTableTest {
     final GrpcRS3Client.Connector connector =
         new GrpcRS3Client.Connector(new MockTime(), "localhost", port);
     connector.useTls(false);
-    pocketClient = connector.connect();
+    rs3Client = connector.connect();
     final ResponsiveMetrics responsiveMetrics = new ResponsiveMetrics(metrics);
     responsiveMetrics.initializeTags(
         "application-id",
@@ -96,7 +96,7 @@ public class RS3KVTableTest {
     this.table = new RS3KVTable(
         testName,
         STORE_ID,
-        pocketClient,
+        rs3Client,
         pssPartitioner,
         responsiveMetrics,
         scopeBuilder
@@ -106,7 +106,7 @@ public class RS3KVTableTest {
   @AfterEach
   public void teardown() {
     System.out.println(rs3Container.getLogs());
-    pocketClient.close();
+    rs3Client.close();
   }
 
   @Test
@@ -130,7 +130,7 @@ public class RS3KVTableTest {
   }
 
   @Test
-  public void shouldWriteToPocketStore() throws InterruptedException, ExecutionException {
+  public void shouldWriteToStore() throws InterruptedException, ExecutionException {
     // given:
     final var flushManager = table.init(PARTITION_ID);
     final var tablePartitioner = flushManager.partitioner();
@@ -145,7 +145,7 @@ public class RS3KVTableTest {
     flushManager.postFlush(10);
 
     // then:
-    final var result = pocketClient.get(
+    final var result = rs3Client.get(
         STORE_ID,
         new LssId(PARTITION_ID),
         pss,
@@ -160,7 +160,7 @@ public class RS3KVTableTest {
     // given:
     int endOffset = 100;
     for (final int pssId : pssPartitioner.pssForLss(new LssId(PARTITION_ID))) {
-      pocketClient.writeWalSegment(
+      rs3Client.writeWalSegment(
           STORE_ID,
           new LssId(PARTITION_ID),
           pssId,
@@ -186,7 +186,7 @@ public class RS3KVTableTest {
         pssPartitioner.pssForLss(new LssId(PARTITION_ID)));
     allPssExcept1.remove();
     for (final int pssId : allPssExcept1) {
-      pocketClient.writeWalSegment(
+      rs3Client.writeWalSegment(
           STORE_ID,
           new LssId(PARTITION_ID),
           pssId,

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/rs3/RS3KVTableTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/rs3/RS3KVTableTest.java
@@ -40,6 +40,7 @@ import junit.framework.AssertionFailedError;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.metrics.Metrics;
 import org.apache.kafka.common.utils.Bytes;
+import org.apache.kafka.common.utils.MockTime;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -70,7 +71,10 @@ public class RS3KVTableTest {
     testName = info.getTestMethod().orElseThrow().getName();
     final int port = rs3Container.getMappedPort(50051);
     this.rs3Container = rs3Container;
-    pocketClient = GrpcRS3Client.connect(String.format("localhost:%d", port), false);
+    final GrpcRS3Client.Connector connector =
+        new GrpcRS3Client.Connector(new MockTime(), "localhost", port);
+    connector.useTls(false);
+    pocketClient = connector.connect();
     final ResponsiveMetrics responsiveMetrics = new ResponsiveMetrics(metrics);
     responsiveMetrics.initializeTags(
         "application-id",

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/rs3/RS3TableFactoryTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/rs3/RS3TableFactoryTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import dev.responsive.kafka.api.config.ResponsiveConfig;
+import dev.responsive.kafka.internal.db.rs3.client.grpc.GrpcRS3Client;
 import dev.responsive.kafka.internal.metrics.ClientVersionMetadata;
 import dev.responsive.kafka.internal.metrics.ResponsiveMetrics;
 import java.util.Collections;
@@ -11,6 +12,7 @@ import java.util.Map;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.common.metrics.Metrics;
+import org.apache.kafka.common.utils.MockTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -42,14 +44,14 @@ class RS3TableFactoryTest {
 
   @Test
   public void testTableMapping() {
-    String table = "test-table";
-    String uuid = "b1a45157-e2f0-4698-be0e-5bf3a9b8e9d1";
+    var table = "test-table";
+    var uuid = "b1a45157-e2f0-4698-be0e-5bf3a9b8e9d1";
 
-    ResponsiveConfig config = Mockito.mock(ResponsiveConfig.class);
+    var config = Mockito.mock(ResponsiveConfig.class);
     Mockito.when(config.getMap(ResponsiveConfig.RS3_LOGICAL_STORE_MAPPING_CONFIG))
         .thenReturn(Collections.singletonMap(table, uuid));
 
-    final RS3TableFactory factory = new RS3TableFactory("localhost", 9888, true);
+    final RS3TableFactory factory = newTestFactory();
     final RS3KVTable rs3Table = (RS3KVTable) factory.kvTable(
         table,
         config,
@@ -66,11 +68,16 @@ class RS3TableFactoryTest {
     Mockito.when(config.getMap(ResponsiveConfig.RS3_LOGICAL_STORE_MAPPING_CONFIG))
         .thenReturn(Collections.emptyMap());
 
-    final RS3TableFactory factory = new RS3TableFactory("localhost", 9888, true);
+    final RS3TableFactory factory = newTestFactory();
     assertThrows(
         ConfigException.class,
         () -> factory.kvTable(table, config, metrics, scopeBuilder)
     );
+  }
+
+  private RS3TableFactory newTestFactory() {
+    final var connector = new GrpcRS3Client.Connector(new MockTime(), "localhost", 50051);
+    return new RS3TableFactory(connector);
   }
 
 }

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/rs3/client/grpc/GrpcRS3ClientTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/rs3/client/grpc/GrpcRS3ClientTest.java
@@ -25,12 +25,20 @@ import static org.mockito.Mockito.when;
 import com.google.protobuf.ByteString;
 import dev.responsive.kafka.internal.db.rs3.client.LssId;
 import dev.responsive.kafka.internal.db.rs3.client.Put;
+import dev.responsive.kafka.internal.db.rs3.client.RS3Exception;
+import dev.responsive.kafka.internal.db.rs3.client.RS3TimeoutException;
 import dev.responsive.rs3.RS3Grpc;
 import dev.responsive.rs3.Rs3;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
 import io.grpc.stub.StreamObserver;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import org.apache.kafka.common.utils.MockTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -56,6 +64,8 @@ class GrpcRS3ClientTest {
   @Captor
   private ArgumentCaptor<StreamObserver<Rs3.WriteWALSegmentResult>>
       writeWALSegmentResultObserverCaptor;
+  private MockTime time = new MockTime();
+  private long retryTimeoutMs = 30000;
 
   private GrpcRS3Client client;
 
@@ -65,7 +75,7 @@ class GrpcRS3ClientTest {
         stub,
         asyncStub
     ));
-    client = new GrpcRS3Client(stubs);
+    client = new GrpcRS3Client(stubs, time, retryTimeoutMs);
   }
 
   @Test
@@ -146,6 +156,69 @@ class GrpcRS3ClientTest {
     // then:
     assertThat(offsets.writtenOffset(), is(Optional.of(13L)));
     assertThat(offsets.flushedOffset(), is(Optional.of(3L)));
+  }
+
+  @Test
+  public void shouldRetryGetOffsets() {
+    // given:
+    when(stub.getOffsets(any()))
+        .thenThrow(new StatusRuntimeException(Status.UNAVAILABLE))
+        .thenThrow(new StatusRuntimeException(Status.UNAVAILABLE))
+        .thenReturn(
+            Rs3.GetOffsetsResult.newBuilder()
+                .setWrittenOffset(13)
+                .setFlushedOffset(3)
+                .build());
+
+    // when:
+    final var offsets = client.getCurrentOffsets(STORE_ID, LSS_ID, PSS_ID);
+
+    // then:
+    assertThat(offsets.writtenOffset(), is(Optional.of(13L)));
+    assertThat(offsets.flushedOffset(), is(Optional.of(3L)));
+  }
+
+  @Test
+  public void shouldPropagateUnexpectedExceptionFromGetOffsets() {
+    // given:
+    when(stub.getOffsets(any()))
+        .thenThrow(new StatusRuntimeException(Status.UNKNOWN));
+
+    // when:
+    final RS3Exception exception =
+        assertThrows(RS3Exception.class, () -> client.getCurrentOffsets(STORE_ID, LSS_ID, PSS_ID));
+
+    // then:
+    assertThat(exception.getCause(), is(instanceOf(StatusRuntimeException.class)));
+    assertThat(((StatusRuntimeException)exception.getCause()).getStatus(), is(Status.UNKNOWN));
+  }
+
+  @Test
+  public void shouldTimeoutGetOffsets() throws Exception {
+    // given:
+    when(stub.getOffsets(any()))
+        .thenThrow(new StatusRuntimeException(Status.UNAVAILABLE));
+
+    // when:
+    final var executor = Executors.newFixedThreadPool(1);
+    final var future = executor.submit(() -> client.getCurrentOffsets(
+        STORE_ID,
+        LSS_ID,
+        PSS_ID
+    ));
+    while (!future.isDone()) {
+      time.sleep(1000);
+    }
+
+    // then:
+    final ExecutionException exception =
+        assertThrows(ExecutionException.class, future::get);
+    assertThat(exception.getCause(), is(instanceOf(RS3TimeoutException.class)));
+
+    executor.shutdown();
+    if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
+      throw new RuntimeException("Timed out waiting for executor to shut down");
+    }
   }
 
   @Test
@@ -361,6 +434,67 @@ class GrpcRS3ClientTest {
     // then:
     assertThat(result.isEmpty(), is(true));
   }
+
+  @Test
+  public void shouldRetryGet() {
+    // given:
+    when(stub.get(any()))
+        .thenThrow(new StatusRuntimeException(Status.UNAVAILABLE))
+        .thenReturn(Rs3.GetResult.newBuilder().build());
+
+    // when:
+    final var result = client.get(STORE_ID, LSS_ID, PSS_ID, Optional.of(123L), "foo".getBytes());
+
+    // then:
+    assertThat(result.isEmpty(), is(true));
+  }
+
+  @Test
+  public void shouldPropagateUnexpectedExceptionsFromGet() {
+    // given:
+    when(stub.get(any()))
+        .thenThrow(new StatusRuntimeException(Status.UNKNOWN));
+
+    // when:
+    final RS3Exception exception = assertThrows(
+        RS3Exception.class,
+        () -> client.get(STORE_ID, LSS_ID, PSS_ID, Optional.of(123L), "foo".getBytes())
+    );
+
+    // then:
+    assertThat(exception.getCause(), is(instanceOf(StatusRuntimeException.class)));
+    assertThat(((StatusRuntimeException)exception.getCause()).getStatus(), is(Status.UNKNOWN));
+  }
+
+  @Test
+  public void shouldTimeoutGet() throws Exception {
+    // given:
+    when(stub.get(any()))
+        .thenThrow(new StatusRuntimeException(Status.UNAVAILABLE));
+
+    // when:
+    final var executor = Executors.newFixedThreadPool(1);
+    final Future<Optional<byte[]>> future = executor.submit(() -> client.get(
+        STORE_ID,
+        LSS_ID,
+        PSS_ID,
+        Optional.of(123L),
+        "foo".getBytes()
+    ));
+    while (!future.isDone()) {
+      time.sleep(1000);
+    }
+
+    // then:
+    final var exception = assertThrows(ExecutionException.class, future::get);
+    assertThat(exception.getCause(), is(instanceOf(RS3TimeoutException.class)));
+
+    executor.shutdown();
+    if (!executor.awaitTermination(5, TimeUnit.SECONDS)) {
+      throw new RuntimeException("Timed out waiting for executor to shut down");
+    }
+  }
+
 
   private StreamObserver<Rs3.WriteWALSegmentResult> verifyWalSegmentResultObserver() {
     verify(asyncStub).writeWALSegmentStream(writeWALSegmentResultObserverCaptor.capture());

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/rs3/client/grpc/GrpcRS3ClientTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/rs3/client/grpc/GrpcRS3ClientTest.java
@@ -193,15 +193,20 @@ class GrpcRS3ClientTest {
   @Test
   public void shouldTimeoutGetOffsets() {
     // given:
+    var startTimeMs = time.milliseconds();
     when(stub.getOffsets(any()))
         .thenThrow(new StatusRuntimeException(Status.UNAVAILABLE));
 
-    // then:
+    // when:
     assertThrows(RS3TimeoutException.class, () -> client.getCurrentOffsets(
         STORE_ID,
         LSS_ID,
         PSS_ID
     ));
+
+    // then:
+    var endTimeMs = time.milliseconds();
+    assertThat(endTimeMs - startTimeMs, is(retryTimeoutMs));
   }
 
   @Test
@@ -452,10 +457,11 @@ class GrpcRS3ClientTest {
   @Test
   public void shouldTimeoutGet() {
     // given:
+    var startTimeMs = time.milliseconds();
     when(stub.get(any()))
         .thenThrow(new StatusRuntimeException(Status.UNAVAILABLE));
 
-    // then:
+    // when:
     assertThrows(RS3TimeoutException.class, () -> client.get(
         STORE_ID,
         LSS_ID,
@@ -463,6 +469,10 @@ class GrpcRS3ClientTest {
         Optional.of(123L),
         "foo".getBytes()
     ));
+
+    // then:
+    var endTimeMs = time.milliseconds();
+    assertThat(endTimeMs - startTimeMs, is(retryTimeoutMs));
   }
 
   private StreamObserver<Rs3.WriteWALSegmentResult> verifyWalSegmentResultObserver() {

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/rs3/client/grpc/GrpcRS3ClientTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/rs3/client/grpc/GrpcRS3ClientTest.java
@@ -190,7 +190,7 @@ class GrpcRS3ClientTest {
 
     // then:
     assertThat(exception.getCause(), is(instanceOf(StatusRuntimeException.class)));
-    assertThat(((StatusRuntimeException)exception.getCause()).getStatus(), is(Status.UNKNOWN));
+    assertThat(((StatusRuntimeException) exception.getCause()).getStatus(), is(Status.UNKNOWN));
   }
 
   @Test
@@ -463,7 +463,7 @@ class GrpcRS3ClientTest {
 
     // then:
     assertThat(exception.getCause(), is(instanceOf(StatusRuntimeException.class)));
-    assertThat(((StatusRuntimeException)exception.getCause()).getStatus(), is(Status.UNKNOWN));
+    assertThat(((StatusRuntimeException) exception.getCause()).getStatus(), is(Status.UNKNOWN));
   }
 
   @Test


### PR DESCRIPTION
Get requests are probably the simplest to retry, so I've started there. This patch adds a new `responsive.rs3.retry.timeout.ms` and uses exponential backoff logic (borrowed from Kafka) to retry after UNAVAILABLE errors from the rs3 server.