### PR TITLE
rs3/minio integration for antithesis

### DIFF
--- a/.github/workflows/github-e2e.yaml
+++ b/.github/workflows/github-e2e.yaml
@@ -102,12 +102,7 @@ jobs:
           password: ${{ secrets.ANTITHESIS_PASSWORD }}
           github_token: ${{ secrets.ANTITHESIS_GH_PAT }}
           config_image: us-central1-docker.pkg.dev/molten-verve-216720/responsive-repository/e2e-test-config-${{ inputs.test-type }}:${{ steps.kafka_client_version.outputs.KAFKA_CLIENT_VERSION }}
-          images: >
-            us-central1-docker.pkg.dev/molten-verve-216720/responsive-repository/e2e-test:${{ steps.kafka_client_version.outputs.KAFKA_CLIENT_VERSION }};
-            docker.io/mongo:5.0;
-            public.ecr.aws/j8q9y0n6/responsiveinc/rs3-antithesis:0.1.0-main.34.0;
-            minio/minio:RELEASE.2025-03-12T18-04-18Z;
-            minio/mc:RELEASE.2025-03-12T17-29-24Z
+          images: us-central1-docker.pkg.dev/molten-verve-216720/responsive-repository/e2e-test:${{ steps.kafka_client_version.outputs.KAFKA_CLIENT_VERSION }};docker.io/mongo:5.0;public.ecr.aws/j8q9y0n6/responsiveinc/rs3-antithesis:0.1.0-main.34.0;minio/minio:RELEASE.2025-03-12T18-04-18Z;minio/mc:RELEASE.2025-03-12T17-29-24Z
           description: "responsive antithesis test run"
           email_recipients: "antithesis-responsive-aaaamurlsqy6e3hxnx6ksnec5y@antithesisgroup.slack.com"
           additional_parameters: |-

--- a/.github/workflows/github-e2e.yaml
+++ b/.github/workflows/github-e2e.yaml
@@ -102,7 +102,12 @@ jobs:
           password: ${{ secrets.ANTITHESIS_PASSWORD }}
           github_token: ${{ secrets.ANTITHESIS_GH_PAT }}
           config_image: us-central1-docker.pkg.dev/molten-verve-216720/responsive-repository/e2e-test-config-${{ inputs.test-type }}:${{ steps.kafka_client_version.outputs.KAFKA_CLIENT_VERSION }}
-          images: us-central1-docker.pkg.dev/molten-verve-216720/responsive-repository/e2e-test:${{ steps.kafka_client_version.outputs.KAFKA_CLIENT_VERSION }};docker.io/mongo:5.0;public.ecr.aws/j8q9y0n6/responsiveinc/rs3-antithesis:0.1.0-main.34.0
+          images: >
+            us-central1-docker.pkg.dev/molten-verve-216720/responsive-repository/e2e-test:${{ steps.kafka_client_version.outputs.KAFKA_CLIENT_VERSION }};
+            docker.io/mongo:5.0;
+            public.ecr.aws/j8q9y0n6/responsiveinc/rs3-antithesis:0.1.0-main.34.0;
+            minio/minio:RELEASE.2025-03-12T18-04-18Z;
+            minio/mc:RELEASE.2025-03-12T17-29-24Z
           description: "responsive antithesis test run"
           email_recipients: "antithesis-responsive-aaaamurlsqy6e3hxnx6ksnec5y@antithesisgroup.slack.com"
           additional_parameters: |-

--- a/.github/workflows/github-e2e.yaml
+++ b/.github/workflows/github-e2e.yaml
@@ -102,7 +102,7 @@ jobs:
           password: ${{ secrets.ANTITHESIS_PASSWORD }}
           github_token: ${{ secrets.ANTITHESIS_GH_PAT }}
           config_image: us-central1-docker.pkg.dev/molten-verve-216720/responsive-repository/e2e-test-config-${{ inputs.test-type }}:${{ steps.kafka_client_version.outputs.KAFKA_CLIENT_VERSION }}
