### PR TITLE
add wiring for creating checkpoints of responsive kv stores

### DIFF
--- a/kafka-client/build.gradle.kts
+++ b/kafka-client/build.gradle.kts
@@ -137,6 +137,7 @@ dependencies {
     implementation("dev.responsive:controller-api:0.16.0")
     implementation(libs.bundles.scylla)
     implementation(libs.bundles.commons)
+    implementation(libs.jackson)
     implementation(libs.mongodb.driver.sync)
     implementation(libs.bundles.otel)
     implementation(libs.bundles.grpc)

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/StoreCommitListener.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/StoreCommitListener.java
@@ -41,14 +41,14 @@ public class StoreCommitListener {
       final TopicPartition p = e.getKey().getPartition();
       for (final ResponsiveStoreRegistration storeRegistration
           : storeRegistry.getRegisteredStoresForChangelog(p, threadId)) {
-        storeRegistration.onCommit().accept(e.getValue());
+        storeRegistration.callbacks().notifyCommit(e.getValue());
       }
     }
     for (final var e : writtenOffsets.entrySet()) {
       final TopicPartition p = e.getKey();
       for (final ResponsiveStoreRegistration storeRegistration
           : storeRegistry.getRegisteredStoresForChangelog(p, threadId)) {
-        storeRegistration.onCommit().accept(e.getValue());
+        storeRegistration.callbacks().notifyCommit(e.getValue());
       }
     }
   }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/RemoteKVTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/RemoteKVTable.java
