### PR TITLE
Change license loading precedence

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveKafkaStreams.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveKafkaStreams.java
@@ -533,16 +533,22 @@ public class ResponsiveKafkaStreams extends KafkaStreams {
           break;
         case RS3:
           LOG.info("Using rs3 responsive store");
-          if (!(license instanceof UsageBasedV1)) {
-            throw new LicenseUseViolationException("rs3 can only be used with usage based license");
+
+          final ApiCredential apiCredential;
+          if (license instanceof UsageBasedV1) {
+            apiCredential = ApiCredential.forApiKey(((UsageBasedV1) license).key());
+          } else {
+            LOG.warn("Connecting to rs3 without a license");
+            apiCredential = null;
           }
+
           final var rs3Host = responsiveConfig.getString(RS3_HOSTNAME_CONFIG);
           final var rs3Port = responsiveConfig.getInt(RS3_PORT_CONFIG);
           final var rs3Connector = new GrpcRS3Client.Connector(
               time,
               rs3Host,
               rs3Port,
-              () -> ApiCredential.forApiKey(((UsageBasedV1) license).key())
+              () -> apiCredential
           );
           rs3Connector.retryTimeoutMs(responsiveConfig.getLong(RS3_RETRY_TIMEOUT_CONFIG));
           rs3Connector.useTls(responsiveConfig.getBoolean(RS3_TLS_ENABLED_CONFIG));

--- a/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveKafkaStreams.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/api/ResponsiveKafkaStreams.java
@@ -49,7 +49,6 @@ import dev.responsive.kafka.internal.db.mongo.ResponsiveMongoClient;
 import dev.responsive.kafka.internal.db.rs3.RS3TableFactory;
 import dev.responsive.kafka.internal.db.rs3.client.grpc.ApiCredential;
 import dev.responsive.kafka.internal.db.rs3.client.grpc.GrpcRS3Client;
-import dev.responsive.kafka.internal.license.exception.LicenseUseViolationException;
 import dev.responsive.kafka.internal.license.model.CloudLicenseV1;
 import dev.responsive.kafka.internal.license.model.LicenseInfo;
 import dev.responsive.kafka.internal.license.model.TimedTrialV1;

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/license/LicenseUtilsTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/license/LicenseUtilsTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2025 Responsive Computing, Inc.
+ *
+ * This source code is licensed under the Responsive Business Source License Agreement v1.0
+ * available at:
+ *
+ * https://www.responsive.dev/legal/responsive-bsl-10
+ *
+ * This software requires a valid Commercial License Key for production use. Trial and commercial
+ * licenses can be obtained at https://www.responsive.dev
+ */
+
+package dev.responsive.kafka.internal.license;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import dev.responsive.kafka.api.config.ResponsiveConfig;
+import dev.responsive.kafka.internal.license.model.CloudLicenseV1;
+import dev.responsive.kafka.internal.license.model.TimedTrialV1;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.Base64;
+import java.util.Properties;
+import org.apache.kafka.common.config.ConfigException;
+import org.junit.jupiter.api.Test;
+
+class LicenseUtilsTest {
+
+  @Test
+  public void testFallBackToPlatformApiKey() {
+    final var props = new Properties();
+    props.put(ResponsiveConfig.PLATFORM_API_KEY_CONFIG, "test-api-key");
+
+    final var config = ResponsiveConfig.responsiveConfig(props);
+    final var license = LicenseUtils.loadLicense(config);
+    assertThat(license, instanceOf(CloudLicenseV1.class));
+
+    final var cloudLicense = (CloudLicenseV1) license;
+    assertThat(cloudLicense.key(), is("test-api-key"));
+  }
+
+  @Test
+  public void testLicenseShouldHavePrecedenceOverApiKey() throws Exception {
+    final var props = new Properties();
+    props.put(ResponsiveConfig.RESPONSIVE_LICENSE_CONFIG, testLicenseContent());
+    props.put(ResponsiveConfig.PLATFORM_API_KEY_CONFIG, "test-api-key");
+
+    final var config = ResponsiveConfig.responsiveConfig(props);
+    final var license = LicenseUtils.loadLicense(config);
+    assertThat(license, instanceOf(TimedTrialV1.class));
+  }
+
+  @Test
+  public void testCannotSpecifyLicenseAndLicenseFile() throws Exception {
+    final var props = new Properties();
+    props.put(ResponsiveConfig.RESPONSIVE_LICENSE_CONFIG, testLicenseContent());
+    props.put(ResponsiveConfig.RESPONSIVE_LICENSE_FILE_CONFIG, "/invalid/location");
+    final var config = ResponsiveConfig.responsiveConfig(props);
+    assertThrows(ConfigException.class, () -> LicenseUtils.loadLicense(config));
+  }
+
+  @Test
+  public void testMustSpecifyLicenseOrApiKey() {
+    final var props = new Properties();
+    final var config = ResponsiveConfig.responsiveConfig(props);
+    assertThrows(ConfigException.class, () -> LicenseUtils.loadLicense(config));
+  }
+
+  private String testLicenseContent() throws URISyntaxException, IOException {
+    final URL resource = LicenseUtils.class.getResource("/test-licenses/test-trial-license.json");
+    final var licenseBytes = Files.readAllBytes(Paths.get(resource.toURI()));
+    return Base64.getEncoder().encodeToString(licenseBytes);
+  }
+
+}


### PR DESCRIPTION
Currently we will not load a license if the API key is provided through `responsive.platform.api.key`. This patch changes the precedence to use this key as a fallback only if license loading fails. 

Additionally, we change RS3 initialization logic to not pass through an API key when the license is not `UsageBasedV1`.