-          images: us-central1-docker.pkg.dev/molten-verve-216720/responsive-repository/e2e-test:${{ steps.kafka_client_version.outputs.KAFKA_CLIENT_VERSION }};docker.io/mongo:5.0;public.ecr.aws/j8q9y0n6/responsiveinc/rs3-antithesis:0.1.0-main.37.0;docker.io/minio/minio:RELEASE.2025-03-12T18-04-18Z;docker.io/minio/mc:RELEASE.2025-03-12T17-29-24Z
+          images: us-central1-docker.pkg.dev/molten-verve-216720/responsive-repository/e2e-test:${{ steps.kafka_client_version.outputs.KAFKA_CLIENT_VERSION }};docker.io/mongo:5.0;public.ecr.aws/j8q9y0n6/responsiveinc/rs3-antithesis:0.1.0-main.37.0;docker.io/minio/minio:RELEASE.2025-03-12T18-04-18Z
           description: "responsive antithesis test run"
           email_recipients: "antithesis-responsive-aaaamurlsqy6e3hxnx6ksnec5y@antithesisgroup.slack.com"
           additional_parameters: |-

--- a/.github/workflows/github-e2e.yaml
+++ b/.github/workflows/github-e2e.yaml
@@ -102,7 +102,7 @@ jobs:
           password: ${{ secrets.ANTITHESIS_PASSWORD }}
           github_token: ${{ secrets.ANTITHESIS_GH_PAT }}
           config_image: us-central1-docker.pkg.dev/molten-verve-216720/responsive-repository/e2e-test-config-${{ inputs.test-type }}:${{ steps.kafka_client_version.outputs.KAFKA_CLIENT_VERSION }}
-          images: us-central1-docker.pkg.dev/molten-verve-216720/responsive-repository/e2e-test:${{ steps.kafka_client_version.outputs.KAFKA_CLIENT_VERSION }};docker.io/mongo:5.0;public.ecr.aws/j8q9y0n6/responsiveinc/rs3-antithesis:0.1.0-main.34.0;docker.io/minio/minio:RELEASE.2025-03-12T18-04-18Z;docker.io/minio/mc:RELEASE.2025-03-12T17-29-24Z
+          images: us-central1-docker.pkg.dev/molten-verve-216720/responsive-repository/e2e-test:${{ steps.kafka_client_version.outputs.KAFKA_CLIENT_VERSION }};docker.io/mongo:5.0;public.ecr.aws/j8q9y0n6/responsiveinc/rs3-antithesis:0.1.0-main.35.0;docker.io/minio/minio:RELEASE.2025-03-12T18-04-18Z;docker.io/minio/mc:RELEASE.2025-03-12T17-29-24Z
           description: "responsive antithesis test run"
           email_recipients: "antithesis-responsive-aaaamurlsqy6e3hxnx6ksnec5y@antithesisgroup.slack.com"
           additional_parameters: |-

--- a/.github/workflows/github-e2e.yaml
+++ b/.github/workflows/github-e2e.yaml
@@ -102,7 +102,7 @@ jobs:
           password: ${{ secrets.ANTITHESIS_PASSWORD }}
           github_token: ${{ secrets.ANTITHESIS_GH_PAT }}
           config_image: us-central1-docker.pkg.dev/molten-verve-216720/responsive-repository/e2e-test-config-${{ inputs.test-type }}:${{ steps.kafka_client_version.outputs.KAFKA_CLIENT_VERSION }}
-          images: us-central1-docker.pkg.dev/molten-verve-216720/responsive-repository/e2e-test:${{ steps.kafka_client_version.outputs.KAFKA_CLIENT_VERSION }};docker.io/mongo:5.0;public.ecr.aws/j8q9y0n6/responsiveinc/rs3-antithesis:0.1.0-main.35.0;docker.io/minio/minio:RELEASE.2025-03-12T18-04-18Z;docker.io/minio/mc:RELEASE.2025-03-12T17-29-24Z
+          images: us-central1-docker.pkg.dev/molten-verve-216720/responsive-repository/e2e-test:${{ steps.kafka_client_version.outputs.KAFKA_CLIENT_VERSION }};docker.io/mongo:5.0;public.ecr.aws/j8q9y0n6/responsiveinc/rs3-antithesis:0.1.0-main.37.0;docker.io/minio/minio:RELEASE.2025-03-12T18-04-18Z;docker.io/minio/mc:RELEASE.2025-03-12T17-29-24Z
           description: "responsive antithesis test run"
           email_recipients: "antithesis-responsive-aaaamurlsqy6e3hxnx6ksnec5y@antithesisgroup.slack.com"
           additional_parameters: |-

