### PR TITLE
Fix off-by-one error in written offset callback

### DIFF
--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/StoreCommitListener.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/clients/StoreCommitListener.java
@@ -41,6 +41,7 @@ public class StoreCommitListener {
       final TopicPartition p = e.getKey().getPartition();
       for (final ResponsiveStoreRegistration storeRegistration
           : storeRegistry.getRegisteredStoresForChangelog(p, threadId)) {
+        // Committed offsets are already exclusive (one more than last consumed offset)
         storeRegistration.callbacks().notifyCommit(e.getValue());
       }
     }
@@ -48,7 +49,8 @@ public class StoreCommitListener {
       final TopicPartition p = e.getKey();
       for (final ResponsiveStoreRegistration storeRegistration
           : storeRegistry.getRegisteredStoresForChangelog(p, threadId)) {
-        storeRegistration.callbacks().notifyCommit(e.getValue());
+        // Add one since the written offset is inclusive
+        storeRegistration.callbacks().notifyCommit(e.getValue() + 1);
       }
     }
   }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/db/RemoteTable.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/db/RemoteTable.java
@@ -62,11 +62,12 @@ public interface RemoteTable<K, S> {
 
   /**
    * Get the offset corresponding to the last write to the table for a specific
-   * Kafka partition.
+   * Kafka partition. This offset is exclusive (one more than the offset of
+   * the last processed record).
    *
    * @param kafkaPartition the kafka partition
-   * @return the current offset fetched from the metadata table
-   *         partition for the given kafka partition
+   * @return the last written offset (exclusive) from the table for
+   *   the given kafka partition
    */
   long lastWrittenOffset(final int kafkaPartition);
 }

--- a/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/CommitBuffer.java
+++ b/kafka-client/src/main/java/dev/responsive/kafka/internal/stores/CommitBuffer.java
@@ -449,17 +449,17 @@ public class CommitBuffer<K extends Comparable<K>, P> implements Closeable {
       streamTimeMs = Math.max(streamTimeMs, r.timestamp());
       batch.add(r);
       if (batch.size() >= maxBatchSize) {
-        restoreCassandraBatch(batch);
+        writeBatch(batch);
         batch.clear();
       }
     }
     if (batch.size() > 0) {
-      restoreCassandraBatch(batch);
+      writeBatch(batch);
     }
     return streamTimeMs;
   }
 