@@ -94,4 +94,8 @@ public interface RemoteKVTable<S> extends RemoteTable<Bytes, S> {
    * @return the approximate number of entries for this kafka partition
    */
   long approximateNumEntries(int kafkaPartition);
+
+  default byte[] checkpoint() {
+    throw new UnsupportedOperationException("checkpoints not supported for this store type");
+  }
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/rs3/TableCheckpoint.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/rs3/TableCheckpoint.java
@@ -1,0 +1,108 @@
+package dev.responsive.kafka.internal.db.rs3;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import dev.responsive.kafka.internal.db.rs3.client.PssCheckpoint;
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+public class TableCheckpoint {
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  static {
+    MAPPER.registerModule(new Jdk8Module());
+  }
+
+  final List<TablePssCheckpoint> pssCheckpoints;
+
+  @JsonCreator
+  public TableCheckpoint(
+      @JsonProperty("pssCheckpoints") final List<TablePssCheckpoint> pssCheckpoints
+  ) {
+    this.pssCheckpoints = List.copyOf(Objects.requireNonNull(pssCheckpoints));
+  }
+
+  @JsonProperty("pssCheckpoints")
+  public List<TablePssCheckpoint> pssCheckpoints() {
+    return pssCheckpoints;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof TableCheckpoint)) {
+      return false;
+    }
+    final TableCheckpoint that = (TableCheckpoint) o;
+    return Objects.equals(pssCheckpoints, that.pssCheckpoints);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(pssCheckpoints);
+  }
+
+  public static class TablePssCheckpoint {
+    final Optional<Long> writtenOffset;
+    final PssCheckpoint checkpoint;
+
+    @JsonCreator
+    public TablePssCheckpoint(
+        @JsonProperty("writtenOffset") final Optional<Long> writtenOffset,
+        @JsonProperty("checkpoint") final PssCheckpoint checkpoint
+    ) {
+      this.writtenOffset = Objects.requireNonNull(writtenOffset);
+      this.checkpoint = Objects.requireNonNull(checkpoint);
+    }
+
+    @JsonProperty("writtenOffset")
+    public Optional<Long> writtenOffset() {
+      return writtenOffset;
+    }
+
+    @JsonProperty("checkpoint")
+    public PssCheckpoint checkpoint() {
+      return checkpoint;
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof TablePssCheckpoint)) {
+        return false;
+      }
+      final TablePssCheckpoint that = (TablePssCheckpoint) o;
+      return Objects.equals(writtenOffset, that.writtenOffset)
+          && Objects.equals(checkpoint, that.checkpoint);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(writtenOffset, checkpoint);
+    }
+  }
+
+  public static byte[] serialize(TableCheckpoint tableCheckpoint) {
+    try {
+      return MAPPER.writeValueAsBytes(tableCheckpoint);
+    } catch (final IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static TableCheckpoint deserialize(byte[] serialized) {
+    try {
+      return MAPPER.readValue(serialized, TableCheckpoint.class);
+    } catch (final IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/rs3/TableCheckpoint.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/rs3/TableCheckpoint.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
 import dev.responsive.kafka.internal.db.rs3.client.PssCheckpoint;
 import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -88,6 +89,11 @@ public class TableCheckpoint {
     public int hashCode() {
       return Objects.hash(writtenOffset, checkpoint);
     }
+  }
+
+  @Override
+  public String toString() {
+    return new String(TableCheckpoint.serialize(this), Charset.defaultCharset());
   }
 
   public static byte[] serialize(TableCheckpoint tableCheckpoint) {

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/rs3/client/LssId.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/rs3/client/LssId.java
@@ -41,4 +41,9 @@ public class LssId {
   public int hashCode() {
     return Objects.hashCode(id);
   }
+
+  @Override
+  public String toString() {
+    return "LssId{" + "id=" + id + '}';
+  }
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/rs3/client/MeteredRS3Client.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/rs3/client/MeteredRS3Client.java
@@ -168,6 +168,15 @@ public class MeteredRS3Client implements RS3Client {
     return delegate.createStore(storeName, options);
   }
 
+  @Override
+  public PssCheckpoint createCheckpoint(
+      final UUID storeId,
+      final LssId lssId,
+      final int pssId,
+      final Optional<Long> expectedWrittenOffset) {
+    return delegate.createCheckpoint(storeId, lssId, pssId, expectedWrittenOffset);
+  }
+
   public void close() {
     this.metrics.removeSensor(GET_SENSOR_NAME);
   }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/rs3/client/PssCheckpoint.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/rs3/client/PssCheckpoint.java
@@ -1,0 +1,175 @@
+package dev.responsive.kafka.internal.db.rs3.client;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import java.util.Objects;
+import java.util.UUID;
+
+public class PssCheckpoint {
+  private final UUID storeId;
+  private final int pssId;
+  private final StorageCheckpoint checkpoint;
+
+  @JsonCreator
+  public PssCheckpoint(
+      @JsonProperty("storeId") final UUID storeId,
+      @JsonProperty("pssId") final int pssId,
+      @JsonProperty("checkpoint") StorageCheckpoint checkpoint,
+      @JsonProperty("slateDbStorageCheckpoint")
+      final SlateDbStorageCheckpoint slateDbStorageCheckpoint
+  ) {
+    this.storeId = Objects.requireNonNull(storeId);
+    this.pssId = pssId;
+    if (slateDbStorageCheckpoint != null) {
+      this.checkpoint = slateDbStorageCheckpoint;
+    } else {
+      this.checkpoint = Objects.requireNonNull(checkpoint);
+    }
+  }
+
+  @JsonProperty("storeId")
+  public UUID getStoreId() {
+    return storeId;
+  }
+
+  @JsonProperty("pssId")
+  public int pssId() {
+    return pssId;
+  }
+
+  @JsonProperty("checkpoint")
+  public StorageCheckpoint checkpoint() {
+    return checkpoint;
+  }
+
+  @Override
+  public boolean equals(final Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof PssCheckpoint)) {
+      return false;
+    }
+    final PssCheckpoint that = (PssCheckpoint) o;
+    return Objects.equals(storeId, that.storeId)
+        && pssId == that.pssId
+        && Objects.equals(checkpoint, that.checkpoint);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(storeId, pssId, checkpoint);
+  }
+
+  public static final String SLATEDB_STORAGE_TYPE = "SlateDbStorage";
+
+  @JsonTypeInfo(
+      use = JsonTypeInfo.Id.NAME,
+      include = JsonTypeInfo.As.EXISTING_PROPERTY,
+      property = "type",
+      visible = true,
+      defaultImpl = SlateDbStorageCheckpoint.class
+  )
+  @JsonSubTypes({
+      @JsonSubTypes.Type(value = SlateDbStorageCheckpoint.class, name = SLATEDB_STORAGE_TYPE)
+  })
+  public abstract static class StorageCheckpoint {
+    private final String type;
+
+    StorageCheckpoint(final String type) {
+      this.type = type;
+    }
+
+    @JsonProperty("type")
+    public String type() {
+      return type;
+    }
+
+    public abstract void visit(CheckpointVisitor visitor);
+
+    public abstract <T> T map(CheckpointMapper<T> mapper);
+  }
+
+  public interface CheckpointVisitor {
+    void visit(SlateDbStorageCheckpoint checkpoint);
+  }
+
+  public interface CheckpointMapper<T> {
+    T map(SlateDbStorageCheckpoint checkpoint);
+  }
+
+  public static class SlateDbStorageCheckpoint extends StorageCheckpoint {
+    private final String path;
+    private final UUID checkpointId;
+
+    @JsonCreator
+    public SlateDbStorageCheckpoint(
+        @JsonProperty("type") final String type,
+        @JsonProperty("path") final String path,
+        @JsonProperty("checkpointId") final UUID checkpointId
+    ) {
+      super(type);
+      this.path = path;
+      this.checkpointId = checkpointId;
+    }
+
+    public SlateDbStorageCheckpoint(
+        @JsonProperty("path") final String path,
+        @JsonProperty("checkpointId") final UUID checkpointId
+    ) {
+      super(SLATEDB_STORAGE_TYPE);
+      this.path = path;
+      this.checkpointId = checkpointId;
+    }
+
+    @JsonProperty("path")
+    public String path() {
+      return path;
+    }
+
+    @JsonProperty("checkpointId")
+    public UUID checkpointId() {
+      return checkpointId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof SlateDbStorageCheckpoint)) {
+        return false;
+      }
+      final SlateDbStorageCheckpoint that = (SlateDbStorageCheckpoint) o;
+      return Objects.equals(path, that.path)
+          && Objects.deepEquals(checkpointId, that.checkpointId);
+    }
+
+    @Override
+    public void visit(final CheckpointVisitor visitor) {
+      visitor.visit(this);
+    }
+
+    @Override
+    public <T> T map(final CheckpointMapper<T> mapper) {
+      return mapper.map(this);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(path, checkpointId);
+    }
+
+    @Override
+    public String toString() {
+      return "SlateDbStorageCheckpoint{"
+          + "path='" + path + '\''
+          + ", checkpointId=" + checkpointId
+          + '}';
+    }
+  }
+
+
+}

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/rs3/client/RS3Client.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/rs3/client/RS3Client.java
@@ -80,5 +80,12 @@ public interface RS3Client {
       CreateStoreOptions options
   );
 
+  PssCheckpoint createCheckpoint(
+      UUID storeId,
+      LssId lssId,
+      int pssId,
+      Optional<Long> expectedWrittenOffset
+  );
+
   void close();
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/rs3/client/grpc/GrpcRS3Client.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/rs3/client/grpc/GrpcRS3Client.java
@@ -14,14 +14,14 @@ package dev.responsive.kafka.internal.db.rs3.client.grpc;
 
 import static dev.responsive.kafka.internal.db.rs3.client.grpc.GrpcRs3Util.basicKeyProto;
 import static dev.responsive.kafka.internal.db.rs3.client.grpc.GrpcRs3Util.checkField;
+import static dev.responsive.kafka.internal.db.rs3.client.grpc.GrpcRs3Util.lssIdProto;
 import static dev.responsive.kafka.internal.db.rs3.client.grpc.GrpcRs3Util.storeStatusFromProto;
 import static dev.responsive.kafka.internal.db.rs3.client.grpc.GrpcRs3Util.storeTypeFromProto;
+import static dev.responsive.kafka.internal.db.rs3.client.grpc.GrpcRs3Util.uuidFromProto;
+import static dev.responsive.kafka.internal.db.rs3.client.grpc.GrpcRs3Util.uuidToProto;
 import static dev.responsive.kafka.internal.db.rs3.client.grpc.GrpcRs3Util.walOffsetFromProto;
 import static dev.responsive.kafka.internal.db.rs3.client.grpc.GrpcRs3Util.walOffsetProto;
 import static dev.responsive.kafka.internal.db.rs3.client.grpc.GrpcRs3Util.windowKeyProto;
-import static dev.responsive.kafka.internal.utils.Utils.lssIdProto;
-import static dev.responsive.kafka.internal.utils.Utils.uuidFromProto;
-import static dev.responsive.kafka.internal.utils.Utils.uuidToProto;
 
 import com.google.common.annotations.VisibleForTesting;
 import dev.responsive.kafka.api.config.ResponsiveConfig;

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/rs3/client/grpc/GrpcRS3Client.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/rs3/client/grpc/GrpcRS3Client.java
@@ -405,11 +405,14 @@ public class GrpcRS3Client implements RS3Client {
         .build();
     final RS3Grpc.RS3BlockingStub stub = stubs.stubs(storeId, pssId).syncStub();
     final Rs3.CreateCheckpointResult result;
-    try {
-      result = stub.createCheckpoint(request);
-    } catch (final RuntimeException e) {
-      throw GrpcRs3Util.wrapThrowable(e);
-    }
+    result = withRetry(
+        () -> stub.createCheckpoint(request),
+        () -> String.format("CreateCheckpoint(storeId=%s, lssId=%s, pssId=%d",
+            storeId.toString(),
+            lssId,
+            pssId
+        )
+    );
     checkField(result::hasCheckpoint, "checkpoint");
     return GrpcRs3Util.pssCheckpointFromProto(storeId, pssId, result.getCheckpoint());
   }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/rs3/client/grpc/GrpcRs3Util.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/rs3/client/grpc/GrpcRs3Util.java
@@ -15,6 +15,7 @@ package dev.responsive.kafka.internal.db.rs3.client.grpc;
 import com.google.protobuf.ByteString;
 import dev.responsive.kafka.internal.db.rs3.client.CreateStoreTypes;
 import dev.responsive.kafka.internal.db.rs3.client.Delete;
+import dev.responsive.kafka.internal.db.rs3.client.LssId;
 import dev.responsive.kafka.internal.db.rs3.client.PssCheckpoint;
 import dev.responsive.kafka.internal.db.rs3.client.Put;
 import dev.responsive.kafka.internal.db.rs3.client.RS3Exception;
@@ -211,6 +212,13 @@ public class GrpcRs3Util {
     return new UUID(uuidProto.getHigh(), uuidProto.getLow());
   }
 
+  public static Rs3.UUID uuidToProto(final UUID uuid) {
+    return Rs3.UUID.newBuilder()
+        .setHigh(uuid.getMostSignificantBits())
+        .setLow(uuid.getLeastSignificantBits())
+        .build();
+  }
+
   public static PssCheckpoint pssCheckpointFromProto(
       final UUID storeId,
       final int pssId,
@@ -225,6 +233,12 @@ public class GrpcRs3Util {
         uuidFromProto(slateDbCheckpointProto.getCheckpointId())
     );
     return new PssCheckpoint(storeId, pssId, slateDbCheckpoint, null);
+  }
+
+  public static Rs3.LSSId lssIdProto(final LssId lssId) {
+    return Rs3.LSSId.newBuilder()
+        .setId(lssId.id())
+        .build();
   }
 
   public static void checkField(final Supplier<Boolean> check, final String field) {

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/utils/Utils.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/utils/Utils.java
@@ -12,9 +12,6 @@
 
 package dev.responsive.kafka.internal.utils;
 
-import dev.responsive.kafka.internal.db.rs3.client.LssId;
-import dev.responsive.rs3.Rs3;
-import java.util.UUID;
 import java.util.regex.Pattern;
 import org.apache.kafka.common.utils.Bytes;
 import org.slf4j.Logger;
@@ -128,22 +125,5 @@ public final class Utils {
     } catch (final IndexOutOfBoundsException e) {
       return null;
     }
-  }
-
-  public static UUID uuidFromProto(final Rs3.UUID uuid) {
-    return new UUID(uuid.getHigh(), uuid.getLow());
-  }
-
-  public static Rs3.UUID uuidToProto(final UUID uuid) {
-    return Rs3.UUID.newBuilder()
-        .setHigh(uuid.getMostSignificantBits())
-        .setLow(uuid.getLeastSignificantBits())
-        .build();
-  }
-
-  public static Rs3.LSSId lssIdProto(final LssId lssId) {
-    return Rs3.LSSId.newBuilder()
-        .setId(lssId.id())
-        .build();
   }
 }

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/rs3/TableCheckpointTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/rs3/TableCheckpointTest.java
@@ -1,0 +1,56 @@
+package dev.responsive.kafka.internal.db.rs3;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import dev.responsive.kafka.internal.db.rs3.client.PssCheckpoint;
+import java.nio.charset.Charset;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+class TableCheckpointTest {
+
+  @Test
+  public void shouldSerializeTableCheckpoint() {
+    // given:
+    final var storeId = UUID.randomUUID();
+    final TableCheckpoint checkpoint = new TableCheckpoint(
+        List.of(
+            new TableCheckpoint.TablePssCheckpoint(
+                Optional.of(123L),
+                new PssCheckpoint(
+                    storeId,
+                    10,
+                    new PssCheckpoint.SlateDbStorageCheckpoint(
+                        "/foo/bar/10",
+                        UUID.randomUUID()
+                    ),
+                    null
+                )
+            ),
+            new TableCheckpoint.TablePssCheckpoint(
+                Optional.empty(),
+                new PssCheckpoint(
+                    storeId,
+                    11,
+                    new PssCheckpoint.SlateDbStorageCheckpoint(
+                        "/foo/bar/11",
+                        UUID.randomUUID()
+                    ),
+                    null
+                )
+            )
+        )
+    );
+
+    // when:
+    final byte[] serialized = TableCheckpoint.serialize(checkpoint);
+    System.out.println(new String(serialized, Charset.defaultCharset()));
+
+    // then:
+    final TableCheckpoint deserialized = TableCheckpoint.deserialize(serialized);
+    assertThat(deserialized, is(checkpoint));
+  }
+}

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/rs3/client/grpc/GrpcRS3ClientTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/rs3/client/grpc/GrpcRS3ClientTest.java
@@ -14,10 +14,10 @@ package dev.responsive.kafka.internal.db.rs3.client.grpc;
 
 import static dev.responsive.kafka.internal.db.rs3.client.grpc.GrpcRs3Util.basicPutProto;
 import static dev.responsive.kafka.internal.db.rs3.client.grpc.GrpcRs3Util.createStoreOptionsProto;
+import static dev.responsive.kafka.internal.db.rs3.client.grpc.GrpcRs3Util.lssIdProto;
+import static dev.responsive.kafka.internal.db.rs3.client.grpc.GrpcRs3Util.uuidToProto;
 import static dev.responsive.kafka.internal.db.rs3.client.grpc.GrpcRs3Util.walOffsetProto;
 import static dev.responsive.kafka.internal.db.rs3.client.grpc.GrpsRs3TestUtil.newEndOfStreamResult;
-import static dev.responsive.kafka.internal.utils.Utils.lssIdProto;
-import static dev.responsive.kafka.internal.utils.Utils.uuidToProto;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/rs3/client/grpc/GrpcRS3ClientTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/rs3/client/grpc/GrpcRS3ClientTest.java
@@ -14,6 +14,7 @@ package dev.responsive.kafka.internal.db.rs3.client.grpc;
 
 import static dev.responsive.kafka.internal.db.rs3.client.grpc.GrpcRs3Util.basicPutProto;
 import static dev.responsive.kafka.internal.db.rs3.client.grpc.GrpcRs3Util.createStoreOptionsProto;
+import static dev.responsive.kafka.internal.db.rs3.client.grpc.GrpcRs3Util.walOffsetProto;
 import static dev.responsive.kafka.internal.db.rs3.client.grpc.GrpsRs3TestUtil.newEndOfStreamResult;
 import static dev.responsive.kafka.internal.utils.Utils.lssIdProto;
 import static dev.responsive.kafka.internal.utils.Utils.uuidToProto;
@@ -38,6 +39,7 @@ import dev.responsive.kafka.internal.db.rs3.client.CreateStoreTypes.ClockType;
 import dev.responsive.kafka.internal.db.rs3.client.CreateStoreTypes.CreateStoreOptions;
 import dev.responsive.kafka.internal.db.rs3.client.CreateStoreTypes.StoreType;
 import dev.responsive.kafka.internal.db.rs3.client.LssId;
+import dev.responsive.kafka.internal.db.rs3.client.PssCheckpoint;
 import dev.responsive.kafka.internal.db.rs3.client.Put;
 import dev.responsive.kafka.internal.db.rs3.client.RS3Exception;
 import dev.responsive.kafka.internal.db.rs3.client.RS3TimeoutException;
@@ -1250,6 +1252,43 @@ class GrpcRS3ClientTest {
           is(Status.Code.UNKNOWN)
       );
     }