--- a/.github/workflows/github-e2e.yaml
+++ b/.github/workflows/github-e2e.yaml
@@ -102,7 +102,7 @@ jobs:
           password: ${{ secrets.ANTITHESIS_PASSWORD }}
           github_token: ${{ secrets.ANTITHESIS_GH_PAT }}
           config_image: us-central1-docker.pkg.dev/molten-verve-216720/responsive-repository/e2e-test-config-${{ inputs.test-type }}:${{ steps.kafka_client_version.outputs.KAFKA_CLIENT_VERSION }}
-          images: us-central1-docker.pkg.dev/molten-verve-216720/responsive-repository/e2e-test:${{ steps.kafka_client_version.outputs.KAFKA_CLIENT_VERSION }};docker.io/mongo:5.0;public.ecr.aws/j8q9y0n6/responsiveinc/rs3-antithesis:0.1.0-main.34.0;minio/minio:RELEASE.2025-03-12T18-04-18Z;minio/mc:RELEASE.2025-03-12T17-29-24Z
+          images: us-central1-docker.pkg.dev/molten-verve-216720/responsive-repository/e2e-test:${{ steps.kafka_client_version.outputs.KAFKA_CLIENT_VERSION }};docker.io/mongo:5.0;public.ecr.aws/j8q9y0n6/responsiveinc/rs3-antithesis:0.1.0-main.34.0;docker.io/minio/minio:RELEASE.2025-03-12T18-04-18Z;docker.io/minio/mc:RELEASE.2025-03-12T17-29-24Z
           description: "responsive antithesis test run"
           email_recipients: "antithesis-responsive-aaaamurlsqy6e3hxnx6ksnec5y@antithesisgroup.slack.com"
           additional_parameters: |-

--- a/.github/workflows/github-e2e.yaml
+++ b/.github/workflows/github-e2e.yaml
@@ -102,7 +102,7 @@ jobs:
           password: ${{ secrets.ANTITHESIS_PASSWORD }}
           github_token: ${{ secrets.ANTITHESIS_GH_PAT }}
           config_image: us-central1-docker.pkg.dev/molten-verve-216720/responsive-repository/e2e-test-config-${{ inputs.test-type }}:${{ steps.kafka_client_version.outputs.KAFKA_CLIENT_VERSION }}
-          images: us-central1-docker.pkg.dev/molten-verve-216720/responsive-repository/e2e-test:${{ steps.kafka_client_version.outputs.KAFKA_CLIENT_VERSION }};docker.io/mongo:5.0;public.ecr.aws/j8q9y0n6/responsiveinc/rs3-antithesis:0.1.0-main.30.0
+          images: us-central1-docker.pkg.dev/molten-verve-216720/responsive-repository/e2e-test:${{ steps.kafka_client_version.outputs.KAFKA_CLIENT_VERSION }};docker.io/mongo:5.0;public.ecr.aws/j8q9y0n6/responsiveinc/rs3-antithesis:0.1.0-main.34.0
           description: "responsive antithesis test run"
           email_recipients: "antithesis-responsive-aaaamurlsqy6e3hxnx6ksnec5y@antithesisgroup.slack.com"
           additional_parameters: |-

--- a/kafka-client-examples/e2e-test/docker/antithesis/async/Dockerfile
+++ b/kafka-client-examples/e2e-test/docker/antithesis/async/Dockerfile
@@ -10,6 +10,7 @@ ADD base/config/volumes/scylla /volumes/scylla
 ADD base/config/volumes/scylla2 /volumes/scylla2
 ADD base/config/volumes/scylla3 /volumes/scylla3
 ADD base/config/volumes/kafka /volumes/kafka
+ADD base/config/volumes/minio /volumes/minio
 
 COPY async/config/rs3.toml volumes/rs3.toml
 COPY async/config/docker-compose.yml /docker-compose.yml