-  private void restoreCassandraBatch(final Collection<ConsumerRecord<byte[], byte[]>> records) {
+  private void writeBatch(final Collection<ConsumerRecord<byte[], byte[]>> records) {
     long consumedOffset = -1L;
     for (ConsumerRecord<byte[], byte[]> record : records) {
       consumedOffset = record.offset();
@@ -471,7 +471,7 @@ public class CommitBuffer<K extends Comparable<K>, P> implements Closeable {
     }
 
     if (consumedOffset >= 0) {
-      doFlush(consumedOffset, records.size());
+      doFlush(consumedOffset + 1, records.size());
     }
   }
 

--- a/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveKeyValueStoreRestoreIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveKeyValueStoreRestoreIntegrationTest.java
@@ -260,11 +260,9 @@ public class ResponsiveKeyValueStoreRestoreIntegrationTest {
     }
   }
 
-//  @ParameterizedTest
-//  @EnumSource(KVSchema.class)
-  @Test
-  public void shouldRestoreUnflushedChangelog() throws Exception {
-    final KVSchema type = KVSchema.KEY_VALUE;
+  @ParameterizedTest
+  @EnumSource(KVSchema.class)
+  public void shouldRestoreUnflushedChangelog(final KVSchema type) throws Exception {
     final Map<String, Object> properties = getMutableProperties(type);
     final KafkaProducer<Long, Long> producer = new KafkaProducer<>(properties);
     final KafkaClientSupplier defaultClientSupplier = new DefaultKafkaClientSupplier();

--- a/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveKeyValueStoreRestoreIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveKeyValueStoreRestoreIntegrationTest.java
@@ -313,7 +313,6 @@ public class ResponsiveKeyValueStoreRestoreIntegrationTest {
     final long remoteOffset = changelogTable.lastWrittenOffset(0);
     assertThat(remoteOffset, greaterThan(0L));
     final long changelogEndOffset = IntegrationTestUtils.endOffset(admin, changelog);
-    LoggerFactory.getLogger(getClass()).info("Last offset for {} is {}", changelog, changelogEndOffset);
     assertThat(remoteOffset, lessThan(changelogEndOffset));
 
     // Restart with restore recorder

--- a/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveKeyValueStoreRestoreIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveKeyValueStoreRestoreIntegrationTest.java
@@ -46,9 +46,7 @@ import static org.mockito.Mockito.spy;
 
 import com.datastax.oss.driver.api.core.CqlSession;
 import com.datastax.oss.driver.api.core.cql.BatchStatement;
-import com.datastax.oss.driver.api.core.cql.BoundStatement;
 import com.datastax.oss.driver.api.core.cql.Statement;
-import com.datastax.oss.driver.internal.core.cql.DefaultBoundStatement;
 import dev.responsive.kafka.api.ResponsiveKafkaStreams;
 import dev.responsive.kafka.api.config.ResponsiveConfig;
 import dev.responsive.kafka.api.config.StorageBackend;
@@ -291,7 +289,7 @@ public class ResponsiveKeyValueStoreRestoreIntegrationTest {
     // restart with fault injecting cassandra client
     final FaultInjectingCassandraClientSupplier cassandraFaultInjector
         = new FaultInjectingCassandraClientSupplier();
-q    try (final ResponsiveKafkaStreams streams
+    try (final ResponsiveKafkaStreams streams
              = buildAggregatorApp(
                  properties, defaultClientSupplier, cassandraFaultInjector, type)) {
       IntegrationTestUtils.startAppAndAwaitRunning(Duration.ofSeconds(10), streams);

--- a/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveKeyValueStoreRestoreIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveKeyValueStoreRestoreIntegrationTest.java
@@ -12,7 +12,6 @@
 
 package dev.responsive.kafka.integration;
 
-import static dev.responsive.kafka.api.config.ResponsiveConfig.MONGO_CONNECTION_STRING_CONFIG;
 import static dev.responsive.kafka.testutils.IntegrationTestUtils.getCassandraValidName;
 import static dev.responsive.kafka.testutils.IntegrationTestUtils.pipeInput;
 import static dev.responsive.kafka.testutils.IntegrationTestUtils.slurpPartition;
@@ -57,14 +56,12 @@ import dev.responsive.kafka.internal.db.CassandraClient;
 import dev.responsive.kafka.internal.db.CassandraClientFactory;
 import dev.responsive.kafka.internal.db.DefaultCassandraClientFactory;
 import dev.responsive.kafka.internal.db.RemoteKVTable;
-import dev.responsive.kafka.internal.db.mongo.CollectionCreationOptions;
-import dev.responsive.kafka.internal.db.mongo.MongoKVTable;
+import dev.responsive.kafka.internal.db.partitioning.SubPartitioner;
 import dev.responsive.kafka.internal.db.partitioning.TablePartitioner;
 import dev.responsive.kafka.internal.db.spec.DefaultTableSpec;
 import dev.responsive.kafka.internal.metrics.ResponsiveMetrics;
 import dev.responsive.kafka.internal.stores.SchemaTypes.KVSchema;
 import dev.responsive.kafka.internal.stores.TtlResolver;
-import dev.responsive.kafka.internal.utils.SessionUtil;
 import dev.responsive.kafka.testutils.IntegrationTestUtils;
 import dev.responsive.kafka.testutils.IntegrationTestUtils.MockResponsiveKafkaStreams;
 import dev.responsive.kafka.testutils.ResponsiveConfigParam;
@@ -75,6 +72,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 import java.util.Properties;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedQueue;
@@ -107,10 +105,12 @@ import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.slf4j.LoggerFactory;
 
 public class ResponsiveKeyValueStoreRestoreIntegrationTest {
 
@@ -185,7 +185,8 @@ public class ResponsiveKeyValueStoreRestoreIntegrationTest {
       final List<ConsumerRecord<Long, Long>> changelogRecords
           = slurpPartition(changelog, properties);
       final long last = changelogRecords.get(changelogRecords.size() - 1).offset();
-      assertThat(cassandraOffset, equalTo(last));
+      // Written offset is exclusive
+      assertThat(cassandraOffset, equalTo(last + 1));
     }
   }
 
@@ -259,9 +260,11 @@ public class ResponsiveKeyValueStoreRestoreIntegrationTest {
     }
   }
 
-  @ParameterizedTest
-  @EnumSource(KVSchema.class)
-  public void shouldRestoreUnflushedChangelog(final KVSchema type) throws Exception {
+//  @ParameterizedTest
+//  @EnumSource(KVSchema.class)
+  @Test
+  public void shouldRestoreUnflushedChangelog() throws Exception {
+    final KVSchema type = KVSchema.KEY_VALUE;
     final Map<String, Object> properties = getMutableProperties(type);
     final KafkaProducer<Long, Long> producer = new KafkaProducer<>(properties);
     final KafkaClientSupplier defaultClientSupplier = new DefaultKafkaClientSupplier();
@@ -279,6 +282,12 @@ public class ResponsiveKeyValueStoreRestoreIntegrationTest {
       // Wait for it to be processed
       waitTillFullyConsumed(admin, input, name, Duration.ofSeconds(120));
     }
+
+    final TopicPartition changelog = new TopicPartition(name + "-" + aggName() + "-changelog", 0);
+    final ResponsiveConfig config = ResponsiveConfig.responsiveConfig(properties);
+
+    final RemoteKVTable<?> changelogTable = remoteKVTable(type, defaultFactory, config, changelog);
+    assertThat(changelogTable.lastWrittenOffset(0), greaterThan(0L));
 
     // restart with fault injecting cassandra client
     final FaultInjectingCassandraClientSupplier cassandraFaultInjector
@@ -299,22 +308,13 @@ public class ResponsiveKeyValueStoreRestoreIntegrationTest {
       IntegrationTestUtils
           .waitTillConsumedPast(admin, input, name, endInput + 1, Duration.ofSeconds(30));
     }
-    final TopicPartition changelog = new TopicPartition(name + "-" + aggName() + "-changelog", 0);
 
     // Make sure changelog is ahead of remote
-    final ResponsiveConfig config = ResponsiveConfig.responsiveConfig(properties);
-    final RemoteKVTable<?> table;
-
-    table = remoteKVTable(type, defaultFactory, config, changelog);
-
-    final long remoteOffset = table.lastWrittenOffset(0);
+    final long remoteOffset = changelogTable.lastWrittenOffset(0);
     assertThat(remoteOffset, greaterThan(0L));
-
-    final long changelogOffset = admin.listOffsets(Map.of(changelog, OffsetSpec.latest())).all()
-        .get()
-        .get(changelog)
-        .offset();
-    assertThat(remoteOffset, lessThan(changelogOffset));
+    final long changelogEndOffset = IntegrationTestUtils.endOffset(admin, changelog);
+    LoggerFactory.getLogger(getClass()).info("Last offset for {} is {}", changelog, changelogEndOffset);
+    assertThat(remoteOffset, lessThan(changelogEndOffset));
 
     // Restart with restore recorder
     final TestKafkaClientSupplier recordingClientSupplier = new TestKafkaClientSupplier();
@@ -351,11 +351,11 @@ public class ResponsiveKeyValueStoreRestoreIntegrationTest {
   ) throws InterruptedException, TimeoutException {
     final RemoteKVTable<?> table;
 
-    if (type == KVSchema.FACT) {
-      final CassandraClient cassandraClient = defaultFactory.createClient(
-          defaultFactory.createCqlSession(config, null),
-          config);
+    final CassandraClient cassandraClient = defaultFactory.createClient(
+        defaultFactory.createCqlSession(config, null),
+        config);
 
+    if (type == KVSchema.FACT) {
       table = cassandraClient.factFactory()
           .create(new DefaultTableSpec(
               aggName(),
@@ -363,18 +363,21 @@ public class ResponsiveKeyValueStoreRestoreIntegrationTest {
               TtlResolver.NO_TTL,
               config
           ));
-
     } else if (type == KVSchema.KEY_VALUE) {
-      final var connectionString = config.getPassword(MONGO_CONNECTION_STRING_CONFIG).value();
-      final var mongoClient = SessionUtil.connect(connectionString, "", null);
-      table = new MongoKVTable(
-          mongoClient,
+      final SubPartitioner partitioner = SubPartitioner.create(
+          OptionalInt.empty(),
+          NUM_PARTITIONS,
           aggName(),
-          CollectionCreationOptions.fromConfig(config),
-          TtlResolver.NO_TTL,
-          config
+          config,
+          changelog.topic()
       );
-      table.init(0);
+      table = cassandraClient.kvFactory()
+          .create(new DefaultTableSpec(
+              aggName(),
+              partitioner,
+              TtlResolver.NO_TTL,
+              config
+          ));
     } else {
       throw new IllegalArgumentException("Unsupported type: " + type);
     }
@@ -537,14 +540,7 @@ public class ResponsiveKeyValueStoreRestoreIntegrationTest {
   private Map<String, Object> getMutableProperties(final KVSchema type) {
     final Map<String, Object> properties = new HashMap<>(responsiveProps);
 
-    if (type == KVSchema.FACT) {
-      properties.put(ResponsiveConfig.STORAGE_BACKEND_TYPE_CONFIG, StorageBackend.CASSANDRA.name());
-    } else if (type == KVSchema.KEY_VALUE) {
-      properties.put(ResponsiveConfig.STORAGE_BACKEND_TYPE_CONFIG, StorageBackend.MONGO_DB.name());
-    } else {
-      throw new IllegalArgumentException("Unexpected schema type: " + type.name());
-    }
-
+    properties.put(ResponsiveConfig.STORAGE_BACKEND_TYPE_CONFIG, StorageBackend.CASSANDRA.name());
     properties.put(KEY_SERIALIZER_CLASS_CONFIG, LongSerializer.class);
     properties.put(VALUE_SERIALIZER_CLASS_CONFIG, LongSerializer.class);
     properties.put(KEY_DESERIALIZER_CLASS_CONFIG, LongDeserializer.class);

--- a/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveKeyValueStoreRestoreIntegrationTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/integration/ResponsiveKeyValueStoreRestoreIntegrationTest.java
@@ -105,12 +105,10 @@ import org.apache.kafka.streams.kstream.KTable;
 import org.apache.kafka.streams.processor.internals.DefaultKafkaClientSupplier;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
-import org.slf4j.LoggerFactory;
 
 public class ResponsiveKeyValueStoreRestoreIntegrationTest {
 

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/clients/StoreCommitListenerTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/clients/StoreCommitListenerTest.java
@@ -78,7 +78,7 @@ class StoreCommitListenerTest {
     sendWrittenOffsets(Map.of(PARTITION2, 456L));
 
     // then:
-    verify(store2Callbacks).notifyCommit(456L);
+    verify(store2Callbacks).notifyCommit(457L);
     verifyNoInteractions(store1Callbacks);
   }
 

--- a/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/CommitBufferTest.java
+++ b/kafka-client/src/test/java/dev/responsive/kafka/internal/stores/CommitBufferTest.java
@@ -613,7 +613,7 @@ public class CommitBufferTest {
       buffer.restoreBatch(List.of(record), -1L);
 
       // Then:
-      assertThat(table.lastWrittenOffset(KAFKA_PARTITION), is(100L));
+      assertThat(table.lastWrittenOffset(KAFKA_PARTITION), is(101L));
       final byte[] value = table.get(KAFKA_PARTITION, KEY, MIN_VALID_TS);
       assertThat(value, is(VALUE));
     }
@@ -657,7 +657,7 @@ public class CommitBufferTest {
     // Then:
     final String errorMsg = "commit-buffer [" + tableName.tableName() + "-2] "
         + "Failed table partition [8]: "
-        + "<batchOffset=100, persistedOffset=-1>, "
+        + "<batchOffset=101, persistedOffset=-1>, "
         + "<localEpoch=1, persistedEpoch=2>";
     assertThat(e.getMessage(), equalTo(errorMsg));
   }


### PR DESCRIPTION
We use two paths to find the committed offset sent through `BatchFlusher.flushWriteBatch`. One of them is through the offset committed through the consumer, and the other is through the producer's send callback. In the first case, the offset we forward through is exclusive (one more than the last consumed record). In the second, it is inclusive (matches the offset of the last written record). 

Later when we are restoring in `ResponsiveRestoreConsumer`, we seek to the last committed offset in the remote store. This is correct in the case of the exclusive consumer committed offset. However, for the inclusive produced offset, we would replay the last written record. This is probably not a big deal for most stores, but RS3 has strict offset validation. If we are just replaying a single record, then we would send an expected written offset which exactly matches the (inclusive) offset of the record. This leads to an `IllegalWalSegment` error from RS3. 

You can see this chain of events from the following logs captured from the window soak:

```
// Recover last committed offset 8663
[2025-05-16 20:09:00,115] INFO Restore RS3 table from offset 8663 for LssId{id=4}. recorded written offsets: 4 -> 8663 (dev.responsive.kafka.internal.db.rs3.client.RS3ClientUtil:65)

// Find range of offsets to recover (8663 to 8665)
[2025-05-16 20:09:00,377] INFO Beginning restoration from offset 8663 to 8665 at 1747426140377ms (epoch time) for partition rs3-window-aggregator-dev-agg-window-store-changelog-4 of state store agg-window-store (dev.responsive.kafka.internal.metrics.ResponsiveRestoreLis\
tener:110)

// Seek to last committed offset 8663
[2025-05-16 20:09:00,377] INFO [Consumer clientId=rs3-window-aggregator-dev-cbf2b455-b7db-4e42-bbfa-0cee71b34d56-StreamThread-1-restore-consumer, groupId=null] Seeking to offset 8663 for partition rs3-window-aggregator-dev-agg-window-store-changelog-4 (org.apache.kafka.clients.consumer.internals.ClassicKafkaConsumer:784)


// Flush exactly one record at offset 8663
[2025-05-16 20:09:00,589] INFO commit-buffer [agg_window_store-4] Flushing 1 records with batchSize=1 to remote (offset=8663, writer=dev.responsive.kafka.internal.db.BatchFlusher@4c92229f) (dev.responsive.kafka.internal.stores.CommitBuffer:399)

// RS3 returns `IllegalWalSegment`
[2025-05-16 20:09:00,702] ERROR Hit StreamsException on task Optional.empty (dev.responsive.soak.Main:362)
org.apache.kafka.streams.errors.ProcessorStateException: stream-thread [rs3-window-aggregator-dev-cbf2b455-b7db-4e42-bbfa-0cee71b34d56-StreamThread-1] stream-task [0_4] Exception caught while trying to restore state from rs3-window-aggregator-dev-agg-window-store-changelog-4
...
Caused by: dev.responsive.kafka.internal.db.rs3.client.RS3Exception: io.grpc.StatusRuntimeException: INVALID_ARGUMENT: illegal wal segment
        at dev.responsive.kafka.internal.db.rs3.client.grpc.GrpcRs3Util.wrapThrowable(GrpcRs3Util.java:51)
        at dev.responsive.kafka.internal.db.rs3.client.grpc.GrpcMessageReceiver.onError(GrpcMessageReceiver.java:35)
        at io.grpc.stub.ClientCalls$StreamObserverToCallListenerAdapter.onClose(ClientCalls.java:481)
        at io.grpc.internal.ClientCallImpl.closeObserver(ClientCallImpl.java:564)
```

The patch fixes the problem by incrementing the offset passed through offsets written by the producer. This ensures that the `notifyCommit` callback always receives an exclusive offset.