### PR TITLE
Rename fetchOffset to lastWrittenOffset

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraFactFlushManager.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraFactFlushManager.java
@@ -64,7 +64,7 @@ public class CassandraFactFlushManager extends KVFlushManager {
   @Override
   public String failedFlushInfo(final long batchOffset, final Integer failedTablePartition) {
     return String.format("<batchOffset=%d, persistedOffset=%d>",
-                         batchOffset, table.fetchOffset(kafkaPartition));
+                         batchOffset, table.lastWrittenOffset(kafkaPartition));
   }
 
   @Override

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraFactTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraFactTable.java
@@ -248,7 +248,7 @@ public class CassandraFactTable implements RemoteKVTable<BoundStatement> {
   }
 
   @Override
-  public long fetchOffset(final int kafkaPartition) {
+  public long lastWrittenOffset(final int kafkaPartition) {
     final BoundStatement bound = fetchOffset
         .bind()
         .setInt(PARTITION_KEY.bind(), kafkaPartition);

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraKVFlushManager.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraKVFlushManager.java
@@ -71,7 +71,7 @@ public class CassandraKVFlushManager extends KVFlushManager {
   @Override
   public String failedFlushInfo(final long batchOffset, final Integer failedTablePartition) {
     return String.format("<batchOffset=%d, persistedOffset=%d>, <localEpoch=%d, persistedEpoch=%d>",
-                         batchOffset, table.fetchOffset(kafkaPartition),
+                         batchOffset, table.lastWrittenOffset(kafkaPartition),
                          epoch, table.fetchEpoch(failedTablePartition));
   }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraKeyValueTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraKeyValueTable.java
@@ -507,7 +507,7 @@ public class CassandraKeyValueTable implements RemoteKVTable<BoundStatement> {
   }
 
   @Override
-  public long fetchOffset(final int kafkaPartition) {
+  public long lastWrittenOffset(final int kafkaPartition) {
     final int metadataTablePartition = partitioner.metadataTablePartition(kafkaPartition);
 
     final List<Row> result = client.execute(

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraWindowFlushManager.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraWindowFlushManager.java
@@ -98,7 +98,7 @@ public class CassandraWindowFlushManager extends SegmentedWindowFlushManager {
       final SegmentPartition failedTablePartition
   ) {
     return String.format("<batchOffset=%d, persistedOffset=%d>, <localEpoch=%d, persistedEpoch=%d>",
-                         batchOffset, table.fetchOffset(kafkaPartition),
+                         batchOffset, table.lastWrittenOffset(kafkaPartition),
                          epoch, table.fetchEpoch(failedTablePartition));
   }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraWindowTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/CassandraWindowTable.java
@@ -627,7 +627,7 @@ public class CassandraWindowTable implements RemoteWindowTable<BoundStatement> {
   }
 
   @Override
-  public long fetchOffset(final int kafkaPartition) {
+  public long lastWrittenOffset(final int kafkaPartition) {
     final Segmenter.SegmentPartition metadataPartition =
         partitioner.metadataTablePartition(kafkaPartition);
     final List<Row> result = client.execute(

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/MongoKVFlushManager.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/MongoKVFlushManager.java
@@ -71,7 +71,7 @@ public class MongoKVFlushManager extends KVFlushManager {
   @Override
   public String failedFlushInfo(final long batchOffset, final Integer failedTablePartition) {
     return String.format("<batchOffset=%d, persistedOffset=%d>, <localEpoch=%d, persistedEpoch=%d>",
-                         batchOffset, table.fetchOffset(kafkaPartition),
+                         batchOffset, table.lastWrittenOffset(kafkaPartition),
                          table.localEpoch(kafkaPartition), table.fetchEpoch(kafkaPartition));
   }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/MongoSessionFlushManager.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/MongoSessionFlushManager.java
@@ -104,7 +104,7 @@ public class MongoSessionFlushManager extends SessionFlushManager {
       final SegmentPartition failedTablePartition
   ) {
     return String.format("<batchOffset=%d, persistedOffset=%d>, <localEpoch=%d, persistedEpoch=%d>",
-                         batchOffset, table.fetchOffset(kafkaPartition),
+                         batchOffset, table.lastWrittenOffset(kafkaPartition),
                          table.localEpoch(kafkaPartition), table.fetchEpoch(kafkaPartition));
   }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/MongoWindowFlushManager.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/MongoWindowFlushManager.java
@@ -103,7 +103,7 @@ public class MongoWindowFlushManager extends SegmentedWindowFlushManager {
       final SegmentPartition failedTablePartition
   ) {
     return String.format("<batchOffset=%d, persistedOffset=%d>, <localEpoch=%d, persistedEpoch=%d>",
-                         batchOffset, table.fetchOffset(kafkaPartition),
+                         batchOffset, table.lastWrittenOffset(kafkaPartition),
                          table.localEpoch(kafkaPartition), table.fetchEpoch(kafkaPartition));
   }
 

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/RemoteTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/RemoteTable.java
@@ -61,9 +61,12 @@ public interface RemoteTable<K, S> {
   );
 
   /**
+   * Get the offset corresponding to the last write to the table for a specific
+   * Kafka partition.
+   *
    * @param kafkaPartition the kafka partition
    * @return the current offset fetched from the metadata table
    *         partition for the given kafka partition
    */
-  long fetchOffset(final int kafkaPartition);
+  long lastWrittenOffset(final int kafkaPartition);
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/inmemory/InMemoryKVTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/inmemory/InMemoryKVTable.java
@@ -180,7 +180,7 @@ public class InMemoryKVTable implements RemoteKVTable<BoundStatement> {
   }
 
   @Override
-  public long fetchOffset(int kafkaPartition) {
+  public long lastWrittenOffset(int kafkaPartition) {
     checkKafkaPartition(kafkaPartition);
     return ResponsiveStoreRegistration.NO_COMMITTED_OFFSET;
   }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoKVTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoKVTable.java
@@ -288,7 +288,7 @@ public class MongoKVTable implements RemoteKVTable<WriteModel<KVDoc>> {
   }
 
   @Override
-  public long fetchOffset(final int kafkaPartition) {
+  public long lastWrittenOffset(final int kafkaPartition) {
     final KVMetadataDoc result = metadata.find(
         Filters.eq(KVMetadataDoc.PARTITION, kafkaPartition)
     ).first();

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoSessionTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoSessionTable.java
@@ -448,7 +448,7 @@ public class MongoSessionTable implements RemoteSessionTable<WriteModel<SessionD
   }
 
   @Override
-  public long fetchOffset(final int kafkaPartition) {
+  public long lastWrittenOffset(final int kafkaPartition) {
     final SessionMetadataDoc remoteMetadata = metadata.find(
         Filters.eq(SessionMetadataDoc.PARTITION, kafkaPartition)
     ).first();

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoWindowTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/mongo/MongoWindowTable.java
@@ -332,7 +332,7 @@ public class MongoWindowTable implements RemoteWindowTable<WriteModel<WindowDoc>
   }
 
   @Override
-  public long fetchOffset(final int kafkaPartition) {
+  public long lastWrittenOffset(final int kafkaPartition) {
     final WindowMetadataDoc remoteMetadata = metadata.find(
         Filters.eq(WindowMetadataDoc.PARTITION, kafkaPartition)
     ).first();

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/rs3/RS3KVTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/rs3/RS3KVTable.java
@@ -188,7 +188,7 @@ public class RS3KVTable implements RemoteKVTable<WalEntry> {
   }
 
   @Override
-  public long fetchOffset(final int kafkaPartition) {
+  public long lastWrittenOffset(final int kafkaPartition) {
     return fetchOffset;
   }
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/GlobalOperations.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/GlobalOperations.java
@@ -182,7 +182,7 @@ public class GlobalOperations implements KeyValueOperations {
       // of auto.commit.interval.ms) unlike the changelog equivalent which
       // always restores from scratch
       final int partition = rec.partition();
-      final long offset = table.fetchOffset(partition);
+      final long offset = table.lastWrittenOffset(partition);
       if (rec.offset() < offset) {
         // ignore records that have already been processed - race conditions
         // are not important since the worst case we'll have just not written

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/PartitionedOperations.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/PartitionedOperations.java
@@ -155,7 +155,7 @@ public class PartitionedOperations implements KeyValueOperations {
           config
       );
 
-      final long restoreStartOffset = table.fetchOffset(changelog.partition());
+      final long restoreStartOffset = table.lastWrittenOffset(changelog.partition());
       registration = new ResponsiveStoreRegistration(
           name.kafkaName(),
           changelog,

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/RemoteWindowOperations.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/RemoteWindowOperations.java
@@ -140,7 +140,7 @@ public class RemoteWindowOperations implements WindowOperations {
           params.retainDuplicates(),
           responsiveConfig
       );
-      final long restoreStartOffset = table.fetchOffset(changelog.partition());
+      final long restoreStartOffset = table.lastWrittenOffset(changelog.partition());
       registration = new ResponsiveStoreRegistration(
           name.kafkaName(),
           changelog,

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/SessionOperationsImpl.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/SessionOperationsImpl.java
@@ -117,7 +117,7 @@ public class SessionOperationsImpl implements SessionOperations {
         false,
         responsiveConfig
     );
-    final long restoreStartOffset = table.fetchOffset(changelog.partition());
+    final long restoreStartOffset = table.lastWrittenOffset(changelog.partition());
     final var registration = new ResponsiveStoreRegistration(
         name.kafkaName(),
         changelog,

--- a/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveKeyValueStoreRestoreIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveKeyValueStoreRestoreIntegrationTest.java
@@ -179,7 +179,7 @@ public class ResponsiveKeyValueStoreRestoreIntegrationTest {
       final ResponsiveConfig config = ResponsiveConfig.responsiveConfig(properties);
       final RemoteKVTable<?> table = remoteKVTable(type, defaultFactory, config, changelog);
 
-      final long cassandraOffset = table.fetchOffset(0);
+      final long cassandraOffset = table.lastWrittenOffset(0);
       assertThat(cassandraOffset, greaterThan(0L));
 
       final List<ConsumerRecord<Long, Long>> changelogRecords
@@ -307,7 +307,7 @@ public class ResponsiveKeyValueStoreRestoreIntegrationTest {
 
     table = remoteKVTable(type, defaultFactory, config, changelog);
 
-    final long remoteOffset = table.fetchOffset(0);
+    final long remoteOffset = table.lastWrittenOffset(0);
     assertThat(remoteOffset, greaterThan(0L));
 
     final long changelogOffset = admin.listOffsets(Map.of(changelog, OffsetSpec.latest())).all()

--- a/kafka-client/src/test/java/dev/responsive/kafka/integration/TablePartitionerIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/integration/TablePartitionerIntegrationTest.java
@@ -257,13 +257,13 @@ public class TablePartitionerIntegrationTest {
       final CassandraFactTable table = CassandraFactTable.create(
           new DefaultTableSpec(cassandraName, partitioner, TtlResolver.NO_TTL, config), client);
 
-      final var offset0 = table.fetchOffset(0);
-      final var offset1 = table.fetchOffset(1);
+      final var offset0 = table.lastWrittenOffset(0);
+      final var offset1 = table.lastWrittenOffset(1);
 
       assertThat(offset0, is(notNullValue()));
       assertThat(offset1, is(notNullValue()));
 
-      Assertions.assertEquals(table.fetchOffset(2), NO_COMMITTED_OFFSET);
+      Assertions.assertEquals(table.lastWrittenOffset(2), NO_COMMITTED_OFFSET);
 
       LOG.info("Checking data in remote table");
       // these store ValueAndTimestamp, so we need to just pluck the last 8 bytes

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/CassandraFactTableIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/CassandraFactTableIntegrationTest.java
@@ -92,8 +92,8 @@ class CassandraFactTableIntegrationTest {
     final var token = schema.init(1);
     schema.init(2);
     client.execute(schema.setOffset(2, 10));
-    final long offset1 = schema.fetchOffset(1);
-    final long offset2 = schema.fetchOffset(2);
+    final long offset1 = schema.lastWrittenOffset(1);
+    final long offset2 = schema.lastWrittenOffset(2);
 
     // Then:
     assertThat(offset1, is(-1L));

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/rs3/RS3KVTableIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/rs3/RS3KVTableIntegrationTest.java
@@ -177,7 +177,7 @@ public class RS3KVTableIntegrationTest {
     table.init(PARTITION_ID);
 
     // when:
-    final var restorePartition = table.fetchOffset(PARTITION_ID);
+    final var restorePartition = table.lastWrittenOffset(PARTITION_ID);
     assertThat(restorePartition, is(100L));
   }
 
@@ -203,7 +203,7 @@ public class RS3KVTableIntegrationTest {
     table.init(PARTITION_ID);
 
     // when:
-    final var restorePartition = table.fetchOffset(PARTITION_ID);
+    final var restorePartition = table.lastWrittenOffset(PARTITION_ID);
     assertThat(restorePartition, is(ResponsiveStoreRegistration.NO_COMMITTED_OFFSET));
   }
 

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/CommitBufferTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/CommitBufferTest.java
@@ -347,7 +347,7 @@ public class CommitBufferTest {
       assertThat(table.fetchEpoch(8), is(1L));
       assertThat(table.fetchEpoch(9), is(2L));
       assertThat(table.fetchEpoch(10), is(1L));
-      assertThat(table.fetchOffset(changelog.partition()), is(-1L));
+      assertThat(table.lastWrittenOffset(changelog.partition()), is(-1L));
     }
   }
 
@@ -449,10 +449,10 @@ public class CommitBufferTest {
       buffer.flush(9L);
 
       // Then:
-      assertThat(table.fetchOffset(KAFKA_PARTITION), is(-1L));
+      assertThat(table.lastWrittenOffset(KAFKA_PARTITION), is(-1L));
       buffer.put(Bytes.wrap(new byte[]{10}), VALUE, CURRENT_TS);
       buffer.flush(10L);
-      assertThat(table.fetchOffset(KAFKA_PARTITION), is(10L));
+      assertThat(table.lastWrittenOffset(KAFKA_PARTITION), is(10L));
     }
   }
 
@@ -473,10 +473,10 @@ public class CommitBufferTest {
       buffer.flush(9L);
 
       // Then:
-      assertThat(table.fetchOffset(KAFKA_PARTITION), is(-1L));
+      assertThat(table.lastWrittenOffset(KAFKA_PARTITION), is(-1L));
       buffer.put(Bytes.wrap(new byte[]{10}), value, CURRENT_TS);
       buffer.flush(10L);
-      assertThat(table.fetchOffset(KAFKA_PARTITION), is(10L));
+      assertThat(table.lastWrittenOffset(KAFKA_PARTITION), is(10L));
     }
   }
 
@@ -496,10 +496,10 @@ public class CommitBufferTest {
       buffer.flush(1L);
 
       // Then:
-      assertThat(table.fetchOffset(KAFKA_PARTITION), is(-1L));
+      assertThat(table.lastWrittenOffset(KAFKA_PARTITION), is(-1L));
       clock.set(clock.get().plus(Duration.ofSeconds(35)));
       buffer.flush(5L);
-      assertThat(table.fetchOffset(KAFKA_PARTITION), is(5L));
+      assertThat(table.lastWrittenOffset(KAFKA_PARTITION), is(5L));
     }
   }
 
@@ -518,7 +518,7 @@ public class CommitBufferTest {
       buffer.flush(10L);
 
       // Then:
-      assertThat(table.fetchOffset(KAFKA_PARTITION), is(10L));
+      assertThat(table.lastWrittenOffset(KAFKA_PARTITION), is(10L));
     }
   }
 
@@ -534,7 +534,7 @@ public class CommitBufferTest {
     buffer.put(Bytes.wrap(new byte[]{18}), VALUE, CURRENT_TS);
     while (clock.get().isBefore(to)) {
       buffer.flush(flushOffset);
-      if (table.fetchOffset(KAFKA_PARTITION) == flushOffset) {
+      if (table.lastWrittenOffset(KAFKA_PARTITION) == flushOffset) {
         return Optional.of(clock.get());
       }
       clock.set(clock.get().plus(Duration.ofSeconds(1)));
@@ -613,7 +613,7 @@ public class CommitBufferTest {
       buffer.restoreBatch(List.of(record), -1L);
 
       // Then:
-      assertThat(table.fetchOffset(KAFKA_PARTITION), is(100L));
+      assertThat(table.lastWrittenOffset(KAFKA_PARTITION), is(100L));
       final byte[] value = table.get(KAFKA_PARTITION, KEY, MIN_VALID_TS);
       assertThat(value, is(VALUE));
     }

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/internal/db/TTDTable.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/internal/db/TTDTable.java
@@ -31,7 +31,7 @@ public abstract class TTDTable<K> implements RemoteTable<K, BoundStatement> {
   public abstract long count();
 
   @Override
-  public long fetchOffset(final int kafkaPartition) {
+  public long lastWrittenOffset(final int kafkaPartition) {
     return 0;
   }
 


### PR DESCRIPTION
As suggested [here](https://github.com/responsivedev/responsive-pub/pull/443#discussion_r2027819702), `RemoteTable.fetchOffset` does not reflect its usage very clearly. In this patch, I've renamed it to `lastWrittenOffset`.