--- a/kafka-client-examples/e2e-test/docker/antithesis/async/config/rs3.toml
+++ b/kafka-client-examples/e2e-test/docker/antithesis/async/config/rs3.toml
@@ -15,4 +15,9 @@ id = "b1a45157-e2f0-4698-be0e-5bf3a9b8e9d1"
 pss = [{ id = 0 }, { id = 1 }, { id = 2 }, { id = 3 }, { id = 4 }, { id = 5 }, { id = 6 }, { id = 7 }]
 
 [cloud_provider]
-provider = "InMemory"
+provider = "Aws"
+
+[cloud_provider.aws]
+region = ""
+bucket = "rs3-antithesis"
+s3_endpoint = "http://minio:9000"

--- a/kafka-client-examples/e2e-test/docker/antithesis/async/config/rs3.toml
+++ b/kafka-client-examples/e2e-test/docker/antithesis/async/config/rs3.toml
@@ -21,3 +21,4 @@ provider = "Aws"
 region = ""
 bucket = "rs3-antithesis"
 s3_endpoint = "http://minio:9000"
+s3_retry_timeout_millis = 1800000

--- a/kafka-client-examples/e2e-test/docker/antithesis/base/config/docker-compose-rs3.yml
+++ b/kafka-client-examples/e2e-test/docker/antithesis/base/config/docker-compose-rs3.yml
@@ -25,7 +25,7 @@ services:
         ipv4_address: 10.0.0.61
   rs3:
     # Remember to update the image in github-e2e.yaml as well
-    image: public.ecr.aws/j8q9y0n6/responsiveinc/rs3-antithesis:0.1.0-main.35.0
+    image: public.ecr.aws/j8q9y0n6/responsiveinc/rs3-antithesis:0.1.0-main.37.0
     platform: linux/amd64
     container_name: rs3
     hostname: rs3

--- a/kafka-client-examples/e2e-test/docker/antithesis/base/config/docker-compose-rs3.yml
+++ b/kafka-client-examples/e2e-test/docker/antithesis/base/config/docker-compose-rs3.yml
@@ -11,8 +11,49 @@ services:
       - 50051:50051
     environment:
       CONFIG_FILE: /etc/rs3/rs3.toml
+    depends_on:
+      - createbucket
     volumes:
       - ./volumes/rs3.toml:/etc/rs3/rs3.toml
     networks:
       backend:
         ipv4_address: 10.0.0.60
+  createbucket:
+    image: minio/mc:RELEASE.2025-03-12T17-29-24Z
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      /usr/bin/mc config host add minio http://minio:9000 antithesis antithesis;
+      /usr/bin/mc rm -r --force minio/rs3-antithesis;
+      /usr/bin/mc mb minio/rs3-antithesis;
+      exit 0;
+      "
+    networks:
+      backend:
+        ipv4_address: 10.0.0.61
+  minio:
+    container_name: minio
+    hostname: minio
+    image: minio/minio:RELEASE.2025-03-12T18-04-18Z
+    command: server /minio --console-address ":9001"
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - ./volumes/minio/data:/minio:rw
+      - ./volumes/minio/etc:/etc/minio:r
+    environment:
+      - MINIO_ACCESS_KEY_FILE=/etc/minio/insecure.access.key
+      - MINIO_SECRET_KEY_FILE=/etc/minio/insecure.secret.key
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 1s
+      timeout: 10s
+      retries: 100
+    networks:
+      backend:
+        ipv4_address: 10.0.0.62
+
+

--- a/kafka-client-examples/e2e-test/docker/antithesis/base/config/docker-compose-rs3.yml
+++ b/kafka-client-examples/e2e-test/docker/antithesis/base/config/docker-compose-rs3.yml
@@ -1,38 +1,6 @@
 include:
   - docker-compose-base.yml
 services:
