### PR TITLE
Fix spammy warn message

### DIFF
--- a/kafka-client-examples/e2e-test/src/main/java/dev/responsive/examples/e2etest/E2ETestDriver.java
+++ b/kafka-client-examples/e2e-test/src/main/java/dev/responsive/examples/e2etest/E2ETestDriver.java
@@ -389,7 +389,7 @@ public class E2ETestDriver {
       while (!sent.isEmpty() && sent.get(0).offset() <= upTo) {
         popped.add(sent.remove(0));
       }
-      LOG.warn("removing multiple offsets: {}",
+      LOG.debug("removing multiple offsets: {}",
           String.join(", ", popped.stream().map(Object::toString).toList()));
       return popped;
     }


### PR DESCRIPTION
This log message seems to be spamming the antithesis runs. Seems like this is a normal flow, so probably DEBUG is more appropriate.