### PR TITLE
Separate segment window flush manager

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraWindowFlushManager.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraWindowFlushManager.java
@@ -22,7 +22,7 @@ import dev.responsive.kafka.internal.utils.WindowedKey;
 import org.apache.kafka.common.utils.LogContext;
 import org.slf4j.Logger;
 
-public class CassandraWindowFlushManager extends WindowFlushManager {
+public class CassandraWindowFlushManager extends SegmentedWindowFlushManager {
 
   private final String logPrefix;
   private final Logger log;

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/FlushManager.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/FlushManager.java
@@ -15,6 +15,11 @@ package dev.responsive.kafka.internal.db;
 import dev.responsive.kafka.internal.db.partitioning.TablePartitioner;
 import dev.responsive.kafka.internal.stores.RemoteWriteResult;
 
+/**
+ *
+ * @param <K> Key type
+ * @param <P> Table partition type
+ */
 public interface FlushManager<K, P> {
 
   String tableName();

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/MongoWindowFlushManager.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/MongoWindowFlushManager.java
@@ -28,7 +28,7 @@ import java.util.function.Function;
 import org.apache.kafka.common.utils.LogContext;
 import org.slf4j.Logger;
 
-public class MongoWindowFlushManager extends WindowFlushManager {
+public class MongoWindowFlushManager extends SegmentedWindowFlushManager {
 
   private final String logPrefix;
   private final Logger log;

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/RemoteWindowTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/RemoteWindowTable.java
@@ -25,7 +25,7 @@ public interface RemoteWindowTable<S> extends RemoteTable<WindowedKey, S> {
    * @return a {@link WindowFlushManager} that gives the callee access
    * to run statements on {@code table}
    */
-  WindowFlushManager init(
+  WindowFlushManager<?> init(
       final int kafkaPartition
   );
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/SegmentedWindowFlushManager.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/SegmentedWindowFlushManager.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2024 Responsive Computing, Inc.
+ *
+ * This source code is licensed under the Responsive Business Source License Agreement v1.0
+ * available at:
+ *
+ * https://www.responsive.dev/legal/responsive-bsl-10
+ *
+ * This software requires a valid Commercial License Key for production use. Trial and commercial
+ * licenses can be obtained at https://www.responsive.dev
+ */
+
+package dev.responsive.kafka.internal.db;
+
+import dev.responsive.kafka.internal.db.partitioning.Segmenter;
+import dev.responsive.kafka.internal.db.partitioning.Segmenter.SegmentPartition;
+import dev.responsive.kafka.internal.stores.RemoteWriteResult;
+import dev.responsive.kafka.internal.utils.PendingFlushSegmentMetadata;
+import dev.responsive.kafka.internal.utils.WindowedKey;
+
+public abstract class SegmentedWindowFlushManager implements WindowFlushManager<SegmentPartition> {
+
+  private final int kafkaPartition;
+  private final Segmenter segmenter;
+  private final PendingFlushSegmentMetadata pendingFlushSegmentMetadata;
+
+  public SegmentedWindowFlushManager(
+      final String tableName,
+      final int kafkaPartition,
+      final Segmenter segmenter,
+      final long streamTime
+  ) {
+    this.kafkaPartition = kafkaPartition;
+    this.segmenter = segmenter;
+    this.pendingFlushSegmentMetadata =
+        new PendingFlushSegmentMetadata(tableName, kafkaPartition, streamTime);
+  }
+
+  @Override
+  public long streamTime() {
+    return pendingFlushSegmentMetadata.batchStreamTime();
+  }
+
+  @Override
+  public void writeAdded(final WindowedKey key) {
+    pendingFlushSegmentMetadata.updateStreamTime(key.windowStartMs);
+  }
+
+  @Override
+  public RemoteWriteResult<SegmentPartition> preFlush() {
+    final var pendingRoll = pendingFlushSegmentMetadata.prepareRoll(segmenter);
+
+    for (final long segmentStartTimestamp : pendingRoll.segmentsToCreate()) {
+      final var createResult =
+          createSegment(new SegmentPartition(kafkaPartition, segmentStartTimestamp));
+      if (!createResult.wasApplied()) {
+        return createResult;
+      }
+    }
+
+    return RemoteWriteResult.success(null);
+  }
+
+  @Override
+  public RemoteWriteResult<SegmentPartition> postFlush(final long consumedOffset) {
+
+    final var metadataResult = updateOffsetAndStreamTime(
+        consumedOffset,
+        pendingFlushSegmentMetadata.batchStreamTime()
+    );
+    if (!metadataResult.wasApplied()) {
+      return metadataResult;
+    }
+
+    for (final long segmentStartTimestamp : pendingFlushSegmentMetadata.segmentRoll()
+        .segmentsToExpire()) {
+      final var deleteResult =
+          deleteSegment(new SegmentPartition(kafkaPartition, segmentStartTimestamp));
+      if (!deleteResult.wasApplied()) {
+        return deleteResult;
+      }
+    }
+
+    pendingFlushSegmentMetadata.finalizeRoll();
+    return RemoteWriteResult.success(null);
+  }
+
+  /**
+   * Persist the latest consumed offset and stream-time corresponding to the batch that was just
+   * flushed to the remote table
+   */
+  protected abstract RemoteWriteResult<SegmentPartition> updateOffsetAndStreamTime(
+      final long consumedOffset,
+      final long streamTime
+  );
+
+  /**
+   * "Create" the passed-in segment by executing whatever preparations are needed to
+   * support writes to this segment. Assumed to be completed synchronously
+   */
+  protected abstract RemoteWriteResult<SegmentPartition> createSegment(
+      final SegmentPartition partition
+  );
+
+  /**
+   * "Delete" the passed-in expired segment by executing whatever cleanup is needed to
+   * release the resources held by this segment and reclaim the storage it previously held
+   */
+  protected abstract RemoteWriteResult<SegmentPartition> deleteSegment(
+      final SegmentPartition partition
+  );
+
+}

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/WindowFlushManager.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/WindowFlushManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Responsive Computing, Inc.
+ * Copyright 2025 Responsive Computing, Inc.
  *
  * This source code is licensed under the Responsive Business Source License Agreement v1.0
  * available at:
@@ -12,101 +12,14 @@
 
 package dev.responsive.kafka.internal.db;
 
-import dev.responsive.kafka.internal.db.partitioning.Segmenter;
-import dev.responsive.kafka.internal.db.partitioning.Segmenter.SegmentPartition;
-import dev.responsive.kafka.internal.stores.RemoteWriteResult;
-import dev.responsive.kafka.internal.utils.PendingFlushSegmentMetadata;
 import dev.responsive.kafka.internal.utils.WindowedKey;
 
-public abstract class WindowFlushManager implements FlushManager<WindowedKey, SegmentPartition> {
+/**
+ *
+ * @param <P> Table partition type
+ */
+public interface WindowFlushManager<P> extends FlushManager<WindowedKey, P> {
 
-  private final int kafkaPartition;
-  private final Segmenter segmenter;
-  private final PendingFlushSegmentMetadata pendingFlushSegmentMetadata;
-
-  public WindowFlushManager(
-      final String tableName,
-      final int kafkaPartition,
-      final Segmenter segmenter,
-      final long streamTime
-  ) {
-    this.kafkaPartition = kafkaPartition;
-    this.segmenter = segmenter;
-    this.pendingFlushSegmentMetadata =
-        new PendingFlushSegmentMetadata(tableName, kafkaPartition, streamTime);
-  }
-
-  public long streamTime() {
-    return pendingFlushSegmentMetadata.batchStreamTime();
-  }
-
-  @Override
-  public void writeAdded(final WindowedKey key) {
-    pendingFlushSegmentMetadata.updateStreamTime(key.windowStartMs);
-  }
-
-  @Override
-  public RemoteWriteResult<SegmentPartition> preFlush() {
-    final var pendingRoll = pendingFlushSegmentMetadata.prepareRoll(segmenter);
-
-    for (final long segmentStartTimestamp : pendingRoll.segmentsToCreate()) {
-      final var createResult =
-          createSegment(new SegmentPartition(kafkaPartition, segmentStartTimestamp));
-      if (!createResult.wasApplied()) {
-        return createResult;
-      }
-    }
-
-    return RemoteWriteResult.success(null);
-  }
-
-  @Override
-  public RemoteWriteResult<SegmentPartition> postFlush(final long consumedOffset) {
-
-    final var metadataResult = updateOffsetAndStreamTime(
-        consumedOffset,
-        pendingFlushSegmentMetadata.batchStreamTime()
-    );
-    if (!metadataResult.wasApplied()) {
-      return metadataResult;
-    }
-
-    for (final long segmentStartTimestamp : pendingFlushSegmentMetadata.segmentRoll()
-        .segmentsToExpire()) {
-      final var deleteResult =
-          deleteSegment(new SegmentPartition(kafkaPartition, segmentStartTimestamp));
-      if (!deleteResult.wasApplied()) {
-        return deleteResult;
-      }
-    }
-
-    pendingFlushSegmentMetadata.finalizeRoll();
-    return RemoteWriteResult.success(null);
-  }
-
-  /**
-   * Persist the latest consumed offset and stream-time corresponding to the batch that was just
-   * flushed to the remote table
-   */
-  protected abstract RemoteWriteResult<SegmentPartition> updateOffsetAndStreamTime(
-      final long consumedOffset,
-      final long streamTime
-  );
-
-  /**
-   * "Create" the passed-in segment by executing whatever preparations are needed to
-   * support writes to this segment. Assumed to be completed synchronously
-   */
-  protected abstract RemoteWriteResult<SegmentPartition> createSegment(
-      final SegmentPartition partition
-  );
-
-  /**
-   * "Delete" the passed-in expired segment by executing whatever cleanup is needed to
-   * release the resources held by this segment and reclaim the storage it previously held
-   */
-  protected abstract RemoteWriteResult<SegmentPartition> deleteSegment(
-      final SegmentPartition partition
-  );
+  long streamTime();
 
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/RemoteWindowOperations.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/RemoteWindowOperations.java
@@ -26,7 +26,6 @@ import dev.responsive.kafka.internal.db.BatchFlusher;
 import dev.responsive.kafka.internal.db.CassandraClient;
 import dev.responsive.kafka.internal.db.RemoteTableSpecFactory;
 import dev.responsive.kafka.internal.db.RemoteWindowTable;
-import dev.responsive.kafka.internal.db.SegmentedWindowFlushManager;
 import dev.responsive.kafka.internal.db.WindowFlushManager;
 import dev.responsive.kafka.internal.db.WindowedKeySpec;
 import dev.responsive.kafka.internal.db.mongo.ResponsiveMongoClient;

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveWindowStore.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/ResponsiveWindowStore.java
@@ -109,7 +109,7 @@ public class ResponsiveWindowStore
         throw new IllegalStateException("Store " + name() + " was opened as a standby");
       }
 
-      windowOperations = SegmentedOperations.create(
+      windowOperations = RemoteWindowOperations.create(
           name,
           storeContext,
           params,

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/internal/db/TTDWindowTable.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/internal/db/TTDWindowTable.java
@@ -56,7 +56,7 @@ public class TTDWindowTable extends TTDTable<WindowedKey>
   }
 
   @Override
-  public WindowFlushManager init(final int kafkaPartition) {
+  public SegmentedWindowFlushManager init(final int kafkaPartition) {
     return new TTDWindowFlushManager(this, kafkaPartition, partitioner);
   }
 
@@ -154,7 +154,7 @@ public class TTDWindowTable extends TTDTable<WindowedKey>
     return 0;
   }
 
-  private static class TTDWindowFlushManager extends WindowFlushManager {
+  private static class TTDWindowFlushManager extends SegmentedWindowFlushManager {
 
     private final String logPrefix;
     private final TTDWindowTable table;


### PR DESCRIPTION
The current `WindowFlushManager` is coupled with the segmenting approach even though it is not really used in `SegmentedOperations`. This patch moves `WindowFlushManager`to `SegmentedWindowFlushManager` and then reuses the `WindowFlushManager` name for an interface sitting between the two. I've also renamed `SegmentedOperations` to `RemoteWindowOperations` to reflect more general usage.