### PR TITLE
Fix spammy antithesis setup complete event

### DIFF
--- a/kafka-client-examples/e2e-test/src/main/java/dev/responsive/examples/e2etest/E2ETestDriver.java
+++ b/kafka-client-examples/e2e-test/src/main/java/dev/responsive/examples/e2etest/E2ETestDriver.java
@@ -271,6 +271,7 @@ public class E2ETestDriver {
   private void maybeFireSetupCompleteSignal() {
     if (!setupCompleteSignalFired && recordsProcessed > 0) {
       LOG.info("Received at least one output record, setup is complete");
+      setupCompleteSignalFired = true;
       Lifecycle.setupComplete(null);
     }
   }


### PR DESCRIPTION
Currently startup events are spamming antithesis logs. We had a field `setupCompleteSignalFired` which was enabled to `false`, but never set to `true` after setup completed.