-  rs3:
-    # Remember to update the image in github-e2e.yaml as well
-    image: public.ecr.aws/j8q9y0n6/responsiveinc/rs3-antithesis:0.1.0-main.34.0
-    platform: linux/amd64
-    container_name: rs3
-    hostname: rs3
-    ports:
-      - 50051:50051
-    environment:
-      CONFIG_FILE: /etc/rs3/rs3.toml
-    depends_on:
-      - createbucket
-    volumes:
-      - ./volumes/rs3.toml:/etc/rs3/rs3.toml
-    networks:
-      backend:
-        ipv4_address: 10.0.0.60
-  createbucket:
-    image: docker.io/minio/mc:RELEASE.2025-03-12T17-29-24Z
-    depends_on:
-      minio:
-        condition: service_healthy
-    entrypoint: >
-      /bin/sh -c "
-      /usr/bin/mc config host add minio http://minio:9000 antithesis antithesis;
-      /usr/bin/mc rm -r --force minio/rs3-antithesis;
-      /usr/bin/mc mb minio/rs3-antithesis;
-      exit 0;
-      "
-    networks:
-      backend:
-        ipv4_address: 10.0.0.61
   minio:
     container_name: minio
     hostname: minio
@@ -55,5 +23,36 @@ services:
     networks:
       backend:
         ipv4_address: 10.0.0.62
-
-
+  createbucket:
+    image: docker.io/minio/mc:RELEASE.2025-03-12T17-29-24Z
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+      sleep 5 # give time for minio to start (antithesis does not support dependencies) 
+      /usr/bin/mc config host add minio http://minio:9000 antithesis antithesis;
+      /usr/bin/mc rm -r --force minio/rs3-antithesis;
+      /usr/bin/mc mb minio/rs3-antithesis;
+      exit 0;
+      "
+    networks:
+      backend:
+        ipv4_address: 10.0.0.61
+  rs3:
+    # Remember to update the image in github-e2e.yaml as well
+    image: public.ecr.aws/j8q9y0n6/responsiveinc/rs3-antithesis:0.1.0-main.34.0
+    platform: linux/amd64
+    container_name: rs3
+    hostname: rs3
+    ports:
+      - 50051:50051
+    environment:
+      CONFIG_FILE: /etc/rs3/rs3.toml
+    depends_on:
+      - createbucket
+    volumes:
+      - ./volumes/rs3.toml:/etc/rs3/rs3.toml
+    networks:
+      backend:
+        ipv4_address: 10.0.0.60

--- a/kafka-client-examples/e2e-test/docker/antithesis/base/config/docker-compose-rs3.yml
+++ b/kafka-client-examples/e2e-test/docker/antithesis/base/config/docker-compose-rs3.yml
@@ -25,7 +25,7 @@ services:
         ipv4_address: 10.0.0.61
   rs3:
     # Remember to update the image in github-e2e.yaml as well
-    image: public.ecr.aws/j8q9y0n6/responsiveinc/rs3-antithesis:0.1.0-main.34.0
+    image: public.ecr.aws/j8q9y0n6/responsiveinc/rs3-antithesis:0.1.0-main.35.0
     platform: linux/amd64
     container_name: rs3
     hostname: rs3

--- a/kafka-client-examples/e2e-test/docker/antithesis/base/config/docker-compose-rs3.yml
+++ b/kafka-client-examples/e2e-test/docker/antithesis/base/config/docker-compose-rs3.yml
@@ -19,7 +19,7 @@ services:
       backend:
         ipv4_address: 10.0.0.60
   createbucket:
-    image: minio/mc:RELEASE.2025-03-12T17-29-24Z
+    image: docker.io/minio/mc:RELEASE.2025-03-12T17-29-24Z
     depends_on:
       minio:
         condition: service_healthy
@@ -36,14 +36,14 @@ services:
   minio:
     container_name: minio
     hostname: minio
-    image: minio/minio:RELEASE.2025-03-12T18-04-18Z
+    image: docker.io/minio/minio:RELEASE.2025-03-12T18-04-18Z
     command: server /minio --console-address ":9001"
     ports:
       - "9000:9000"
       - "9001:9001"
     volumes:
       - ./volumes/minio/data:/minio:rw
-      - ./volumes/minio/etc:/etc/minio:r
+      - ./volumes/minio/etc:/etc/minio:ro
     environment:
       - MINIO_ACCESS_KEY_FILE=/etc/minio/insecure.access.key
       - MINIO_SECRET_KEY_FILE=/etc/minio/insecure.secret.key

--- a/kafka-client-examples/e2e-test/docker/antithesis/base/config/docker-compose-rs3.yml
+++ b/kafka-client-examples/e2e-test/docker/antithesis/base/config/docker-compose-rs3.yml
@@ -3,7 +3,7 @@ include:
 services:
   rs3:
     # Remember to update the image in github-e2e.yaml as well