+  }
+
+  @Test
+  public void shouldCreateCheckpoint() {
+    final var checkpointId = UUID.randomUUID();
+    final var checkpointPath = "/some/checkpoint/path";
+    final var storageCheckpoint = Rs3.StorageCheckpoint.newBuilder().setSlatedbStorageCheckpoint(
+        Rs3.SlateDbStorageCheckpoint
+            .newBuilder()
+            .setCheckpointId(uuidToProto(checkpointId))
+            .setPath(checkpointPath)
+            .build()
+    );
+    when(stub.createCheckpoint(any()))
+        .thenReturn(Rs3.CreateCheckpointResult
+            .newBuilder()
+            .setCheckpoint(storageCheckpoint)
+            .build());
+
+    final var checkpoint = client.createCheckpoint(
+        STORE_ID,
+        LSS_ID,
+        PSS_ID,
+        Optional.of(10L)
+    ).checkpoint();
+
+    assertThat(
+        checkpoint.map(PssCheckpoint.SlateDbStorageCheckpoint::checkpointId), is(checkpointId));
+    assertThat(checkpoint.map(PssCheckpoint.SlateDbStorageCheckpoint::path), is(checkpointPath));
+
+    verify(stub).createCheckpoint(
+        Rs3.CreateCheckpointRequest
+            .newBuilder()
+            .setLssId(lssIdProto(LSS_ID))
+            .setExpectedWrittenOffset(walOffsetProto(10))
+            .build()
+    );
   }
 
   private StreamObserver<Rs3.WriteWALSegmentResult> verifyWalSegmentResultObserver() {

--- a/responsive-test-utils/src/main/java/dev/responsive/kafka/internal/clients/TTDCassandraClient.java
+++ b/responsive-test-utils/src/main/java/dev/responsive/kafka/internal/clients/TTDCassandraClient.java
@@ -71,7 +71,7 @@ public class TTDCassandraClient extends CassandraClient {
   }
 
   public void flush() {
-    storeRegistry.stores().forEach(s -> s.onCommit().accept(0L));
+    storeRegistry.stores().forEach(s -> s.callbacks().notifyCommit(0L));
   }
 
   @Override


### PR DESCRIPTION
This patch adds wiring for taking checkpoints from ResponsiveKafkaStreams
- We implement the rs3 grpc client apis for taking checkpoints using the rs3 client
- The rs3 grpc client returns a `PssCheckpoint`, which the kv table aggregates into a `TableCheckpoint`. This type is then serialized and returned by `KVTable.checkpoint`
- `ResponsiveStoreRegistry` is extended to support taking checkpoints from registered stores