### PR TITLE
Update base e2e-test image to latest stable debian (12)

### DIFF
--- a/kafka-client-examples/e2e-test/docker/Dockerfile
+++ b/kafka-client-examples/e2e-test/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM amd64/debian:11.6
+FROM amd64/debian:12
 
 RUN apt update
 RUN apt install -y wget


### PR DESCRIPTION
I was getting errors building image depndencies (`wget` specifically) when running locally . Upgrading to the latest debian stable image fixed the issue.