-    image: public.ecr.aws/j8q9y0n6/responsiveinc/rs3-antithesis:0.1.0-main.30.0
+    image: public.ecr.aws/j8q9y0n6/responsiveinc/rs3-antithesis:0.1.0-main.34.0
     platform: linux/amd64
     container_name: rs3
     hostname: rs3

--- a/kafka-client-examples/e2e-test/docker/antithesis/base/config/docker-compose-rs3.yml
+++ b/kafka-client-examples/e2e-test/docker/antithesis/base/config/docker-compose-rs3.yml
@@ -22,22 +22,6 @@ services:
       retries: 100
     networks:
       backend:
-        ipv4_address: 10.0.0.62
-  createbucket:
-    image: docker.io/minio/mc:RELEASE.2025-03-12T17-29-24Z
-    depends_on:
-      minio:
-        condition: service_healthy
-    entrypoint: >
-      /bin/sh -c "
-      sleep 5 # give time for minio to start (antithesis does not support dependencies) 
-      /usr/bin/mc config host add minio http://minio:9000 antithesis antithesis;
-      /usr/bin/mc rm -r --force minio/rs3-antithesis;
-      /usr/bin/mc mb minio/rs3-antithesis;
-      exit 0;
-      "
-    networks:
-      backend:
         ipv4_address: 10.0.0.61
   rs3:
     # Remember to update the image in github-e2e.yaml as well
@@ -49,8 +33,8 @@ services:
       - 50051:50051
     environment:
       CONFIG_FILE: /etc/rs3/rs3.toml
-    depends_on:
-      - createbucket
+      AWS_ACCESS_KEY_ID: antithesis
+      AWS_SECRET_ACCESS_KEY: antithesis
     volumes:
       - ./volumes/rs3.toml:/etc/rs3/rs3.toml
     networks:

--- a/kafka-client-examples/e2e-test/docker/antithesis/base/config/volumes/minio/etc/insecure.access.key
+++ b/kafka-client-examples/e2e-test/docker/antithesis/base/config/volumes/minio/etc/insecure.access.key
@@ -1,0 +1,1 @@
+antithesis

--- a/kafka-client-examples/e2e-test/docker/antithesis/base/config/volumes/minio/etc/insecure.secret.key
+++ b/kafka-client-examples/e2e-test/docker/antithesis/base/config/volumes/minio/etc/insecure.secret.key
@@ -1,0 +1,1 @@
+antithesis

--- a/kafka-client-examples/e2e-test/docker/antithesis/regression/Dockerfile
+++ b/kafka-client-examples/e2e-test/docker/antithesis/regression/Dockerfile
@@ -13,6 +13,7 @@ ADD base/config/volumes/mongo /volumes/mongo
 ADD base/config/volumes/mongo2 /volumes/mongo2
 ADD base/config/volumes/mongo3 /volumes/mongo3
 ADD base/config/volumes/kafka /volumes/kafka
+ADD base/config/volumes/minio /volumes/minio
 
 COPY regression/config/rs3.toml volumes/rs3.toml
 COPY regression/config/docker-compose.yml /docker-compose.yml

--- a/kafka-client-examples/e2e-test/docker/antithesis/regression/config/rs3.toml
+++ b/kafka-client-examples/e2e-test/docker/antithesis/regression/config/rs3.toml
@@ -19,4 +19,9 @@ id = "013a57c3-16b3-44be-8de4-0d1083671cc6"
 pss = [{ id = 0 }, { id = 1 }, { id = 2 }, { id = 3 }, { id = 4 }, { id = 5 }, { id = 6 }, { id = 7 }]
 
 [cloud_provider]
-provider = "InMemory"
+provider = "Aws"
+
+[cloud_provider.aws]
+region = ""
+bucket = "rs3-antithesis"
+s3_endpoint = "http://minio:9000"


### PR DESCRIPTION
Changes RS3 configuration to use minio for the backend. This is based initially off the documented example here: https://antithesis.com/docs/reference/dependencies/?sid=9f2f2.38&sterm=locals#minio. Note that this requires an updated RS3 image with the `s3_endpoint` configuration.