### PR TITLE
Window stores should use stream time

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/rs3/RS3TableFactory.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/rs3/RS3TableFactory.java
@@ -113,7 +113,7 @@ public class RS3TableFactory {
     final UUID storeId = createdStores.computeIfAbsent(storeName, n -> createStore(
         storeName,
         CreateStoreTypes.StoreType.WINDOW,
-        Optional.of(ClockType.WALL_CLOCK),
+        Optional.of(ClockType.STREAM_TIME),
         Optional.of(defaultTtl),
         Optional.of(storageOptions),
         computeNumKafkaPartitions.get(),

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/db/rs3/RS3TableFactoryTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/db/rs3/RS3TableFactoryTest.java
@@ -163,7 +163,7 @@ class RS3TableFactoryTest {
     final var expectedOptions = new CreateStoreOptions(
         partitions,
         CreateStoreTypes.StoreType.WINDOW,
-        Optional.of(CreateStoreTypes.ClockType.WALL_CLOCK),
+        Optional.of(CreateStoreTypes.ClockType.STREAM_TIME),
         Optional.of(defaultTtl.toMillis()),
         expectedStorageOptions
     );


### PR DESCRIPTION
We used `WALL_CLOCK ` initially because rs3 didn't support stream time. Then I forgot to change it back after we finished implementing on the server.